### PR TITLE
Replay variable changes in Quaver.Tools

### DIFF
--- a/Quaver.Tools/Commands/ReplayBuildCommand.cs
+++ b/Quaver.Tools/Commands/ReplayBuildCommand.cs
@@ -37,7 +37,7 @@ namespace Quaver.Tools.Commands
 
             Replay = new Replay(args[1], true)
             {
-                QuaverVersion = args[3],
+                ReplayVersion = args[3],
                 MapMd5 = args[4],
                 PlayerName = string.Join(" ", username),
                 TimePlayed = long.Parse(args[5]),

--- a/Quaver.Tools/Commands/ReplayCommand.cs
+++ b/Quaver.Tools/Commands/ReplayCommand.cs
@@ -32,7 +32,7 @@ namespace Quaver.Tools.Commands
             Replay.PlayerName,
             Replay.Md5,
             Replay.MapMd5,
-            Replay.QuaverVersion,
+            Replay.ReplayVersion,
             Date = Replay.Date.ToString(CultureInfo.InvariantCulture),
             Replay.Mods,
             Replay.Mode,

--- a/Quaver.Tools/Commands/VirtualReplayPlayerCommand.cs
+++ b/Quaver.Tools/Commands/VirtualReplayPlayerCommand.cs
@@ -88,7 +88,7 @@ namespace Quaver.Tools.Commands
                 {
                     Replay.Md5,
                     Replay.MapMd5,
-                    Replay.QuaverVersion,
+                    Replay.ReplayVersion,
                     Replay.PlayerName,
                     Replay.Date,
                     Replay.TimePlayed,


### PR DESCRIPTION
Never got build errors for these classes due to editing the Quaver.API submodule in the main Quaver solution instead of the Quaver.API solution.