### PR TITLE
7K Converts stacking notes fix

### DIFF
--- a/Quaver.API/Maps/Parsers/OsuBeatmap.cs
+++ b/Quaver.API/Maps/Parsers/OsuBeatmap.cs
@@ -376,13 +376,13 @@ namespace Quaver.API.Maps.Parsers
                                     if (osuHitObject.X >= 384 && osuHitObject.X <= 511)
                                         osuHitObject.Key4 = true;
                                     break;
-                                case 7 when osuHitObject.X >= 0 && osuHitObject.X <= 108:
+                                case 7 when osuHitObject.X != 96 && osuHitObject.X >= 0 && osuHitObject.X <= 108:
                                     osuHitObject.Key1 = true;
                                     break;
-                                case 7 when osuHitObject.X >= 109 && osuHitObject.X <= 181:
+                                case 7 when osuHitObject.X == 96 | (osuHitObject.X != 160 && osuHitObject.X >= 109 && osuHitObject.X <= 181):
                                     osuHitObject.Key2 = true;
                                     break;
-                                case 7 when osuHitObject.X >= 182 && osuHitObject.X <= 255:
+                                case 7 when osuHitObject.X == 160 | (osuHitObject.X >= 182 && osuHitObject.X <= 255):
                                     osuHitObject.Key3 = true;
                                     break;
                                 case 7 when osuHitObject.X >= 256 && osuHitObject.X <= 328:


### PR DESCRIPTION
On some 7K Osu maps, when converted by Quaver, has stacking notes on the first collumn. This is due to the osuHitPosition.X of Key1 and Key2 are both in the range of 0-108.

Update:
This fix is intended for 7K BMS converts in osu, maps such as https://osu.ppy.sh/beatmapsets/538667/#mania/1140929 are originally 8K before converted to 7K, so they use a different set of numbers to define hit position