### PR TITLE
Fix SV issues

### DIFF
--- a/Quaver.API.Tests/Osu/Resources/Camellia - Backbeat Maniac (Evening) [Rewind VIP].qua
+++ b/Quaver.API.Tests/Osu/Resources/Camellia - Backbeat Maniac (Evening) [Rewind VIP].qua
@@ -7844,10664 +7844,15994 @@ TimingPoints:
   Bpm: 299.301147
 - StartTime: 214969
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 214971
   Bpm: 13
+  Signature: 99999
 - StartTime: 214972
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 214974
   Bpm: 79970
+  Signature: 99999
 - StartTime: 214975
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 214977
   Bpm: 49.0000038
+  Signature: 99999
 - StartTime: 214978
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 214980
   Bpm: 79934
+  Signature: 99999
 - StartTime: 214981
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 214983
   Bpm: 85
+  Signature: 99999
 - StartTime: 214984
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 214986
   Bpm: 79898
+  Signature: 99999
 - StartTime: 214987
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 214989
   Bpm: 121
+  Signature: 99999
 - StartTime: 214990
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 214992
   Bpm: 79862
+  Signature: 99999
 - StartTime: 214993
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 214995
   Bpm: 157
+  Signature: 99999
 - StartTime: 214996
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 214998
   Bpm: 79826
+  Signature: 99999
 - StartTime: 214999
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215001
   Bpm: 193
+  Signature: 99999
 - StartTime: 215002
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215004
   Bpm: 79790
+  Signature: 99999
 - StartTime: 215005
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215007
   Bpm: 229
+  Signature: 99999
 - StartTime: 215008
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215010
   Bpm: 79754
+  Signature: 99999
 - StartTime: 215011
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215013
   Bpm: 265
+  Signature: 99999
 - StartTime: 215014
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215016
   Bpm: 79718
+  Signature: 99999
 - StartTime: 215017
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215019
   Bpm: 301
+  Signature: 99999
 - StartTime: 215020
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215022
   Bpm: 79682
+  Signature: 99999
 - StartTime: 215023
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215025
   Bpm: 337
+  Signature: 99999
 - StartTime: 215026
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215028
   Bpm: 79646
+  Signature: 99999
 - StartTime: 215029
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215031
   Bpm: 373
+  Signature: 99999
 - StartTime: 215032
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215034
   Bpm: 79610
+  Signature: 99999
 - StartTime: 215035
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215037
   Bpm: 409
+  Signature: 99999
 - StartTime: 215038
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215040
   Bpm: 79574
+  Signature: 99999
 - StartTime: 215041
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215043
   Bpm: 444.999969
+  Signature: 99999
 - StartTime: 215044
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215046
   Bpm: 79538
+  Signature: 99999
 - StartTime: 215047
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215049
   Bpm: 481
+  Signature: 99999
 - StartTime: 215050
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215052
   Bpm: 79502
+  Signature: 99999
 - StartTime: 215053
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215055
   Bpm: 517
+  Signature: 99999
 - StartTime: 215056
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215058
   Bpm: 79466
+  Signature: 99999
 - StartTime: 215059
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215061
   Bpm: 553
+  Signature: 99999
 - StartTime: 215062
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215064
   Bpm: 79430
+  Signature: 99999
 - StartTime: 215065
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215067
   Bpm: 589
+  Signature: 99999
 - StartTime: 215068
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215070
   Bpm: 79394
+  Signature: 99999
 - StartTime: 215071
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215073
   Bpm: 625
+  Signature: 99999
 - StartTime: 215074
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215076
   Bpm: 79358
+  Signature: 99999
 - StartTime: 215077
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215079
   Bpm: 661
+  Signature: 99999
 - StartTime: 215080
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215082
   Bpm: 79322
+  Signature: 99999
 - StartTime: 215083
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215085
   Bpm: 697
+  Signature: 99999
 - StartTime: 215086
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215088
   Bpm: 79286
+  Signature: 99999
 - StartTime: 215089
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215091
   Bpm: 732.999939
+  Signature: 99999
 - StartTime: 215092
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215094
   Bpm: 79250
+  Signature: 99999
 - StartTime: 215095
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215097
   Bpm: 769
+  Signature: 99999
 - StartTime: 215098
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215100
   Bpm: 79214
+  Signature: 99999
 - StartTime: 215101
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215103
   Bpm: 804.999939
+  Signature: 99999
 - StartTime: 215104
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215106
   Bpm: 79178
+  Signature: 99999
 - StartTime: 215107
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215109
   Bpm: 841.000061
+  Signature: 99999
 - StartTime: 215110
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215112
   Bpm: 79142
+  Signature: 99999
 - StartTime: 215113
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215115
   Bpm: 876.999939
+  Signature: 99999
 - StartTime: 215116
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215118
   Bpm: 79106
+  Signature: 99999
 - StartTime: 215119
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215121
   Bpm: 913
+  Signature: 99999
 - StartTime: 215122
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215124
   Bpm: 79070
+  Signature: 99999
 - StartTime: 215125
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215127
   Bpm: 949
+  Signature: 99999
 - StartTime: 215128
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215130
   Bpm: 79034
+  Signature: 99999
 - StartTime: 215131
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215133
   Bpm: 985
+  Signature: 99999
 - StartTime: 215134
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215136
   Bpm: 78998
+  Signature: 99999
 - StartTime: 215137
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215139
   Bpm: 1021
+  Signature: 99999
 - StartTime: 215140
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215142
   Bpm: 78962
+  Signature: 99999
 - StartTime: 215143
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215145
   Bpm: 1057
+  Signature: 99999
 - StartTime: 215146
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215148
   Bpm: 78926
+  Signature: 99999
 - StartTime: 215149
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215151
   Bpm: 1093
+  Signature: 99999
 - StartTime: 215152
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215154
   Bpm: 78890
+  Signature: 99999
 - StartTime: 215155
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215157
   Bpm: 1129
+  Signature: 99999
 - StartTime: 215158
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215160
   Bpm: 78854
+  Signature: 99999
 - StartTime: 215161
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215163
   Bpm: 1165
+  Signature: 99999
 - StartTime: 215164
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215166
   Bpm: 78818
+  Signature: 99999
 - StartTime: 215167
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215169
   Bpm: 1201
+  Signature: 99999
 - StartTime: 215170
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215172
   Bpm: 78782
+  Signature: 99999
 - StartTime: 215173
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215175
   Bpm: 1237
+  Signature: 99999
 - StartTime: 215176
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215178
   Bpm: 78746
+  Signature: 99999
 - StartTime: 215179
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215181
   Bpm: 1273
+  Signature: 99999
 - StartTime: 215182
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215184
   Bpm: 78710
+  Signature: 99999
 - StartTime: 215185
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215187
   Bpm: 1309
+  Signature: 99999
 - StartTime: 215188
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215190
   Bpm: 78674
+  Signature: 99999
 - StartTime: 215191
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215193
   Bpm: 1345
+  Signature: 99999
 - StartTime: 215194
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215196
   Bpm: 78638
+  Signature: 99999
 - StartTime: 215197
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215199
   Bpm: 1381
+  Signature: 99999
 - StartTime: 215200
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215202
   Bpm: 78602
+  Signature: 99999
 - StartTime: 215203
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215205
   Bpm: 1417
+  Signature: 99999
 - StartTime: 215206
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215208
   Bpm: 78566
+  Signature: 99999
 - StartTime: 215209
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215211
   Bpm: 1452.99988
+  Signature: 99999
 - StartTime: 215212
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215214
   Bpm: 78530
+  Signature: 99999
 - StartTime: 215215
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215217
   Bpm: 1489
+  Signature: 99999
 - StartTime: 215218
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215220
   Bpm: 78494
+  Signature: 99999
 - StartTime: 215221
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215223
   Bpm: 1525
+  Signature: 99999
 - StartTime: 215224
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215226
   Bpm: 78458
+  Signature: 99999
 - StartTime: 215227
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215229
   Bpm: 1560.99988
+  Signature: 99999
 - StartTime: 215230
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215232
   Bpm: 78422
+  Signature: 99999
 - StartTime: 215233
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215235
   Bpm: 1597
+  Signature: 99999
 - StartTime: 215236
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215238
   Bpm: 78386
+  Signature: 99999
 - StartTime: 215239
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215241
   Bpm: 1633
+  Signature: 99999
 - StartTime: 215242
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215244
   Bpm: 78350
+  Signature: 99999
 - StartTime: 215245
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215247
   Bpm: 1669.00012
+  Signature: 99999
 - StartTime: 215248
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215250
   Bpm: 78314
+  Signature: 99999
 - StartTime: 215251
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215253
   Bpm: 1705
+  Signature: 99999
 - StartTime: 215254
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215256
   Bpm: 78278
+  Signature: 99999
 - StartTime: 215257
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215259
   Bpm: 1741
+  Signature: 99999
 - StartTime: 215260
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215262
   Bpm: 78242
+  Signature: 99999
 - StartTime: 215263
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215265
   Bpm: 1777.00012
+  Signature: 99999
 - StartTime: 215266
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215268
   Bpm: 78206
+  Signature: 99999
 - StartTime: 215269
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215271
   Bpm: 1813
+  Signature: 99999
 - StartTime: 215272
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215274
   Bpm: 78170
+  Signature: 99999
 - StartTime: 215275
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215277
   Bpm: 1848.99988
+  Signature: 99999
 - StartTime: 215278
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215280
   Bpm: 78134
+  Signature: 99999
 - StartTime: 215281
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215283
   Bpm: 1885
+  Signature: 99999
 - StartTime: 215284
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215286
   Bpm: 78098
+  Signature: 99999
 - StartTime: 215287
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215289
   Bpm: 1921
+  Signature: 99999
 - StartTime: 215290
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215292
   Bpm: 78062
+  Signature: 99999
 - StartTime: 215293
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215295
   Bpm: 1957
+  Signature: 99999
 - StartTime: 215296
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215298
   Bpm: 78026
+  Signature: 99999
 - StartTime: 215299
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215301
   Bpm: 1993
+  Signature: 99999
 - StartTime: 215302
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215304
   Bpm: 77990
+  Signature: 99999
 - StartTime: 215305
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215307
   Bpm: 2029
+  Signature: 99999
 - StartTime: 215308
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215310
   Bpm: 77954
+  Signature: 99999
 - StartTime: 215311
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215313
   Bpm: 2065
+  Signature: 99999
 - StartTime: 215314
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215316
   Bpm: 77918
+  Signature: 99999
 - StartTime: 215317
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215319
   Bpm: 2101
+  Signature: 99999
 - StartTime: 215320
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215322
   Bpm: 77882
+  Signature: 99999
 - StartTime: 215323
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215325
   Bpm: 2137
+  Signature: 99999
 - StartTime: 215326
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215328
   Bpm: 77846
+  Signature: 99999
 - StartTime: 215329
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215331
   Bpm: 2173
+  Signature: 99999
 - StartTime: 215332
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215334
   Bpm: 77810
+  Signature: 99999
 - StartTime: 215335
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215337
   Bpm: 2209
+  Signature: 99999
 - StartTime: 215338
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215340
   Bpm: 77774
+  Signature: 99999
 - StartTime: 215341
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215343
   Bpm: 2245
+  Signature: 99999
 - StartTime: 215344
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215346
   Bpm: 77738
+  Signature: 99999
 - StartTime: 215347
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215349
   Bpm: 2281
+  Signature: 99999
 - StartTime: 215350
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215352
   Bpm: 77702
+  Signature: 99999
 - StartTime: 215353
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215355
   Bpm: 2317
+  Signature: 99999
 - StartTime: 215356
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215358
   Bpm: 77666
+  Signature: 99999
 - StartTime: 215359
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215361
   Bpm: 2353
+  Signature: 99999
 - StartTime: 215362
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215364
   Bpm: 77630
+  Signature: 99999
 - StartTime: 215365
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215367
   Bpm: 2389
+  Signature: 99999
 - StartTime: 215368
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215370
   Bpm: 77594
+  Signature: 99999
 - StartTime: 215371
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215373
   Bpm: 2425
+  Signature: 99999
 - StartTime: 215374
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215376
   Bpm: 77558
+  Signature: 99999
 - StartTime: 215377
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215379
   Bpm: 2461
+  Signature: 99999
 - StartTime: 215380
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215382
   Bpm: 77522
+  Signature: 99999
 - StartTime: 215383
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215385
   Bpm: 2497
+  Signature: 99999
 - StartTime: 215386
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215388
   Bpm: 77486
+  Signature: 99999
 - StartTime: 215389
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215391
   Bpm: 2533
+  Signature: 99999
 - StartTime: 215392
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215394
   Bpm: 77450
+  Signature: 99999
 - StartTime: 215395
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215397
   Bpm: 2569
+  Signature: 99999
 - StartTime: 215398
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215400
   Bpm: 77414
+  Signature: 99999
 - StartTime: 215401
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215403
   Bpm: 2605
+  Signature: 99999
 - StartTime: 215404
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215406
   Bpm: 77378
+  Signature: 99999
 - StartTime: 215407
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215409
   Bpm: 2641
+  Signature: 99999
 - StartTime: 215410
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215412
   Bpm: 77342
+  Signature: 99999
 - StartTime: 215413
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215415
   Bpm: 2677
+  Signature: 99999
 - StartTime: 215416
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215418
   Bpm: 77306
+  Signature: 99999
 - StartTime: 215419
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215421
   Bpm: 2713
+  Signature: 99999
 - StartTime: 215422
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215424
   Bpm: 77270
+  Signature: 99999
 - StartTime: 215425
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215427
   Bpm: 2749
+  Signature: 99999
 - StartTime: 215428
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215430
   Bpm: 77234
+  Signature: 99999
 - StartTime: 215431
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215433
   Bpm: 2785
+  Signature: 99999
 - StartTime: 215434
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215436
   Bpm: 77198
+  Signature: 99999
 - StartTime: 215437
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215439
   Bpm: 2821
+  Signature: 99999
 - StartTime: 215440
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215442
   Bpm: 77162
+  Signature: 99999
 - StartTime: 215443
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215445
   Bpm: 2857
+  Signature: 99999
 - StartTime: 215446
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215448
   Bpm: 77126
+  Signature: 99999
 - StartTime: 215449
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215451
   Bpm: 2892.99976
+  Signature: 99999
 - StartTime: 215452
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215454
   Bpm: 77090
+  Signature: 99999
 - StartTime: 215455
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215457
   Bpm: 2928.99976
+  Signature: 99999
 - StartTime: 215458
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215460
   Bpm: 77054
+  Signature: 99999
 - StartTime: 215461
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215463
   Bpm: 2965
+  Signature: 99999
 - StartTime: 215464
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215466
   Bpm: 77018
+  Signature: 99999
 - StartTime: 215467
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215469
   Bpm: 3001
+  Signature: 99999
 - StartTime: 215470
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215472
   Bpm: 76982
+  Signature: 99999
 - StartTime: 215473
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215475
   Bpm: 3037
+  Signature: 99999
 - StartTime: 215476
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215478
   Bpm: 76946
+  Signature: 99999
 - StartTime: 215479
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215481
   Bpm: 3073
+  Signature: 99999
 - StartTime: 215482
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215484
   Bpm: 76910
+  Signature: 99999
 - StartTime: 215485
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215487
   Bpm: 3109.00024
+  Signature: 99999
 - StartTime: 215488
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215490
   Bpm: 76874
+  Signature: 99999
 - StartTime: 215491
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215493
   Bpm: 3145
+  Signature: 99999
 - StartTime: 215494
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215496
   Bpm: 76838
+  Signature: 99999
 - StartTime: 215497
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215499
   Bpm: 3181
+  Signature: 99999
 - StartTime: 215500
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215502
   Bpm: 76802
+  Signature: 99999
 - StartTime: 215503
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215505
   Bpm: 3217
+  Signature: 99999
 - StartTime: 215506
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215508
   Bpm: 76766
+  Signature: 99999
 - StartTime: 215509
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215511
   Bpm: 3253
+  Signature: 99999
 - StartTime: 215512
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215514
   Bpm: 76730
+  Signature: 99999
 - StartTime: 215515
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215517
   Bpm: 3289.00024
+  Signature: 99999
 - StartTime: 215518
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215520
   Bpm: 76694
+  Signature: 99999
 - StartTime: 215521
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215523
   Bpm: 3325
+  Signature: 99999
 - StartTime: 215524
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215526
   Bpm: 76658
+  Signature: 99999
 - StartTime: 215527
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215529
   Bpm: 3361
+  Signature: 99999
 - StartTime: 215530
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215532
   Bpm: 76622
+  Signature: 99999
 - StartTime: 215533
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215535
   Bpm: 3397
+  Signature: 99999
 - StartTime: 215536
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215538
   Bpm: 76586
+  Signature: 99999
 - StartTime: 215539
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215541
   Bpm: 3433
+  Signature: 99999
 - StartTime: 215542
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215544
   Bpm: 76550
+  Signature: 99999
 - StartTime: 215545
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215547
   Bpm: 3469
+  Signature: 99999
 - StartTime: 215548
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215550
   Bpm: 76514
+  Signature: 99999
 - StartTime: 215551
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215553
   Bpm: 3505
+  Signature: 99999
 - StartTime: 215554
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215556
   Bpm: 76478
+  Signature: 99999
 - StartTime: 215557
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215559
   Bpm: 3541
+  Signature: 99999
 - StartTime: 215560
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215562
   Bpm: 76442
+  Signature: 99999
 - StartTime: 215563
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215565
   Bpm: 3577
+  Signature: 99999
 - StartTime: 215566
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215568
   Bpm: 76406
+  Signature: 99999
 - StartTime: 215569
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215571
   Bpm: 3613.00024
+  Signature: 99999
 - StartTime: 215572
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215574
   Bpm: 76370
+  Signature: 99999
 - StartTime: 215575
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215577
   Bpm: 3649
+  Signature: 99999
 - StartTime: 215578
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215580
   Bpm: 76334
+  Signature: 99999
 - StartTime: 215581
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215583
   Bpm: 3685.00024
+  Signature: 99999
 - StartTime: 215584
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215586
   Bpm: 76298
+  Signature: 99999
 - StartTime: 215587
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215589
   Bpm: 3721.00024
+  Signature: 99999
 - StartTime: 215590
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215592
   Bpm: 76262
+  Signature: 99999
 - StartTime: 215593
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215595
   Bpm: 3757
+  Signature: 99999
 - StartTime: 215596
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215598
   Bpm: 76226
+  Signature: 99999
 - StartTime: 215599
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215601
   Bpm: 3793
+  Signature: 99999
 - StartTime: 215602
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215604
   Bpm: 76190
+  Signature: 99999
 - StartTime: 215605
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215607
   Bpm: 3829
+  Signature: 99999
 - StartTime: 215608
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215610
   Bpm: 76154
+  Signature: 99999
 - StartTime: 215611
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215613
   Bpm: 3865
+  Signature: 99999
 - StartTime: 215614
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215616
   Bpm: 76118
+  Signature: 99999
 - StartTime: 215617
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215619
   Bpm: 3901
+  Signature: 99999
 - StartTime: 215620
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215622
   Bpm: 76082
+  Signature: 99999
 - StartTime: 215623
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215625
   Bpm: 3937
+  Signature: 99999
 - StartTime: 215626
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215628
   Bpm: 76046
+  Signature: 99999
 - StartTime: 215629
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215631
   Bpm: 3973
+  Signature: 99999
 - StartTime: 215632
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215634
   Bpm: 76010
+  Signature: 99999
 - StartTime: 215635
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215637
   Bpm: 4009
+  Signature: 99999
 - StartTime: 215638
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215640
   Bpm: 75974
+  Signature: 99999
 - StartTime: 215641
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215643
   Bpm: 4045
+  Signature: 99999
 - StartTime: 215644
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215646
   Bpm: 75938
+  Signature: 99999
 - StartTime: 215647
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215649
   Bpm: 4081
+  Signature: 99999
 - StartTime: 215650
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215652
   Bpm: 75902
+  Signature: 99999
 - StartTime: 215653
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215655
   Bpm: 4117
+  Signature: 99999
 - StartTime: 215656
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215658
   Bpm: 75866
+  Signature: 99999
 - StartTime: 215659
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215661
   Bpm: 4153
+  Signature: 99999
 - StartTime: 215662
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215664
   Bpm: 75830
+  Signature: 99999
 - StartTime: 215665
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215667
   Bpm: 4189
+  Signature: 99999
 - StartTime: 215668
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215670
   Bpm: 75794
+  Signature: 99999
 - StartTime: 215671
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215673
   Bpm: 4225
+  Signature: 99999
 - StartTime: 215674
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215676
   Bpm: 75758
+  Signature: 99999
 - StartTime: 215677
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215679
   Bpm: 4261
+  Signature: 99999
 - StartTime: 215680
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215682
   Bpm: 75722
+  Signature: 99999
 - StartTime: 215683
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215685
   Bpm: 4297
+  Signature: 99999
 - StartTime: 215686
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215688
   Bpm: 75686
+  Signature: 99999
 - StartTime: 215689
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215691
   Bpm: 4333
+  Signature: 99999
 - StartTime: 215692
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215694
   Bpm: 75650
+  Signature: 99999
 - StartTime: 215695
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215697
   Bpm: 4369
+  Signature: 99999
 - StartTime: 215698
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215700
   Bpm: 75614
+  Signature: 99999
 - StartTime: 215701
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215703
   Bpm: 4405
+  Signature: 99999
 - StartTime: 215704
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215706
   Bpm: 75578
+  Signature: 99999
 - StartTime: 215707
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215709
   Bpm: 4441
+  Signature: 99999
 - StartTime: 215710
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215712
   Bpm: 75542
+  Signature: 99999
 - StartTime: 215713
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215715
   Bpm: 4477
+  Signature: 99999
 - StartTime: 215716
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215718
   Bpm: 75506
+  Signature: 99999
 - StartTime: 215719
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215721
   Bpm: 4513
+  Signature: 99999
 - StartTime: 215722
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215724
   Bpm: 75470
+  Signature: 99999
 - StartTime: 215725
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215727
   Bpm: 4549
+  Signature: 99999
 - StartTime: 215728
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215730
   Bpm: 75434
+  Signature: 99999
 - StartTime: 215731
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215733
   Bpm: 4585
+  Signature: 99999
 - StartTime: 215734
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215736
   Bpm: 75398
+  Signature: 99999
 - StartTime: 215737
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215739
   Bpm: 4621
+  Signature: 99999
 - StartTime: 215740
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215742
   Bpm: 75362
+  Signature: 99999
 - StartTime: 215743
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215745
   Bpm: 4657
+  Signature: 99999
 - StartTime: 215746
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215748
   Bpm: 75326
+  Signature: 99999
 - StartTime: 215749
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215751
   Bpm: 4693
+  Signature: 99999
 - StartTime: 215752
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215754
   Bpm: 75290
+  Signature: 99999
 - StartTime: 215755
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215757
   Bpm: 4729
+  Signature: 99999
 - StartTime: 215758
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215760
   Bpm: 75254
+  Signature: 99999
 - StartTime: 215761
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215763
   Bpm: 4765
+  Signature: 99999
 - StartTime: 215764
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215766
   Bpm: 75218
+  Signature: 99999
 - StartTime: 215767
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215769
   Bpm: 4801
+  Signature: 99999
 - StartTime: 215770
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215772
   Bpm: 75182
+  Signature: 99999
 - StartTime: 215773
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215775
   Bpm: 4837
+  Signature: 99999
 - StartTime: 215776
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215778
   Bpm: 75146
+  Signature: 99999
 - StartTime: 215779
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215781
   Bpm: 4873
+  Signature: 99999
 - StartTime: 215782
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215784
   Bpm: 75110
+  Signature: 99999
 - StartTime: 215785
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215787
   Bpm: 4909
+  Signature: 99999
 - StartTime: 215788
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215790
   Bpm: 75074
+  Signature: 99999
 - StartTime: 215791
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215793
   Bpm: 4945
+  Signature: 99999
 - StartTime: 215794
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215796
   Bpm: 75038
+  Signature: 99999
 - StartTime: 215797
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215799
   Bpm: 4981
+  Signature: 99999
 - StartTime: 215800
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215802
   Bpm: 75002
+  Signature: 99999
 - StartTime: 215803
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215805
   Bpm: 5017
+  Signature: 99999
 - StartTime: 215806
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215808
   Bpm: 74966
+  Signature: 99999
 - StartTime: 215809
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215811
   Bpm: 5053
+  Signature: 99999
 - StartTime: 215812
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215814
   Bpm: 74930
+  Signature: 99999
 - StartTime: 215815
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215817
   Bpm: 5089
+  Signature: 99999
 - StartTime: 215818
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215820
   Bpm: 74894
+  Signature: 99999
 - StartTime: 215821
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215823
   Bpm: 5125
+  Signature: 99999
 - StartTime: 215824
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215826
   Bpm: 74858
+  Signature: 99999
 - StartTime: 215827
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215829
   Bpm: 5161
+  Signature: 99999
 - StartTime: 215830
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215832
   Bpm: 74822
+  Signature: 99999
 - StartTime: 215833
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215835
   Bpm: 5197
+  Signature: 99999
 - StartTime: 215836
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215838
   Bpm: 74786
+  Signature: 99999
 - StartTime: 215839
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215841
   Bpm: 5233
+  Signature: 99999
 - StartTime: 215842
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215844
   Bpm: 74750
+  Signature: 99999
 - StartTime: 215845
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215847
   Bpm: 5269
+  Signature: 99999
 - StartTime: 215848
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215850
   Bpm: 74714
+  Signature: 99999
 - StartTime: 215851
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215853
   Bpm: 5305
+  Signature: 99999
 - StartTime: 215854
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215856
   Bpm: 74678
+  Signature: 99999
 - StartTime: 215857
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215859
   Bpm: 5341
+  Signature: 99999
 - StartTime: 215860
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215862
   Bpm: 74642
+  Signature: 99999
 - StartTime: 215863
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215865
   Bpm: 5377
+  Signature: 99999
 - StartTime: 215866
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215868
   Bpm: 74606
+  Signature: 99999
 - StartTime: 215869
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215871
   Bpm: 5413
+  Signature: 99999
 - StartTime: 215872
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215874
   Bpm: 74570
+  Signature: 99999
 - StartTime: 215875
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215877
   Bpm: 5449
+  Signature: 99999
 - StartTime: 215878
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215880
   Bpm: 74534
+  Signature: 99999
 - StartTime: 215881
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215883
   Bpm: 5485
+  Signature: 99999
 - StartTime: 215884
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215886
   Bpm: 74498
+  Signature: 99999
 - StartTime: 215887
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215889
   Bpm: 5521
+  Signature: 99999
 - StartTime: 215890
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215892
   Bpm: 74462
+  Signature: 99999
 - StartTime: 215893
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215895
   Bpm: 5557
+  Signature: 99999
 - StartTime: 215896
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215898
   Bpm: 74426
+  Signature: 99999
 - StartTime: 215899
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215901
   Bpm: 5593
+  Signature: 99999
 - StartTime: 215902
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215904
   Bpm: 74390
+  Signature: 99999
 - StartTime: 215905
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215907
   Bpm: 5629
+  Signature: 99999
 - StartTime: 215908
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215910
   Bpm: 74354
+  Signature: 99999
 - StartTime: 215911
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215913
   Bpm: 5665
+  Signature: 99999
 - StartTime: 215914
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215916
   Bpm: 74318
+  Signature: 99999
 - StartTime: 215917
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215919
   Bpm: 5701
+  Signature: 99999
 - StartTime: 215920
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215922
   Bpm: 74282
+  Signature: 99999
 - StartTime: 215923
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215925
   Bpm: 5737
+  Signature: 99999
 - StartTime: 215926
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215928
   Bpm: 74246
+  Signature: 99999
 - StartTime: 215929
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215931
   Bpm: 5773
+  Signature: 99999
 - StartTime: 215932
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215934
   Bpm: 74210
+  Signature: 99999
 - StartTime: 215935
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215937
   Bpm: 5809
+  Signature: 99999
 - StartTime: 215938
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215940
   Bpm: 74174
+  Signature: 99999
 - StartTime: 215941
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215943
   Bpm: 5845.00049
+  Signature: 99999
 - StartTime: 215944
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215946
   Bpm: 74138
+  Signature: 99999
 - StartTime: 215947
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215949
   Bpm: 5881
+  Signature: 99999
 - StartTime: 215950
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215952
   Bpm: 74102
+  Signature: 99999
 - StartTime: 215953
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215955
   Bpm: 5917
+  Signature: 99999
 - StartTime: 215956
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215958
   Bpm: 74066
+  Signature: 99999
 - StartTime: 215959
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215961
   Bpm: 5953
+  Signature: 99999
 - StartTime: 215962
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215964
   Bpm: 74030
+  Signature: 99999
 - StartTime: 215965
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215967
   Bpm: 5989
+  Signature: 99999
 - StartTime: 215968
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215970
   Bpm: 73994
+  Signature: 99999
 - StartTime: 215971
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215973
   Bpm: 6025
+  Signature: 99999
 - StartTime: 215974
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215976
   Bpm: 73958
+  Signature: 99999
 - StartTime: 215977
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215979
   Bpm: 6061
+  Signature: 99999
 - StartTime: 215980
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215982
   Bpm: 73922
+  Signature: 99999
 - StartTime: 215983
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215985
   Bpm: 6097
+  Signature: 99999
 - StartTime: 215986
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215988
   Bpm: 73886
+  Signature: 99999
 - StartTime: 215989
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215991
   Bpm: 6133
+  Signature: 99999
 - StartTime: 215992
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 215994
   Bpm: 73850
+  Signature: 99999
 - StartTime: 215995
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 215997
   Bpm: 6169
+  Signature: 99999
 - StartTime: 215998
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216000
   Bpm: 73814
+  Signature: 99999
 - StartTime: 216001
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216003
   Bpm: 6205
+  Signature: 99999
 - StartTime: 216004
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216006
   Bpm: 73778
+  Signature: 99999
 - StartTime: 216007
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216009
   Bpm: 6241
+  Signature: 99999
 - StartTime: 216010
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216012
   Bpm: 73742
+  Signature: 99999
 - StartTime: 216013
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216015
   Bpm: 6277
+  Signature: 99999
 - StartTime: 216016
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216018
   Bpm: 73706
+  Signature: 99999
 - StartTime: 216019
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216021
   Bpm: 6312.99951
+  Signature: 99999
 - StartTime: 216022
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216024
   Bpm: 73670
+  Signature: 99999
 - StartTime: 216025
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216027
   Bpm: 6349
+  Signature: 99999
 - StartTime: 216028
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216030
   Bpm: 73634
+  Signature: 99999
 - StartTime: 216031
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216033
   Bpm: 6385
+  Signature: 99999
 - StartTime: 216034
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216036
   Bpm: 73598
+  Signature: 99999
 - StartTime: 216037
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216039
   Bpm: 6421.00049
+  Signature: 99999
 - StartTime: 216040
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216042
   Bpm: 73562
+  Signature: 99999
 - StartTime: 216043
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216045
   Bpm: 6457
+  Signature: 99999
 - StartTime: 216046
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216048
   Bpm: 73526
+  Signature: 99999
 - StartTime: 216049
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216051
   Bpm: 6493
+  Signature: 99999
 - StartTime: 216052
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216054
   Bpm: 73490
+  Signature: 99999
 - StartTime: 216055
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216057
   Bpm: 6529
+  Signature: 99999
 - StartTime: 216058
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216060
   Bpm: 73454
+  Signature: 99999
 - StartTime: 216061
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216063
   Bpm: 6565
+  Signature: 99999
 - StartTime: 216064
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216066
   Bpm: 73418
+  Signature: 99999
 - StartTime: 216067
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216069
   Bpm: 6601
+  Signature: 99999
 - StartTime: 216070
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216072
   Bpm: 73382
+  Signature: 99999
 - StartTime: 216073
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216075
   Bpm: 6637
+  Signature: 99999
 - StartTime: 216076
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216078
   Bpm: 73346
+  Signature: 99999
 - StartTime: 216079
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216081
   Bpm: 6673
+  Signature: 99999
 - StartTime: 216082
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216084
   Bpm: 73310
+  Signature: 99999
 - StartTime: 216085
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216087
   Bpm: 6709
+  Signature: 99999
 - StartTime: 216088
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216090
   Bpm: 73274
+  Signature: 99999
 - StartTime: 216091
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216093
   Bpm: 6745
+  Signature: 99999
 - StartTime: 216094
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216096
   Bpm: 73238
+  Signature: 99999
 - StartTime: 216097
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216099
   Bpm: 6781
+  Signature: 99999
 - StartTime: 216100
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216102
   Bpm: 73202
+  Signature: 99999
 - StartTime: 216103
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216105
   Bpm: 6816.99951
+  Signature: 99999
 - StartTime: 216106
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216108
   Bpm: 73166
+  Signature: 99999
 - StartTime: 216109
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216111
   Bpm: 6852.99951
+  Signature: 99999
 - StartTime: 216112
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216114
   Bpm: 73130
+  Signature: 99999
 - StartTime: 216115
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216117
   Bpm: 6889.00049
+  Signature: 99999
 - StartTime: 216118
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216120
   Bpm: 73094
+  Signature: 99999
 - StartTime: 216121
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216123
   Bpm: 6925
+  Signature: 99999
 - StartTime: 216124
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216126
   Bpm: 73058
+  Signature: 99999
 - StartTime: 216127
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216129
   Bpm: 6961
+  Signature: 99999
 - StartTime: 216130
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216132
   Bpm: 73022
+  Signature: 99999
 - StartTime: 216133
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216135
   Bpm: 6997
+  Signature: 99999
 - StartTime: 216136
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216138
   Bpm: 72986
+  Signature: 99999
 - StartTime: 216139
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216141
   Bpm: 7033
+  Signature: 99999
 - StartTime: 216142
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216144
   Bpm: 72950
+  Signature: 99999
 - StartTime: 216145
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216147
   Bpm: 7069
+  Signature: 99999
 - StartTime: 216148
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216150
   Bpm: 72914
+  Signature: 99999
 - StartTime: 216151
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216153
   Bpm: 7105
+  Signature: 99999
 - StartTime: 216154
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216156
   Bpm: 72878
+  Signature: 99999
 - StartTime: 216157
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216159
   Bpm: 7141
+  Signature: 99999
 - StartTime: 216160
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216162
   Bpm: 72842
+  Signature: 99999
 - StartTime: 216163
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216165
   Bpm: 7177
+  Signature: 99999
 - StartTime: 216166
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216168
   Bpm: 72806
+  Signature: 99999
 - StartTime: 216169
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216171
   Bpm: 7212.99951
+  Signature: 99999
 - StartTime: 216172
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216174
   Bpm: 72770
+  Signature: 99999
 - StartTime: 216175
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216177
   Bpm: 7249.00049
+  Signature: 99999
 - StartTime: 216178
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216180
   Bpm: 72734
+  Signature: 99999
 - StartTime: 216181
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216183
   Bpm: 7285.00049
+  Signature: 99999
 - StartTime: 216184
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216186
   Bpm: 72698
+  Signature: 99999
 - StartTime: 216187
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216189
   Bpm: 7321
+  Signature: 99999
 - StartTime: 216190
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216192
   Bpm: 72662
+  Signature: 99999
 - StartTime: 216193
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216195
   Bpm: 7356.99951
+  Signature: 99999
 - StartTime: 216196
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216198
   Bpm: 72626
+  Signature: 99999
 - StartTime: 216199
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216201
   Bpm: 7392.99951
+  Signature: 99999
 - StartTime: 216202
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216204
   Bpm: 72590
+  Signature: 99999
 - StartTime: 216205
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216207
   Bpm: 7429
+  Signature: 99999
 - StartTime: 216208
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216210
   Bpm: 72554
+  Signature: 99999
 - StartTime: 216211
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216213
   Bpm: 7465.00049
+  Signature: 99999
 - StartTime: 216214
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216216
   Bpm: 72518
+  Signature: 99999
 - StartTime: 216217
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216219
   Bpm: 7501
+  Signature: 99999
 - StartTime: 216220
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216222
   Bpm: 72482
+  Signature: 99999
 - StartTime: 216223
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216225
   Bpm: 7537
+  Signature: 99999
 - StartTime: 216226
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216228
   Bpm: 72446
+  Signature: 99999
 - StartTime: 216229
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216231
   Bpm: 7573
+  Signature: 99999
 - StartTime: 216232
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216234
   Bpm: 72410
+  Signature: 99999
 - StartTime: 216235
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216237
   Bpm: 7609
+  Signature: 99999
 - StartTime: 216238
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216240
   Bpm: 72374
+  Signature: 99999
 - StartTime: 216241
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216243
   Bpm: 7645
+  Signature: 99999
 - StartTime: 216244
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216246
   Bpm: 72338
+  Signature: 99999
 - StartTime: 216247
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216249
   Bpm: 7681
+  Signature: 99999
 - StartTime: 216250
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216252
   Bpm: 72302
+  Signature: 99999
 - StartTime: 216253
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216255
   Bpm: 7717
+  Signature: 99999
 - StartTime: 216256
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216258
   Bpm: 72266
+  Signature: 99999
 - StartTime: 216259
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216261
   Bpm: 7753
+  Signature: 99999
 - StartTime: 216262
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216264
   Bpm: 72230
+  Signature: 99999
 - StartTime: 216265
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216267
   Bpm: 7789
+  Signature: 99999
 - StartTime: 216268
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216270
   Bpm: 72194
+  Signature: 99999
 - StartTime: 216271
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216273
   Bpm: 7825
+  Signature: 99999
 - StartTime: 216274
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216276
   Bpm: 72158
+  Signature: 99999
 - StartTime: 216277
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216279
   Bpm: 7861
+  Signature: 99999
 - StartTime: 216280
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216282
   Bpm: 72122
+  Signature: 99999
 - StartTime: 216283
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216285
   Bpm: 7897
+  Signature: 99999
 - StartTime: 216286
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216288
   Bpm: 72086
+  Signature: 99999
 - StartTime: 216289
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216291
   Bpm: 7933
+  Signature: 99999
 - StartTime: 216292
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216294
   Bpm: 72050
+  Signature: 99999
 - StartTime: 216295
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216297
   Bpm: 7969
+  Signature: 99999
 - StartTime: 216298
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216300
   Bpm: 72014
+  Signature: 99999
 - StartTime: 216301
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216303
   Bpm: 8005
+  Signature: 99999
 - StartTime: 216304
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216306
   Bpm: 71978
+  Signature: 99999
 - StartTime: 216307
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216309
   Bpm: 8041
+  Signature: 99999
 - StartTime: 216310
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216312
   Bpm: 71942
+  Signature: 99999
 - StartTime: 216313
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216315
   Bpm: 8077
+  Signature: 99999
 - StartTime: 216316
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216318
   Bpm: 71906
+  Signature: 99999
 - StartTime: 216319
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216321
   Bpm: 8113
+  Signature: 99999
 - StartTime: 216322
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216324
   Bpm: 71870
+  Signature: 99999
 - StartTime: 216325
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216327
   Bpm: 8149
+  Signature: 99999
 - StartTime: 216328
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216330
   Bpm: 71834
+  Signature: 99999
 - StartTime: 216331
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216333
   Bpm: 8185
+  Signature: 99999
 - StartTime: 216334
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216336
   Bpm: 71798
+  Signature: 99999
 - StartTime: 216337
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216339
   Bpm: 8221
+  Signature: 99999
 - StartTime: 216340
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216342
   Bpm: 71762
+  Signature: 99999
 - StartTime: 216343
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216345
   Bpm: 8257
+  Signature: 99999
 - StartTime: 216346
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216348
   Bpm: 71726
+  Signature: 99999
 - StartTime: 216349
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216351
   Bpm: 8293
+  Signature: 99999
 - StartTime: 216352
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216354
   Bpm: 71690
+  Signature: 99999
 - StartTime: 216355
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216357
   Bpm: 8329
+  Signature: 99999
 - StartTime: 216358
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216360
   Bpm: 71654
+  Signature: 99999
 - StartTime: 216361
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216363
   Bpm: 8365
+  Signature: 99999
 - StartTime: 216364
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216366
   Bpm: 71618
+  Signature: 99999
 - StartTime: 216367
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216369
   Bpm: 8401
+  Signature: 99999
 - StartTime: 216370
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216372
   Bpm: 71582
+  Signature: 99999
 - StartTime: 216373
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216375
   Bpm: 8437
+  Signature: 99999
 - StartTime: 216376
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216378
   Bpm: 71546
+  Signature: 99999
 - StartTime: 216379
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216381
   Bpm: 8473
+  Signature: 99999
 - StartTime: 216382
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216384
   Bpm: 71510
+  Signature: 99999
 - StartTime: 216385
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216387
   Bpm: 8509
+  Signature: 99999
 - StartTime: 216388
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216390
   Bpm: 71474
+  Signature: 99999
 - StartTime: 216391
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216393
   Bpm: 8545
+  Signature: 99999
 - StartTime: 216394
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216396
   Bpm: 71438
+  Signature: 99999
 - StartTime: 216397
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216399
   Bpm: 8581
+  Signature: 99999
 - StartTime: 216400
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216402
   Bpm: 71402
+  Signature: 99999
 - StartTime: 216403
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216405
   Bpm: 8617
+  Signature: 99999
 - StartTime: 216406
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216408
   Bpm: 71366
+  Signature: 99999
 - StartTime: 216409
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216411
   Bpm: 8653
+  Signature: 99999
 - StartTime: 216412
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216414
   Bpm: 71330
+  Signature: 99999
 - StartTime: 216415
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216417
   Bpm: 8689
+  Signature: 99999
 - StartTime: 216418
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216420
   Bpm: 71294
+  Signature: 99999
 - StartTime: 216421
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216423
   Bpm: 8725
+  Signature: 99999
 - StartTime: 216424
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216426
   Bpm: 71258
+  Signature: 99999
 - StartTime: 216427
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216429
   Bpm: 8761
+  Signature: 99999
 - StartTime: 216430
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216432
   Bpm: 71222
+  Signature: 99999
 - StartTime: 216433
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216435
   Bpm: 8797
+  Signature: 99999
 - StartTime: 216436
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216438
   Bpm: 71186
+  Signature: 99999
 - StartTime: 216439
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216441
   Bpm: 8833
+  Signature: 99999
 - StartTime: 216442
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216444
   Bpm: 71150
+  Signature: 99999
 - StartTime: 216445
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216447
   Bpm: 8869
+  Signature: 99999
 - StartTime: 216448
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216450
   Bpm: 71114
+  Signature: 99999
 - StartTime: 216451
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216453
   Bpm: 8905
+  Signature: 99999
 - StartTime: 216454
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216456
   Bpm: 71078
+  Signature: 99999
 - StartTime: 216457
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216459
   Bpm: 8941
+  Signature: 99999
 - StartTime: 216460
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216462
   Bpm: 71042
+  Signature: 99999
 - StartTime: 216463
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216465
   Bpm: 8977
+  Signature: 99999
 - StartTime: 216466
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216468
   Bpm: 71006
+  Signature: 99999
 - StartTime: 216469
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216471
   Bpm: 9013
+  Signature: 99999
 - StartTime: 216472
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216474
   Bpm: 70970
+  Signature: 99999
 - StartTime: 216475
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216477
   Bpm: 9049
+  Signature: 99999
 - StartTime: 216478
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216480
   Bpm: 70934
+  Signature: 99999
 - StartTime: 216481
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216483
   Bpm: 9085
+  Signature: 99999
 - StartTime: 216484
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216486
   Bpm: 70898
+  Signature: 99999
 - StartTime: 216487
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216489
   Bpm: 9121
+  Signature: 99999
 - StartTime: 216490
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216492
   Bpm: 70862
+  Signature: 99999
 - StartTime: 216493
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216495
   Bpm: 9157
+  Signature: 99999
 - StartTime: 216496
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216498
   Bpm: 70826
+  Signature: 99999
 - StartTime: 216499
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216501
   Bpm: 9193
+  Signature: 99999
 - StartTime: 216502
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216504
   Bpm: 70790
+  Signature: 99999
 - StartTime: 216505
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216507
   Bpm: 9229
+  Signature: 99999
 - StartTime: 216508
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216510
   Bpm: 70754
+  Signature: 99999
 - StartTime: 216511
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216513
   Bpm: 9265
+  Signature: 99999
 - StartTime: 216514
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216516
   Bpm: 70718
+  Signature: 99999
 - StartTime: 216517
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216519
   Bpm: 9301
+  Signature: 99999
 - StartTime: 216520
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216522
   Bpm: 70682
+  Signature: 99999
 - StartTime: 216523
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216525
   Bpm: 9337
+  Signature: 99999
 - StartTime: 216526
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216528
   Bpm: 70646
+  Signature: 99999
 - StartTime: 216529
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216531
   Bpm: 9373
+  Signature: 99999
 - StartTime: 216532
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216534
   Bpm: 70610
+  Signature: 99999
 - StartTime: 216535
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216537
   Bpm: 9409
+  Signature: 99999
 - StartTime: 216538
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216540
   Bpm: 70574
+  Signature: 99999
 - StartTime: 216541
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216543
   Bpm: 9445
+  Signature: 99999
 - StartTime: 216544
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216546
   Bpm: 70538
+  Signature: 99999
 - StartTime: 216547
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216549
   Bpm: 9481
+  Signature: 99999
 - StartTime: 216550
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216552
   Bpm: 70502
+  Signature: 99999
 - StartTime: 216553
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216555
   Bpm: 9517
+  Signature: 99999
 - StartTime: 216556
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216558
   Bpm: 70466
+  Signature: 99999
 - StartTime: 216559
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216561
   Bpm: 9553
+  Signature: 99999
 - StartTime: 216562
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216564
   Bpm: 70430
+  Signature: 99999
 - StartTime: 216565
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216567
   Bpm: 9589
+  Signature: 99999
 - StartTime: 216568
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216570
   Bpm: 70394
+  Signature: 99999
 - StartTime: 216571
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216573
   Bpm: 9625
+  Signature: 99999
 - StartTime: 216574
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216576
   Bpm: 70358
+  Signature: 99999
 - StartTime: 216577
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216579
   Bpm: 9661
+  Signature: 99999
 - StartTime: 216580
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216582
   Bpm: 70322
+  Signature: 99999
 - StartTime: 216583
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216585
   Bpm: 9697
+  Signature: 99999
 - StartTime: 216586
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216588
   Bpm: 70286
+  Signature: 99999
 - StartTime: 216589
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216591
   Bpm: 9733
+  Signature: 99999
 - StartTime: 216592
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216594
   Bpm: 70250
+  Signature: 99999
 - StartTime: 216595
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216597
   Bpm: 9769
+  Signature: 99999
 - StartTime: 216598
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216600
   Bpm: 70214
+  Signature: 99999
 - StartTime: 216601
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216603
   Bpm: 9805
+  Signature: 99999
 - StartTime: 216604
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216606
   Bpm: 70178
+  Signature: 99999
 - StartTime: 216607
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216609
   Bpm: 9841
+  Signature: 99999
 - StartTime: 216610
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216612
   Bpm: 70142
+  Signature: 99999
 - StartTime: 216613
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216615
   Bpm: 9877
+  Signature: 99999
 - StartTime: 216616
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216618
   Bpm: 70106
+  Signature: 99999
 - StartTime: 216619
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216621
   Bpm: 9913
+  Signature: 99999
 - StartTime: 216622
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216624
   Bpm: 70070
+  Signature: 99999
 - StartTime: 216625
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216627
   Bpm: 9949
+  Signature: 99999
 - StartTime: 216628
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216630
   Bpm: 70034
+  Signature: 99999
 - StartTime: 216631
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216633
   Bpm: 9985
+  Signature: 99999
 - StartTime: 216634
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216636
   Bpm: 69998
+  Signature: 99999
 - StartTime: 216637
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216639
   Bpm: 10021
+  Signature: 99999
 - StartTime: 216640
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216642
   Bpm: 69962
+  Signature: 99999
 - StartTime: 216643
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216645
   Bpm: 10057
+  Signature: 99999
 - StartTime: 216646
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216648
   Bpm: 69926
+  Signature: 99999
 - StartTime: 216649
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216651
   Bpm: 10093
+  Signature: 99999
 - StartTime: 216652
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216654
   Bpm: 69890
+  Signature: 99999
 - StartTime: 216655
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216657
   Bpm: 10129
+  Signature: 99999
 - StartTime: 216658
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216660
   Bpm: 69854
+  Signature: 99999
 - StartTime: 216661
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216663
   Bpm: 10165
+  Signature: 99999
 - StartTime: 216664
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216666
   Bpm: 69818
+  Signature: 99999
 - StartTime: 216667
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216669
   Bpm: 10201
+  Signature: 99999
 - StartTime: 216670
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216672
   Bpm: 69782
+  Signature: 99999
 - StartTime: 216673
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216675
   Bpm: 10237
+  Signature: 99999
 - StartTime: 216676
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216678
   Bpm: 69746
+  Signature: 99999
 - StartTime: 216679
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216681
   Bpm: 10273
+  Signature: 99999
 - StartTime: 216682
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216684
   Bpm: 69710
+  Signature: 99999
 - StartTime: 216685
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216687
   Bpm: 10309
+  Signature: 99999
 - StartTime: 216688
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216690
   Bpm: 69674
+  Signature: 99999
 - StartTime: 216691
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216693
   Bpm: 10345
+  Signature: 99999
 - StartTime: 216694
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216696
   Bpm: 69638
+  Signature: 99999
 - StartTime: 216697
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216699
   Bpm: 10381
+  Signature: 99999
 - StartTime: 216700
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216702
   Bpm: 69602
+  Signature: 99999
 - StartTime: 216703
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216705
   Bpm: 10417
+  Signature: 99999
 - StartTime: 216706
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216708
   Bpm: 69566
+  Signature: 99999
 - StartTime: 216709
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216711
   Bpm: 10453
+  Signature: 99999
 - StartTime: 216712
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216714
   Bpm: 69530
+  Signature: 99999
 - StartTime: 216715
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216717
   Bpm: 10489
+  Signature: 99999
 - StartTime: 216718
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216720
   Bpm: 69494
+  Signature: 99999
 - StartTime: 216721
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216723
   Bpm: 10525
+  Signature: 99999
 - StartTime: 216724
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216726
   Bpm: 69458
+  Signature: 99999
 - StartTime: 216727
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216729
   Bpm: 10561
+  Signature: 99999
 - StartTime: 216730
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216732
   Bpm: 69422
+  Signature: 99999
 - StartTime: 216733
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216735
   Bpm: 10597
+  Signature: 99999
 - StartTime: 216736
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216738
   Bpm: 69386
+  Signature: 99999
 - StartTime: 216739
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216741
   Bpm: 10633
+  Signature: 99999
 - StartTime: 216742
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216744
   Bpm: 69350
+  Signature: 99999
 - StartTime: 216745
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216747
   Bpm: 10669
+  Signature: 99999
 - StartTime: 216748
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216750
   Bpm: 69314
+  Signature: 99999
 - StartTime: 216751
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216753
   Bpm: 10705
+  Signature: 99999
 - StartTime: 216754
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216756
   Bpm: 69278
+  Signature: 99999
 - StartTime: 216757
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216759
   Bpm: 10741
+  Signature: 99999
 - StartTime: 216760
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216762
   Bpm: 69242
+  Signature: 99999
 - StartTime: 216763
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216765
   Bpm: 10777
+  Signature: 99999
 - StartTime: 216766
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216768
   Bpm: 69206
+  Signature: 99999
 - StartTime: 216769
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216771
   Bpm: 10813
+  Signature: 99999
 - StartTime: 216772
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216774
   Bpm: 69170
+  Signature: 99999
 - StartTime: 216775
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216777
   Bpm: 10849
+  Signature: 99999
 - StartTime: 216778
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216780
   Bpm: 69134
+  Signature: 99999
 - StartTime: 216781
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216783
   Bpm: 10885
+  Signature: 99999
 - StartTime: 216784
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216786
   Bpm: 69098
+  Signature: 99999
 - StartTime: 216787
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216789
   Bpm: 10921
+  Signature: 99999
 - StartTime: 216790
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216792
   Bpm: 69062
+  Signature: 99999
 - StartTime: 216793
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216795
   Bpm: 10957
+  Signature: 99999
 - StartTime: 216796
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216798
   Bpm: 69026
+  Signature: 99999
 - StartTime: 216799
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216801
   Bpm: 10993
+  Signature: 99999
 - StartTime: 216802
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216804
   Bpm: 68990
+  Signature: 99999
 - StartTime: 216805
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216807
   Bpm: 11029
+  Signature: 99999
 - StartTime: 216808
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216810
   Bpm: 68954
+  Signature: 99999
 - StartTime: 216811
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216813
   Bpm: 11065
+  Signature: 99999
 - StartTime: 216814
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216816
   Bpm: 68918
+  Signature: 99999
 - StartTime: 216817
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216819
   Bpm: 11101
+  Signature: 99999
 - StartTime: 216820
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216822
   Bpm: 68882
+  Signature: 99999
 - StartTime: 216823
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216825
   Bpm: 11137
+  Signature: 99999
 - StartTime: 216826
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216828
   Bpm: 68846
+  Signature: 99999
 - StartTime: 216829
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216831
   Bpm: 11173
+  Signature: 99999
 - StartTime: 216832
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216834
   Bpm: 68810
+  Signature: 99999
 - StartTime: 216835
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216837
   Bpm: 11209
+  Signature: 99999
 - StartTime: 216838
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216840
   Bpm: 68774
+  Signature: 99999
 - StartTime: 216841
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216843
   Bpm: 11245
+  Signature: 99999
 - StartTime: 216844
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216846
   Bpm: 68738
+  Signature: 99999
 - StartTime: 216847
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216849
   Bpm: 11281
+  Signature: 99999
 - StartTime: 216850
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216852
   Bpm: 68702
+  Signature: 99999
 - StartTime: 216853
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216855
   Bpm: 11317
+  Signature: 99999
 - StartTime: 216856
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216858
   Bpm: 68666
+  Signature: 99999
 - StartTime: 216859
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216861
   Bpm: 11353
+  Signature: 99999
 - StartTime: 216862
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216864
   Bpm: 68630
+  Signature: 99999
 - StartTime: 216865
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216867
   Bpm: 11389
+  Signature: 99999
 - StartTime: 216868
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216870
   Bpm: 68594
+  Signature: 99999
 - StartTime: 216871
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216873
   Bpm: 11425
+  Signature: 99999
 - StartTime: 216874
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216876
   Bpm: 68558
+  Signature: 99999
 - StartTime: 216877
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216879
   Bpm: 11461
+  Signature: 99999
 - StartTime: 216880
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216882
   Bpm: 68522
+  Signature: 99999
 - StartTime: 216883
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216885
   Bpm: 11497
+  Signature: 99999
 - StartTime: 216886
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216888
   Bpm: 68486
+  Signature: 99999
 - StartTime: 216889
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216891
   Bpm: 11533
+  Signature: 99999
 - StartTime: 216892
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216894
   Bpm: 68450
+  Signature: 99999
 - StartTime: 216895
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216897
   Bpm: 11569
+  Signature: 99999
 - StartTime: 216898
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216900
   Bpm: 68414
+  Signature: 99999
 - StartTime: 216901
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216903
   Bpm: 11605
+  Signature: 99999
 - StartTime: 216904
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216906
   Bpm: 68378
+  Signature: 99999
 - StartTime: 216907
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216909
   Bpm: 11641
+  Signature: 99999
 - StartTime: 216910
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216912
   Bpm: 68342
+  Signature: 99999
 - StartTime: 216913
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216915
   Bpm: 11677
+  Signature: 99999
 - StartTime: 216916
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216918
   Bpm: 68306
+  Signature: 99999
 - StartTime: 216919
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216921
   Bpm: 11713
+  Signature: 99999
 - StartTime: 216922
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216924
   Bpm: 68270
+  Signature: 99999
 - StartTime: 216925
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216927
   Bpm: 11749
+  Signature: 99999
 - StartTime: 216928
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216930
   Bpm: 68234
+  Signature: 99999
 - StartTime: 216931
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216933
   Bpm: 11785
+  Signature: 99999
 - StartTime: 216934
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216936
   Bpm: 68198
+  Signature: 99999
 - StartTime: 216937
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216939
   Bpm: 11821
+  Signature: 99999
 - StartTime: 216940
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216942
   Bpm: 68162
+  Signature: 99999
 - StartTime: 216943
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216945
   Bpm: 11857
+  Signature: 99999
 - StartTime: 216946
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216948
   Bpm: 68126
+  Signature: 99999
 - StartTime: 216949
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216951
   Bpm: 11893
+  Signature: 99999
 - StartTime: 216952
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216954
   Bpm: 68090
+  Signature: 99999
 - StartTime: 216955
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216957
   Bpm: 11929
+  Signature: 99999
 - StartTime: 216958
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216960
   Bpm: 68054
+  Signature: 99999
 - StartTime: 216961
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216963
   Bpm: 11965
+  Signature: 99999
 - StartTime: 216964
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216966
   Bpm: 68018
+  Signature: 99999
 - StartTime: 216967
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216969
   Bpm: 12001
+  Signature: 99999
 - StartTime: 216970
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216972
   Bpm: 67982
+  Signature: 99999
 - StartTime: 216973
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216975
   Bpm: 12037
+  Signature: 99999
 - StartTime: 216976
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216978
   Bpm: 67946
+  Signature: 99999
 - StartTime: 216979
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216981
   Bpm: 12073
+  Signature: 99999
 - StartTime: 216982
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216984
   Bpm: 67910
+  Signature: 99999
 - StartTime: 216985
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216987
   Bpm: 12109
+  Signature: 99999
 - StartTime: 216988
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216990
   Bpm: 67874
+  Signature: 99999
 - StartTime: 216991
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216993
   Bpm: 12145
+  Signature: 99999
 - StartTime: 216994
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 216996
   Bpm: 67838
+  Signature: 99999
 - StartTime: 216997
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 216999
   Bpm: 12181
+  Signature: 99999
 - StartTime: 217000
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217002
   Bpm: 67802
+  Signature: 99999
 - StartTime: 217003
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217005
   Bpm: 12216.999
+  Signature: 99999
 - StartTime: 217006
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217008
   Bpm: 67766
+  Signature: 99999
 - StartTime: 217009
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217011
   Bpm: 12253
+  Signature: 99999
 - StartTime: 217012
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217014
   Bpm: 67730
+  Signature: 99999
 - StartTime: 217015
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217017
   Bpm: 12289
+  Signature: 99999
 - StartTime: 217018
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217020
   Bpm: 67694
+  Signature: 99999
 - StartTime: 217021
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217023
   Bpm: 12325
+  Signature: 99999
 - StartTime: 217024
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217026
   Bpm: 67658
+  Signature: 99999
 - StartTime: 217027
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217029
   Bpm: 12361
+  Signature: 99999
 - StartTime: 217030
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217032
   Bpm: 67622
+  Signature: 99999
 - StartTime: 217033
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217035
   Bpm: 12397
+  Signature: 99999
 - StartTime: 217036
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217038
   Bpm: 67586
+  Signature: 99999
 - StartTime: 217039
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217041
   Bpm: 12433
+  Signature: 99999
 - StartTime: 217042
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217044
   Bpm: 67550
+  Signature: 99999
 - StartTime: 217045
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217047
   Bpm: 12469
+  Signature: 99999
 - StartTime: 217048
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217050
   Bpm: 67514
+  Signature: 99999
 - StartTime: 217051
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217053
   Bpm: 12505
+  Signature: 99999
 - StartTime: 217054
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217056
   Bpm: 67478
+  Signature: 99999
 - StartTime: 217057
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217059
   Bpm: 12541
+  Signature: 99999
 - StartTime: 217060
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217062
   Bpm: 67442
+  Signature: 99999
 - StartTime: 217063
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217065
   Bpm: 12577
+  Signature: 99999
 - StartTime: 217066
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217068
   Bpm: 67406
+  Signature: 99999
 - StartTime: 217069
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217071
   Bpm: 12613
+  Signature: 99999
 - StartTime: 217072
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217074
   Bpm: 67370
+  Signature: 99999
 - StartTime: 217075
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217077
   Bpm: 12649.001
+  Signature: 99999
 - StartTime: 217078
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217080
   Bpm: 67334
+  Signature: 99999
 - StartTime: 217081
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217083
   Bpm: 12685
+  Signature: 99999
 - StartTime: 217084
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217086
   Bpm: 67298
+  Signature: 99999
 - StartTime: 217087
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217089
   Bpm: 12721
+  Signature: 99999
 - StartTime: 217090
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217092
   Bpm: 67262
+  Signature: 99999
 - StartTime: 217093
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217095
   Bpm: 12757
+  Signature: 99999
 - StartTime: 217096
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217098
   Bpm: 67226
+  Signature: 99999
 - StartTime: 217099
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217101
   Bpm: 12793
+  Signature: 99999
 - StartTime: 217102
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217104
   Bpm: 67190
+  Signature: 99999
 - StartTime: 217105
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217107
   Bpm: 12829
+  Signature: 99999
 - StartTime: 217108
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217110
   Bpm: 67154
+  Signature: 99999
 - StartTime: 217111
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217113
   Bpm: 12865
+  Signature: 99999
 - StartTime: 217114
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217116
   Bpm: 67118
+  Signature: 99999
 - StartTime: 217117
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217119
   Bpm: 12901
+  Signature: 99999
 - StartTime: 217120
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217122
   Bpm: 67082
+  Signature: 99999
 - StartTime: 217123
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217125
   Bpm: 12937
+  Signature: 99999
 - StartTime: 217126
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217128
   Bpm: 67046
+  Signature: 99999
 - StartTime: 217129
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217131
   Bpm: 12973
+  Signature: 99999
 - StartTime: 217132
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217134
   Bpm: 67010
+  Signature: 99999
 - StartTime: 217135
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217137
   Bpm: 13009
+  Signature: 99999
 - StartTime: 217138
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217140
   Bpm: 66974
+  Signature: 99999
 - StartTime: 217141
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217143
   Bpm: 13045
+  Signature: 99999
 - StartTime: 217144
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217146
   Bpm: 66938
+  Signature: 99999
 - StartTime: 217147
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217149
   Bpm: 13081
+  Signature: 99999
 - StartTime: 217150
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217152
   Bpm: 66902
+  Signature: 99999
 - StartTime: 217153
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217155
   Bpm: 13116.999
+  Signature: 99999
 - StartTime: 217156
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217158
   Bpm: 66866
+  Signature: 99999
 - StartTime: 217159
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217161
   Bpm: 13153
+  Signature: 99999
 - StartTime: 217162
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217164
   Bpm: 66830
+  Signature: 99999
 - StartTime: 217165
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217167
   Bpm: 13189.001
+  Signature: 99999
 - StartTime: 217168
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217170
   Bpm: 66794
+  Signature: 99999
 - StartTime: 217171
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217173
   Bpm: 13225
+  Signature: 99999
 - StartTime: 217174
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217176
   Bpm: 66758
+  Signature: 99999
 - StartTime: 217177
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217179
   Bpm: 13261
+  Signature: 99999
 - StartTime: 217180
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217182
   Bpm: 66722
+  Signature: 99999
 - StartTime: 217183
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217185
   Bpm: 13296.999
+  Signature: 99999
 - StartTime: 217186
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217188
   Bpm: 66686
+  Signature: 99999
 - StartTime: 217189
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217191
   Bpm: 13333
+  Signature: 99999
 - StartTime: 217192
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217194
   Bpm: 66650
+  Signature: 99999
 - StartTime: 217195
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217197
   Bpm: 13369
+  Signature: 99999
 - StartTime: 217198
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217200
   Bpm: 66614
+  Signature: 99999
 - StartTime: 217201
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217203
   Bpm: 13405
+  Signature: 99999
 - StartTime: 217204
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217206
   Bpm: 66578
+  Signature: 99999
 - StartTime: 217207
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217209
   Bpm: 13441
+  Signature: 99999
 - StartTime: 217210
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217212
   Bpm: 66542
+  Signature: 99999
 - StartTime: 217213
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217215
   Bpm: 13477
+  Signature: 99999
 - StartTime: 217216
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217218
   Bpm: 66506
+  Signature: 99999
 - StartTime: 217219
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217221
   Bpm: 13513
+  Signature: 99999
 - StartTime: 217222
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217224
   Bpm: 66470
+  Signature: 99999
 - StartTime: 217225
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217227
   Bpm: 13549
+  Signature: 99999
 - StartTime: 217228
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217230
   Bpm: 66434
+  Signature: 99999
 - StartTime: 217231
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217233
   Bpm: 13585
+  Signature: 99999
 - StartTime: 217234
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217236
   Bpm: 66398
+  Signature: 99999
 - StartTime: 217237
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217239
   Bpm: 13621
+  Signature: 99999
 - StartTime: 217240
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217242
   Bpm: 66362
+  Signature: 99999
 - StartTime: 217243
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217245
   Bpm: 13656.999
+  Signature: 99999
 - StartTime: 217246
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217248
   Bpm: 66326
+  Signature: 99999
 - StartTime: 217249
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217251
   Bpm: 13692.999
+  Signature: 99999
 - StartTime: 217252
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217254
   Bpm: 66290
+  Signature: 99999
 - StartTime: 217255
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217257
   Bpm: 13729.001
+  Signature: 99999
 - StartTime: 217258
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217260
   Bpm: 66254
+  Signature: 99999
 - StartTime: 217261
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217263
   Bpm: 13765.001
+  Signature: 99999
 - StartTime: 217264
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217266
   Bpm: 66218
+  Signature: 99999
 - StartTime: 217267
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217269
   Bpm: 13801.001
+  Signature: 99999
 - StartTime: 217270
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217272
   Bpm: 66182
+  Signature: 99999
 - StartTime: 217273
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217275
   Bpm: 13836.999
+  Signature: 99999
 - StartTime: 217276
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217278
   Bpm: 66146
+  Signature: 99999
 - StartTime: 217279
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217281
   Bpm: 13873
+  Signature: 99999
 - StartTime: 217282
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217284
   Bpm: 66110
+  Signature: 99999
 - StartTime: 217285
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217287
   Bpm: 13909
+  Signature: 99999
 - StartTime: 217288
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217290
   Bpm: 66074
+  Signature: 99999
 - StartTime: 217291
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217293
   Bpm: 13945
+  Signature: 99999
 - StartTime: 217294
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217296
   Bpm: 66038
+  Signature: 99999
 - StartTime: 217297
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217299
   Bpm: 13980.999
+  Signature: 99999
 - StartTime: 217300
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217302
   Bpm: 66002
+  Signature: 99999
 - StartTime: 217303
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217305
   Bpm: 14017
+  Signature: 99999
 - StartTime: 217306
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217308
   Bpm: 65966
+  Signature: 99999
 - StartTime: 217309
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217311
   Bpm: 14053.001
+  Signature: 99999
 - StartTime: 217312
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217314
   Bpm: 65930
+  Signature: 99999
 - StartTime: 217315
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217317
   Bpm: 14088.999
+  Signature: 99999
 - StartTime: 217318
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217320
   Bpm: 65894
+  Signature: 99999
 - StartTime: 217321
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217323
   Bpm: 14125
+  Signature: 99999
 - StartTime: 217324
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217326
   Bpm: 65858
+  Signature: 99999
 - StartTime: 217327
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217329
   Bpm: 14161
+  Signature: 99999
 - StartTime: 217330
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217332
   Bpm: 65822
+  Signature: 99999
 - StartTime: 217333
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217335
   Bpm: 14197
+  Signature: 99999
 - StartTime: 217336
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217338
   Bpm: 65786
+  Signature: 99999
 - StartTime: 217339
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217341
   Bpm: 14233.001
+  Signature: 99999
 - StartTime: 217342
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217344
   Bpm: 65750
+  Signature: 99999
 - StartTime: 217345
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217347
   Bpm: 14269
+  Signature: 99999
 - StartTime: 217348
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217350
   Bpm: 65714
+  Signature: 99999
 - StartTime: 217351
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217353
   Bpm: 14304.999
+  Signature: 99999
 - StartTime: 217354
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217356
   Bpm: 65678
+  Signature: 99999
 - StartTime: 217357
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217359
   Bpm: 14340.999
+  Signature: 99999
 - StartTime: 217360
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217362
   Bpm: 65642
+  Signature: 99999
 - StartTime: 217363
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217365
   Bpm: 14377.001
+  Signature: 99999
 - StartTime: 217366
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217368
   Bpm: 65606
+  Signature: 99999
 - StartTime: 217369
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217371
   Bpm: 14413
+  Signature: 99999
 - StartTime: 217372
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217374
   Bpm: 65570
+  Signature: 99999
 - StartTime: 217375
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217377
   Bpm: 14449
+  Signature: 99999
 - StartTime: 217378
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217380
   Bpm: 65534
+  Signature: 99999
 - StartTime: 217381
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217383
   Bpm: 14485
+  Signature: 99999
 - StartTime: 217384
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217386
   Bpm: 65498
+  Signature: 99999
 - StartTime: 217387
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217389
   Bpm: 14520.999
+  Signature: 99999
 - StartTime: 217390
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217392
   Bpm: 65462
+  Signature: 99999
 - StartTime: 217393
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217395
   Bpm: 14557
+  Signature: 99999
 - StartTime: 217396
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217398
   Bpm: 65426
+  Signature: 99999
 - StartTime: 217399
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217401
   Bpm: 14593
+  Signature: 99999
 - StartTime: 217402
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217404
   Bpm: 65390
+  Signature: 99999
 - StartTime: 217405
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217407
   Bpm: 14629
+  Signature: 99999
 - StartTime: 217408
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217410
   Bpm: 65354
+  Signature: 99999
 - StartTime: 217411
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217413
   Bpm: 14665
+  Signature: 99999
 - StartTime: 217414
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217416
   Bpm: 65318
+  Signature: 99999
 - StartTime: 217417
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217419
   Bpm: 14701
+  Signature: 99999
 - StartTime: 217420
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217422
   Bpm: 65282
+  Signature: 99999
 - StartTime: 217423
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217425
   Bpm: 14737
+  Signature: 99999
 - StartTime: 217426
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217428
   Bpm: 65246
+  Signature: 99999
 - StartTime: 217429
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217431
   Bpm: 14773
+  Signature: 99999
 - StartTime: 217432
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217434
   Bpm: 65210
+  Signature: 99999
 - StartTime: 217435
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217437
   Bpm: 14808.999
+  Signature: 99999
 - StartTime: 217438
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217440
   Bpm: 65174
+  Signature: 99999
 - StartTime: 217441
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217443
   Bpm: 14845.001
+  Signature: 99999
 - StartTime: 217444
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217446
   Bpm: 65138
+  Signature: 99999
 - StartTime: 217447
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217449
   Bpm: 14881
+  Signature: 99999
 - StartTime: 217450
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217452
   Bpm: 65102
+  Signature: 99999
 - StartTime: 217453
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217455
   Bpm: 14917
+  Signature: 99999
 - StartTime: 217456
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217458
   Bpm: 65066
+  Signature: 99999
 - StartTime: 217459
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217461
   Bpm: 14953
+  Signature: 99999
 - StartTime: 217462
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217464
   Bpm: 65029.9961
+  Signature: 99999
 - StartTime: 217465
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217467
   Bpm: 14989
+  Signature: 99999
 - StartTime: 217468
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217470
   Bpm: 64994
+  Signature: 99999
 - StartTime: 217471
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217473
   Bpm: 15025
+  Signature: 99999
 - StartTime: 217474
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217476
   Bpm: 64958
+  Signature: 99999
 - StartTime: 217477
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217479
   Bpm: 15061
+  Signature: 99999
 - StartTime: 217480
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217482
   Bpm: 64922
+  Signature: 99999
 - StartTime: 217483
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217485
   Bpm: 15097
+  Signature: 99999
 - StartTime: 217486
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217488
   Bpm: 64886
+  Signature: 99999
 - StartTime: 217489
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217491
   Bpm: 15133
+  Signature: 99999
 - StartTime: 217492
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217494
   Bpm: 64850
+  Signature: 99999
 - StartTime: 217495
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217497
   Bpm: 15169
+  Signature: 99999
 - StartTime: 217498
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217500
   Bpm: 64814
+  Signature: 99999
 - StartTime: 217501
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217503
   Bpm: 15205
+  Signature: 99999
 - StartTime: 217504
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217506
   Bpm: 64778
+  Signature: 99999
 - StartTime: 217507
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217509
   Bpm: 15241
+  Signature: 99999
 - StartTime: 217510
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217512
   Bpm: 64742
+  Signature: 99999
 - StartTime: 217513
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217515
   Bpm: 15277
+  Signature: 99999
 - StartTime: 217516
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217518
   Bpm: 64706
+  Signature: 99999
 - StartTime: 217519
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217521
   Bpm: 15313
+  Signature: 99999
 - StartTime: 217522
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217524
   Bpm: 64670
+  Signature: 99999
 - StartTime: 217525
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217527
   Bpm: 15349
+  Signature: 99999
 - StartTime: 217528
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217530
   Bpm: 64634
+  Signature: 99999
 - StartTime: 217531
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217533
   Bpm: 15385
+  Signature: 99999
 - StartTime: 217534
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217536
   Bpm: 64598
+  Signature: 99999
 - StartTime: 217537
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217539
   Bpm: 15421
+  Signature: 99999
 - StartTime: 217540
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217542
   Bpm: 64562
+  Signature: 99999
 - StartTime: 217543
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217545
   Bpm: 15457
+  Signature: 99999
 - StartTime: 217546
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217548
   Bpm: 64526
+  Signature: 99999
 - StartTime: 217549
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217551
   Bpm: 15493
+  Signature: 99999
 - StartTime: 217552
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217554
   Bpm: 64490
+  Signature: 99999
 - StartTime: 217555
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217557
   Bpm: 15529
+  Signature: 99999
 - StartTime: 217558
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217560
   Bpm: 64454
+  Signature: 99999
 - StartTime: 217561
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217563
   Bpm: 15565
+  Signature: 99999
 - StartTime: 217564
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217566
   Bpm: 64418
+  Signature: 99999
 - StartTime: 217567
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217569
   Bpm: 15601
+  Signature: 99999
 - StartTime: 217570
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217572
   Bpm: 64382
+  Signature: 99999
 - StartTime: 217573
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217575
   Bpm: 15637
+  Signature: 99999
 - StartTime: 217576
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217578
   Bpm: 64346
+  Signature: 99999
 - StartTime: 217579
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217581
   Bpm: 15673
+  Signature: 99999
 - StartTime: 217582
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217584
   Bpm: 64310
+  Signature: 99999
 - StartTime: 217585
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217587
   Bpm: 15709
+  Signature: 99999
 - StartTime: 217588
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217590
   Bpm: 64274
+  Signature: 99999
 - StartTime: 217591
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217593
   Bpm: 15745
+  Signature: 99999
 - StartTime: 217594
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217596
   Bpm: 64238
+  Signature: 99999
 - StartTime: 217597
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217599
   Bpm: 15781
+  Signature: 99999
 - StartTime: 217600
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217602
   Bpm: 64202
+  Signature: 99999
 - StartTime: 217603
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217605
   Bpm: 15817
+  Signature: 99999
 - StartTime: 217606
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217608
   Bpm: 64166
+  Signature: 99999
 - StartTime: 217609
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217611
   Bpm: 15853
+  Signature: 99999
 - StartTime: 217612
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217614
   Bpm: 64130
+  Signature: 99999
 - StartTime: 217615
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217617
   Bpm: 15889
+  Signature: 99999
 - StartTime: 217618
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217620
   Bpm: 64094
+  Signature: 99999
 - StartTime: 217621
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217623
   Bpm: 15925
+  Signature: 99999
 - StartTime: 217624
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217626
   Bpm: 64058
+  Signature: 99999
 - StartTime: 217627
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217629
   Bpm: 15961
+  Signature: 99999
 - StartTime: 217630
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217632
   Bpm: 64022
+  Signature: 99999
 - StartTime: 217633
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217635
   Bpm: 15997
+  Signature: 99999
 - StartTime: 217636
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217638
   Bpm: 63986
+  Signature: 99999
 - StartTime: 217639
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217641
   Bpm: 16033
+  Signature: 99999
 - StartTime: 217642
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217644
   Bpm: 63950
+  Signature: 99999
 - StartTime: 217645
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217647
   Bpm: 16069.001
+  Signature: 99999
 - StartTime: 217648
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217650
   Bpm: 63914
+  Signature: 99999
 - StartTime: 217651
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217653
   Bpm: 16105
+  Signature: 99999
 - StartTime: 217654
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217656
   Bpm: 63878
+  Signature: 99999
 - StartTime: 217657
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217659
   Bpm: 16141
+  Signature: 99999
 - StartTime: 217660
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217662
   Bpm: 63842
+  Signature: 99999
 - StartTime: 217663
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217665
   Bpm: 16177
+  Signature: 99999
 - StartTime: 217666
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217668
   Bpm: 63806
+  Signature: 99999
 - StartTime: 217669
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217671
   Bpm: 16213
+  Signature: 99999
 - StartTime: 217672
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217674
   Bpm: 63770
+  Signature: 99999
 - StartTime: 217675
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217677
   Bpm: 16249
+  Signature: 99999
 - StartTime: 217678
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217680
   Bpm: 63734
+  Signature: 99999
 - StartTime: 217681
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217683
   Bpm: 16285
+  Signature: 99999
 - StartTime: 217684
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217686
   Bpm: 63698
+  Signature: 99999
 - StartTime: 217687
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217689
   Bpm: 16321.001
+  Signature: 99999
 - StartTime: 217690
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217692
   Bpm: 63662
+  Signature: 99999
 - StartTime: 217693
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217695
   Bpm: 16357
+  Signature: 99999
 - StartTime: 217696
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217698
   Bpm: 63626
+  Signature: 99999
 - StartTime: 217699
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217701
   Bpm: 16393
+  Signature: 99999
 - StartTime: 217702
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217704
   Bpm: 63590
+  Signature: 99999
 - StartTime: 217705
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217707
   Bpm: 16429
+  Signature: 99999
 - StartTime: 217708
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217710
   Bpm: 63554
+  Signature: 99999
 - StartTime: 217711
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217713
   Bpm: 16465
+  Signature: 99999
 - StartTime: 217714
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217716
   Bpm: 63518
+  Signature: 99999
 - StartTime: 217717
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217719
   Bpm: 16501
+  Signature: 99999
 - StartTime: 217720
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217722
   Bpm: 63482
+  Signature: 99999
 - StartTime: 217723
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217725
   Bpm: 16537
+  Signature: 99999
 - StartTime: 217726
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217728
   Bpm: 63446
+  Signature: 99999
 - StartTime: 217729
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217731
   Bpm: 16573
+  Signature: 99999
 - StartTime: 217732
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217734
   Bpm: 63410
+  Signature: 99999
 - StartTime: 217735
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217737
   Bpm: 16609
+  Signature: 99999
 - StartTime: 217738
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217740
   Bpm: 63374
+  Signature: 99999
 - StartTime: 217741
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217743
   Bpm: 16645
+  Signature: 99999
 - StartTime: 217744
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217746
   Bpm: 63338
+  Signature: 99999
 - StartTime: 217747
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217749
   Bpm: 16681
+  Signature: 99999
 - StartTime: 217750
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217752
   Bpm: 63302
+  Signature: 99999
 - StartTime: 217753
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217755
   Bpm: 16717
+  Signature: 99999
 - StartTime: 217756
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217758
   Bpm: 63266
+  Signature: 99999
 - StartTime: 217759
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217761
   Bpm: 16753
+  Signature: 99999
 - StartTime: 217762
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217764
   Bpm: 63230
+  Signature: 99999
 - StartTime: 217765
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217767
   Bpm: 16789
+  Signature: 99999
 - StartTime: 217768
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217770
   Bpm: 63194
+  Signature: 99999
 - StartTime: 217771
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217773
   Bpm: 16825
+  Signature: 99999
 - StartTime: 217774
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217776
   Bpm: 63158
+  Signature: 99999
 - StartTime: 217777
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217779
   Bpm: 16861
+  Signature: 99999
 - StartTime: 217780
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217782
   Bpm: 63122
+  Signature: 99999
 - StartTime: 217783
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217785
   Bpm: 16897
+  Signature: 99999
 - StartTime: 217786
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217788
   Bpm: 63086
+  Signature: 99999
 - StartTime: 217789
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217791
   Bpm: 16933
+  Signature: 99999
 - StartTime: 217792
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217794
   Bpm: 63050
+  Signature: 99999
 - StartTime: 217795
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217797
   Bpm: 16969
+  Signature: 99999
 - StartTime: 217798
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217800
   Bpm: 63014
+  Signature: 99999
 - StartTime: 217801
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217803
   Bpm: 17005
+  Signature: 99999
 - StartTime: 217804
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217806
   Bpm: 62978
+  Signature: 99999
 - StartTime: 217807
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217809
   Bpm: 17041
+  Signature: 99999
 - StartTime: 217810
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217812
   Bpm: 62942
+  Signature: 99999
 - StartTime: 217813
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217815
   Bpm: 17077
+  Signature: 99999
 - StartTime: 217816
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217818
   Bpm: 62906
+  Signature: 99999
 - StartTime: 217819
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217821
   Bpm: 17113
+  Signature: 99999
 - StartTime: 217822
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217824
   Bpm: 62870
+  Signature: 99999
 - StartTime: 217825
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217827
   Bpm: 17149
+  Signature: 99999
 - StartTime: 217828
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217830
   Bpm: 62834
+  Signature: 99999
 - StartTime: 217831
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217833
   Bpm: 17185
+  Signature: 99999
 - StartTime: 217834
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217836
   Bpm: 62798
+  Signature: 99999
 - StartTime: 217837
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217839
   Bpm: 17221
+  Signature: 99999
 - StartTime: 217840
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217842
   Bpm: 62762
+  Signature: 99999
 - StartTime: 217843
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217845
   Bpm: 17257
+  Signature: 99999
 - StartTime: 217846
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217848
   Bpm: 62726
+  Signature: 99999
 - StartTime: 217849
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217851
   Bpm: 17293
+  Signature: 99999
 - StartTime: 217852
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217854
   Bpm: 62690
+  Signature: 99999
 - StartTime: 217855
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217857
   Bpm: 17329
+  Signature: 99999
 - StartTime: 217858
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217860
   Bpm: 62654
+  Signature: 99999
 - StartTime: 217861
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217863
   Bpm: 17365
+  Signature: 99999
 - StartTime: 217864
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217866
   Bpm: 62618
+  Signature: 99999
 - StartTime: 217867
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217869
   Bpm: 17401
+  Signature: 99999
 - StartTime: 217870
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217872
   Bpm: 62582
+  Signature: 99999
 - StartTime: 217873
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217875
   Bpm: 17437
+  Signature: 99999
 - StartTime: 217876
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217878
   Bpm: 62546
+  Signature: 99999
 - StartTime: 217879
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217881
   Bpm: 17473
+  Signature: 99999
 - StartTime: 217882
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217884
   Bpm: 62510
+  Signature: 99999
 - StartTime: 217885
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217887
   Bpm: 17509
+  Signature: 99999
 - StartTime: 217888
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217890
   Bpm: 62474
+  Signature: 99999
 - StartTime: 217891
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217893
   Bpm: 17545
+  Signature: 99999
 - StartTime: 217894
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217896
   Bpm: 62438
+  Signature: 99999
 - StartTime: 217897
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217899
   Bpm: 17581
+  Signature: 99999
 - StartTime: 217900
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217902
   Bpm: 62402
+  Signature: 99999
 - StartTime: 217903
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217905
   Bpm: 17617
+  Signature: 99999
 - StartTime: 217906
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217908
   Bpm: 62366
+  Signature: 99999
 - StartTime: 217909
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217911
   Bpm: 17653
+  Signature: 99999
 - StartTime: 217912
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217914
   Bpm: 62330
+  Signature: 99999
 - StartTime: 217915
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217917
   Bpm: 17689
+  Signature: 99999
 - StartTime: 217918
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217920
   Bpm: 62294
+  Signature: 99999
 - StartTime: 217921
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217923
   Bpm: 17725
+  Signature: 99999
 - StartTime: 217924
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217926
   Bpm: 62258
+  Signature: 99999
 - StartTime: 217927
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217929
   Bpm: 17761
+  Signature: 99999
 - StartTime: 217930
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217932
   Bpm: 62222
+  Signature: 99999
 - StartTime: 217933
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217935
   Bpm: 17797
+  Signature: 99999
 - StartTime: 217936
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217938
   Bpm: 62186
+  Signature: 99999
 - StartTime: 217939
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217941
   Bpm: 17833
+  Signature: 99999
 - StartTime: 217942
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217944
   Bpm: 62150
+  Signature: 99999
 - StartTime: 217945
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217947
   Bpm: 17869
+  Signature: 99999
 - StartTime: 217948
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217950
   Bpm: 62114
+  Signature: 99999
 - StartTime: 217951
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217953
   Bpm: 17905
+  Signature: 99999
 - StartTime: 217954
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217956
   Bpm: 62078
+  Signature: 99999
 - StartTime: 217957
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217959
   Bpm: 17941
+  Signature: 99999
 - StartTime: 217960
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217962
   Bpm: 62042
+  Signature: 99999
 - StartTime: 217963
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217965
   Bpm: 17977
+  Signature: 99999
 - StartTime: 217966
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217968
   Bpm: 62006
+  Signature: 99999
 - StartTime: 217969
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217971
   Bpm: 18013
+  Signature: 99999
 - StartTime: 217972
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217974
   Bpm: 61970
+  Signature: 99999
 - StartTime: 217975
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217977
   Bpm: 18049
+  Signature: 99999
 - StartTime: 217978
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217980
   Bpm: 61934
+  Signature: 99999
 - StartTime: 217981
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217983
   Bpm: 18085
+  Signature: 99999
 - StartTime: 217984
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217986
   Bpm: 61898
+  Signature: 99999
 - StartTime: 217987
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217989
   Bpm: 18121
+  Signature: 99999
 - StartTime: 217990
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217992
   Bpm: 61862
+  Signature: 99999
 - StartTime: 217993
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 217995
   Bpm: 18157
+  Signature: 99999
 - StartTime: 217996
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 217998
   Bpm: 61826
+  Signature: 99999
 - StartTime: 217999
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218001
   Bpm: 18193
+  Signature: 99999
 - StartTime: 218002
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218004
   Bpm: 61790
+  Signature: 99999
 - StartTime: 218005
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218007
   Bpm: 18229
+  Signature: 99999
 - StartTime: 218008
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218010
   Bpm: 61754
+  Signature: 99999
 - StartTime: 218011
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218013
   Bpm: 18265
+  Signature: 99999
 - StartTime: 218014
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218016
   Bpm: 61718
+  Signature: 99999
 - StartTime: 218017
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218019
   Bpm: 18301
+  Signature: 99999
 - StartTime: 218020
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218022
   Bpm: 61682
+  Signature: 99999
 - StartTime: 218023
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218025
   Bpm: 18337
+  Signature: 99999
 - StartTime: 218026
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218028
   Bpm: 61646
+  Signature: 99999
 - StartTime: 218029
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218031
   Bpm: 18373
+  Signature: 99999
 - StartTime: 218032
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218034
   Bpm: 61610
+  Signature: 99999
 - StartTime: 218035
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218037
   Bpm: 18409
+  Signature: 99999
 - StartTime: 218038
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218040
   Bpm: 61574
+  Signature: 99999
 - StartTime: 218041
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218043
   Bpm: 18445
+  Signature: 99999
 - StartTime: 218044
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218046
   Bpm: 61538
+  Signature: 99999
 - StartTime: 218047
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218049
   Bpm: 18481
+  Signature: 99999
 - StartTime: 218050
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218052
   Bpm: 61502
+  Signature: 99999
 - StartTime: 218053
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218055
   Bpm: 18517
+  Signature: 99999
 - StartTime: 218056
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218058
   Bpm: 61466
+  Signature: 99999
 - StartTime: 218059
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218061
   Bpm: 18553
+  Signature: 99999
 - StartTime: 218062
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218064
   Bpm: 61430
+  Signature: 99999
 - StartTime: 218065
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218067
   Bpm: 18589
+  Signature: 99999
 - StartTime: 218068
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218070
   Bpm: 61394
+  Signature: 99999
 - StartTime: 218071
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218073
   Bpm: 18625
+  Signature: 99999
 - StartTime: 218074
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218076
   Bpm: 61358
+  Signature: 99999
 - StartTime: 218077
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218079
   Bpm: 18661
+  Signature: 99999
 - StartTime: 218080
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218082
   Bpm: 61322
+  Signature: 99999
 - StartTime: 218083
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218085
   Bpm: 18697
+  Signature: 99999
 - StartTime: 218086
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218088
   Bpm: 61286
+  Signature: 99999
 - StartTime: 218089
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218091
   Bpm: 18733
+  Signature: 99999
 - StartTime: 218092
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218094
   Bpm: 61250
+  Signature: 99999
 - StartTime: 218095
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218097
   Bpm: 18769
+  Signature: 99999
 - StartTime: 218098
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218100
   Bpm: 61214
+  Signature: 99999
 - StartTime: 218101
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218103
   Bpm: 18805
+  Signature: 99999
 - StartTime: 218104
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218106
   Bpm: 61178
+  Signature: 99999
 - StartTime: 218107
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218109
   Bpm: 18841
+  Signature: 99999
 - StartTime: 218110
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218112
   Bpm: 61142
+  Signature: 99999
 - StartTime: 218113
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218115
   Bpm: 18877
+  Signature: 99999
 - StartTime: 218116
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218118
   Bpm: 61106
+  Signature: 99999
 - StartTime: 218119
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218121
   Bpm: 18913
+  Signature: 99999
 - StartTime: 218122
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218124
   Bpm: 61070
+  Signature: 99999
 - StartTime: 218125
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218127
   Bpm: 18949
+  Signature: 99999
 - StartTime: 218128
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218130
   Bpm: 61034
+  Signature: 99999
 - StartTime: 218131
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218133
   Bpm: 18985
+  Signature: 99999
 - StartTime: 218134
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218136
   Bpm: 60998
+  Signature: 99999
 - StartTime: 218137
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218139
   Bpm: 19021
+  Signature: 99999
 - StartTime: 218140
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218142
   Bpm: 60962
+  Signature: 99999
 - StartTime: 218143
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218145
   Bpm: 19057
+  Signature: 99999
 - StartTime: 218146
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218148
   Bpm: 60926
+  Signature: 99999
 - StartTime: 218149
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218151
   Bpm: 19093
+  Signature: 99999
 - StartTime: 218152
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218154
   Bpm: 60890
+  Signature: 99999
 - StartTime: 218155
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218157
   Bpm: 19129
+  Signature: 99999
 - StartTime: 218158
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218160
   Bpm: 60854
+  Signature: 99999
 - StartTime: 218161
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218163
   Bpm: 19165
+  Signature: 99999
 - StartTime: 218164
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218166
   Bpm: 60818
+  Signature: 99999
 - StartTime: 218167
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218169
   Bpm: 19201
+  Signature: 99999
 - StartTime: 218170
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218172
   Bpm: 60782
+  Signature: 99999
 - StartTime: 218173
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218175
   Bpm: 19237
+  Signature: 99999
 - StartTime: 218176
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218178
   Bpm: 60746
+  Signature: 99999
 - StartTime: 218179
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218181
   Bpm: 19273
+  Signature: 99999
 - StartTime: 218182
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218184
   Bpm: 60710
+  Signature: 99999
 - StartTime: 218185
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218187
   Bpm: 19309
+  Signature: 99999
 - StartTime: 218188
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218190
   Bpm: 60674
+  Signature: 99999
 - StartTime: 218191
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218193
   Bpm: 19345
+  Signature: 99999
 - StartTime: 218194
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218196
   Bpm: 60638
+  Signature: 99999
 - StartTime: 218197
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218199
   Bpm: 19381
+  Signature: 99999
 - StartTime: 218200
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218202
   Bpm: 60602
+  Signature: 99999
 - StartTime: 218203
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218205
   Bpm: 19417
+  Signature: 99999
 - StartTime: 218206
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218208
   Bpm: 60566
+  Signature: 99999
 - StartTime: 218209
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218211
   Bpm: 19453
+  Signature: 99999
 - StartTime: 218212
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218214
   Bpm: 60530
+  Signature: 99999
 - StartTime: 218215
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218217
   Bpm: 19489
+  Signature: 99999
 - StartTime: 218218
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218220
   Bpm: 60494
+  Signature: 99999
 - StartTime: 218221
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218223
   Bpm: 19525
+  Signature: 99999
 - StartTime: 218224
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218226
   Bpm: 60458
+  Signature: 99999
 - StartTime: 218227
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218229
   Bpm: 19561
+  Signature: 99999
 - StartTime: 218230
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218232
   Bpm: 60422
+  Signature: 99999
 - StartTime: 218233
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218235
   Bpm: 19597
+  Signature: 99999
 - StartTime: 218236
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218238
   Bpm: 60386
+  Signature: 99999
 - StartTime: 218239
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218241
   Bpm: 19633
+  Signature: 99999
 - StartTime: 218242
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218244
   Bpm: 60350
+  Signature: 99999
 - StartTime: 218245
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218247
   Bpm: 19669
+  Signature: 99999
 - StartTime: 218248
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218250
   Bpm: 60314
+  Signature: 99999
 - StartTime: 218251
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218253
   Bpm: 19705
+  Signature: 99999
 - StartTime: 218254
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218256
   Bpm: 60278
+  Signature: 99999
 - StartTime: 218257
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218259
   Bpm: 19741
+  Signature: 99999
 - StartTime: 218260
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218262
   Bpm: 60242
+  Signature: 99999
 - StartTime: 218263
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218265
   Bpm: 19777
+  Signature: 99999
 - StartTime: 218266
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218268
   Bpm: 60206
+  Signature: 99999
 - StartTime: 218269
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218271
   Bpm: 19813
+  Signature: 99999
 - StartTime: 218272
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218274
   Bpm: 60170
+  Signature: 99999
 - StartTime: 218275
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218277
   Bpm: 19849
+  Signature: 99999
 - StartTime: 218278
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218280
   Bpm: 60134
+  Signature: 99999
 - StartTime: 218281
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218283
   Bpm: 19885
+  Signature: 99999
 - StartTime: 218284
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218286
   Bpm: 60098
+  Signature: 99999
 - StartTime: 218287
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218289
   Bpm: 19921
+  Signature: 99999
 - StartTime: 218290
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218292
   Bpm: 60062
+  Signature: 99999
 - StartTime: 218293
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218295
   Bpm: 19957
+  Signature: 99999
 - StartTime: 218296
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218298
   Bpm: 60026
+  Signature: 99999
 - StartTime: 218299
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218301
   Bpm: 19993
+  Signature: 99999
 - StartTime: 218302
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218304
   Bpm: 59990.0039
+  Signature: 99999
 - StartTime: 218305
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218307
   Bpm: 20029
+  Signature: 99999
 - StartTime: 218308
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218310
   Bpm: 59954
+  Signature: 99999
 - StartTime: 218311
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218313
   Bpm: 20065
+  Signature: 99999
 - StartTime: 218314
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218316
   Bpm: 59918
+  Signature: 99999
 - StartTime: 218317
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218319
   Bpm: 20101
+  Signature: 99999
 - StartTime: 218320
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218322
   Bpm: 59882
+  Signature: 99999
 - StartTime: 218323
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218325
   Bpm: 20137
+  Signature: 99999
 - StartTime: 218326
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218328
   Bpm: 59846
+  Signature: 99999
 - StartTime: 218329
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218331
   Bpm: 20173
+  Signature: 99999
 - StartTime: 218332
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218334
   Bpm: 59810.0039
+  Signature: 99999
 - StartTime: 218335
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218337
   Bpm: 20209
+  Signature: 99999
 - StartTime: 218338
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218340
   Bpm: 59773.9961
+  Signature: 99999
 - StartTime: 218341
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218343
   Bpm: 20245
+  Signature: 99999
 - StartTime: 218344
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218346
   Bpm: 59738
+  Signature: 99999
 - StartTime: 218347
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218349
   Bpm: 20281
+  Signature: 99999
 - StartTime: 218350
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218352
   Bpm: 59702.0039
+  Signature: 99999
 - StartTime: 218353
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218355
   Bpm: 20317
+  Signature: 99999
 - StartTime: 218356
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218358
   Bpm: 59666
+  Signature: 99999
 - StartTime: 218359
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218361
   Bpm: 20353
+  Signature: 99999
 - StartTime: 218362
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218364
   Bpm: 59630
+  Signature: 99999
 - StartTime: 218365
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218367
   Bpm: 20389
+  Signature: 99999
 - StartTime: 218368
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218370
   Bpm: 59593.9961
+  Signature: 99999
 - StartTime: 218371
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218373
   Bpm: 20425
+  Signature: 99999
 - StartTime: 218374
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218376
   Bpm: 59557.9961
+  Signature: 99999
 - StartTime: 218377
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218379
   Bpm: 20461
+  Signature: 99999
 - StartTime: 218380
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218382
   Bpm: 59522
+  Signature: 99999
 - StartTime: 218383
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218385
   Bpm: 20497
+  Signature: 99999
 - StartTime: 218386
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218388
   Bpm: 59486.0039
+  Signature: 99999
 - StartTime: 218389
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218391
   Bpm: 20533
+  Signature: 99999
 - StartTime: 218392
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218394
   Bpm: 59450
+  Signature: 99999
 - StartTime: 218395
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218397
   Bpm: 20569
+  Signature: 99999
 - StartTime: 218398
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218400
   Bpm: 59414
+  Signature: 99999
 - StartTime: 218401
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218403
   Bpm: 20605
+  Signature: 99999
 - StartTime: 218404
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218406
   Bpm: 59378
+  Signature: 99999
 - StartTime: 218407
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218409
   Bpm: 20641
+  Signature: 99999
 - StartTime: 218410
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218412
   Bpm: 59342
+  Signature: 99999
 - StartTime: 218413
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218415
   Bpm: 20677
+  Signature: 99999
 - StartTime: 218416
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218418
   Bpm: 59305.9961
+  Signature: 99999
 - StartTime: 218419
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218421
   Bpm: 20713
+  Signature: 99999
 - StartTime: 218422
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218424
   Bpm: 59270.0039
+  Signature: 99999
 - StartTime: 218425
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218427
   Bpm: 20749
+  Signature: 99999
 - StartTime: 218428
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218430
   Bpm: 59234.0039
+  Signature: 99999
 - StartTime: 218431
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218433
   Bpm: 20785
+  Signature: 99999
 - StartTime: 218434
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218436
   Bpm: 59198
+  Signature: 99999
 - StartTime: 218437
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218439
   Bpm: 20821
+  Signature: 99999
 - StartTime: 218440
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218442
   Bpm: 59162.0039
+  Signature: 99999
 - StartTime: 218443
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218445
   Bpm: 20857
+  Signature: 99999
 - StartTime: 218446
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218448
   Bpm: 59126.0039
+  Signature: 99999
 - StartTime: 218449
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218451
   Bpm: 20893
+  Signature: 99999
 - StartTime: 218452
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218454
   Bpm: 59089.9961
+  Signature: 99999
 - StartTime: 218455
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218457
   Bpm: 20929
+  Signature: 99999
 - StartTime: 218458
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218460
   Bpm: 59054
+  Signature: 99999
 - StartTime: 218461
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218463
   Bpm: 20965
+  Signature: 99999
 - StartTime: 218464
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218466
   Bpm: 59018
+  Signature: 99999
 - StartTime: 218467
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218469
   Bpm: 21001
+  Signature: 99999
 - StartTime: 218470
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218472
   Bpm: 58982
+  Signature: 99999
 - StartTime: 218473
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218475
   Bpm: 21037
+  Signature: 99999
 - StartTime: 218476
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218478
   Bpm: 58946
+  Signature: 99999
 - StartTime: 218479
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218481
   Bpm: 21073
+  Signature: 99999
 - StartTime: 218482
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218484
   Bpm: 58910
+  Signature: 99999
 - StartTime: 218485
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218487
   Bpm: 21109
+  Signature: 99999
 - StartTime: 218488
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218490
   Bpm: 58874
+  Signature: 99999
 - StartTime: 218491
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218493
   Bpm: 21145
+  Signature: 99999
 - StartTime: 218494
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218496
   Bpm: 58838
+  Signature: 99999
 - StartTime: 218497
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218499
   Bpm: 21181
+  Signature: 99999
 - StartTime: 218500
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218502
   Bpm: 58802
+  Signature: 99999
 - StartTime: 218503
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218505
   Bpm: 21217
+  Signature: 99999
 - StartTime: 218506
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218508
   Bpm: 58766.0039
+  Signature: 99999
 - StartTime: 218509
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218511
   Bpm: 21253
+  Signature: 99999
 - StartTime: 218512
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218514
   Bpm: 58730.0039
+  Signature: 99999
 - StartTime: 218515
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218517
   Bpm: 21289
+  Signature: 99999
 - StartTime: 218518
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218520
   Bpm: 58694
+  Signature: 99999
 - StartTime: 218521
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218523
   Bpm: 21325
+  Signature: 99999
 - StartTime: 218524
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218526
   Bpm: 58658
+  Signature: 99999
 - StartTime: 218527
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218529
   Bpm: 21361
+  Signature: 99999
 - StartTime: 218530
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218532
   Bpm: 58622
+  Signature: 99999
 - StartTime: 218533
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218535
   Bpm: 21397
+  Signature: 99999
 - StartTime: 218536
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218538
   Bpm: 58586
+  Signature: 99999
 - StartTime: 218539
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218541
   Bpm: 21433
+  Signature: 99999
 - StartTime: 218542
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218544
   Bpm: 58550
+  Signature: 99999
 - StartTime: 218545
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218547
   Bpm: 21469
+  Signature: 99999
 - StartTime: 218548
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218550
   Bpm: 58514
+  Signature: 99999
 - StartTime: 218551
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218553
   Bpm: 21505
+  Signature: 99999
 - StartTime: 218554
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218556
   Bpm: 58478.0039
+  Signature: 99999
 - StartTime: 218557
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218559
   Bpm: 21541
+  Signature: 99999
 - StartTime: 218560
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218562
   Bpm: 58442
+  Signature: 99999
 - StartTime: 218563
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218565
   Bpm: 21577
+  Signature: 99999
 - StartTime: 218566
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218568
   Bpm: 58405.9961
+  Signature: 99999
 - StartTime: 218569
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218571
   Bpm: 21613
+  Signature: 99999
 - StartTime: 218572
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218574
   Bpm: 58370.0039
+  Signature: 99999
 - StartTime: 218575
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218577
   Bpm: 21649
+  Signature: 99999
 - StartTime: 218578
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218580
   Bpm: 58334
+  Signature: 99999
 - StartTime: 218581
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218583
   Bpm: 21685
+  Signature: 99999
 - StartTime: 218584
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218586
   Bpm: 58298
+  Signature: 99999
 - StartTime: 218587
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218589
   Bpm: 21721
+  Signature: 99999
 - StartTime: 218590
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218592
   Bpm: 58261.9961
+  Signature: 99999
 - StartTime: 218593
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218595
   Bpm: 21757
+  Signature: 99999
 - StartTime: 218596
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218598
   Bpm: 58226
+  Signature: 99999
 - StartTime: 218599
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218601
   Bpm: 21793
+  Signature: 99999
 - StartTime: 218602
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218604
   Bpm: 58189.9961
+  Signature: 99999
 - StartTime: 218605
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218607
   Bpm: 21829
+  Signature: 99999
 - StartTime: 218608
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218610
   Bpm: 58154
+  Signature: 99999
 - StartTime: 218611
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218613
   Bpm: 21865
+  Signature: 99999
 - StartTime: 218614
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218616
   Bpm: 58118
+  Signature: 99999
 - StartTime: 218617
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218619
   Bpm: 21901
+  Signature: 99999
 - StartTime: 218620
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218622
   Bpm: 58082
+  Signature: 99999
 - StartTime: 218623
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218625
   Bpm: 21937
+  Signature: 99999
 - StartTime: 218626
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218628
   Bpm: 58046.0039
+  Signature: 99999
 - StartTime: 218629
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218631
   Bpm: 21973
+  Signature: 99999
 - StartTime: 218632
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218634
   Bpm: 58010.0039
+  Signature: 99999
 - StartTime: 218635
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218637
   Bpm: 22009
+  Signature: 99999
 - StartTime: 218638
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218640
   Bpm: 57974
+  Signature: 99999
 - StartTime: 218641
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218643
   Bpm: 22045
+  Signature: 99999
 - StartTime: 218644
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218646
   Bpm: 57937.9961
+  Signature: 99999
 - StartTime: 218647
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218649
   Bpm: 22081
+  Signature: 99999
 - StartTime: 218650
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218652
   Bpm: 57902
+  Signature: 99999
 - StartTime: 218653
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218655
   Bpm: 22117
+  Signature: 99999
 - StartTime: 218656
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218658
   Bpm: 57865.9961
+  Signature: 99999
 - StartTime: 218659
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218661
   Bpm: 22153
+  Signature: 99999
 - StartTime: 218662
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218664
   Bpm: 57830
+  Signature: 99999
 - StartTime: 218665
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218667
   Bpm: 22189
+  Signature: 99999
 - StartTime: 218668
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218670
   Bpm: 57793.9961
+  Signature: 99999
 - StartTime: 218671
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218673
   Bpm: 22225
+  Signature: 99999
 - StartTime: 218674
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218676
   Bpm: 57758
+  Signature: 99999
 - StartTime: 218677
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218679
   Bpm: 22261
+  Signature: 99999
 - StartTime: 218680
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218682
   Bpm: 57721.9961
+  Signature: 99999
 - StartTime: 218683
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218685
   Bpm: 22297
+  Signature: 99999
 - StartTime: 218686
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218688
   Bpm: 57686
+  Signature: 99999
 - StartTime: 218689
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218691
   Bpm: 22333
+  Signature: 99999
 - StartTime: 218692
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218694
   Bpm: 57650
+  Signature: 99999
 - StartTime: 218695
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218697
   Bpm: 22369
+  Signature: 99999
 - StartTime: 218698
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218700
   Bpm: 57614
+  Signature: 99999
 - StartTime: 218701
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218703
   Bpm: 22405
+  Signature: 99999
 - StartTime: 218704
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218706
   Bpm: 57578
+  Signature: 99999
 - StartTime: 218707
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218709
   Bpm: 22441
+  Signature: 99999
 - StartTime: 218710
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218712
   Bpm: 57542
+  Signature: 99999
 - StartTime: 218713
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218715
   Bpm: 22477
+  Signature: 99999
 - StartTime: 218716
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218718
   Bpm: 57506
+  Signature: 99999
 - StartTime: 218719
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218721
   Bpm: 22513
+  Signature: 99999
 - StartTime: 218722
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218724
   Bpm: 57470.0039
+  Signature: 99999
 - StartTime: 218725
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218727
   Bpm: 22549
+  Signature: 99999
 - StartTime: 218728
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218730
   Bpm: 57434
+  Signature: 99999
 - StartTime: 218731
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218733
   Bpm: 22585
+  Signature: 99999
 - StartTime: 218734
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218736
   Bpm: 57398.0039
+  Signature: 99999
 - StartTime: 218737
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218739
   Bpm: 22621
+  Signature: 99999
 - StartTime: 218740
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218742
   Bpm: 57361.9961
+  Signature: 99999
 - StartTime: 218743
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218745
   Bpm: 22657
+  Signature: 99999
 - StartTime: 218746
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218748
   Bpm: 57326
+  Signature: 99999
 - StartTime: 218749
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218751
   Bpm: 22693
+  Signature: 99999
 - StartTime: 218752
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218754
   Bpm: 57290
+  Signature: 99999
 - StartTime: 218755
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218757
   Bpm: 22729
+  Signature: 99999
 - StartTime: 218758
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218760
   Bpm: 57254
+  Signature: 99999
 - StartTime: 218761
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218763
   Bpm: 22765
+  Signature: 99999
 - StartTime: 218764
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218766
   Bpm: 57218
+  Signature: 99999
 - StartTime: 218767
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218769
   Bpm: 22801
+  Signature: 99999
 - StartTime: 218770
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218772
   Bpm: 57182
+  Signature: 99999
 - StartTime: 218773
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218775
   Bpm: 22837
+  Signature: 99999
 - StartTime: 218776
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218778
   Bpm: 57146
+  Signature: 99999
 - StartTime: 218779
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218781
   Bpm: 22873
+  Signature: 99999
 - StartTime: 218782
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218784
   Bpm: 57110
+  Signature: 99999
 - StartTime: 218785
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218787
   Bpm: 22909.002
+  Signature: 99999
 - StartTime: 218788
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218790
   Bpm: 57074
+  Signature: 99999
 - StartTime: 218791
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218793
   Bpm: 22945
+  Signature: 99999
 - StartTime: 218794
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218796
   Bpm: 57038
+  Signature: 99999
 - StartTime: 218797
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218799
   Bpm: 22981
+  Signature: 99999
 - StartTime: 218800
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218802
   Bpm: 57002
+  Signature: 99999
 - StartTime: 218803
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218805
   Bpm: 23017
+  Signature: 99999
 - StartTime: 218806
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218808
   Bpm: 56966
+  Signature: 99999
 - StartTime: 218809
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218811
   Bpm: 23053
+  Signature: 99999
 - StartTime: 218812
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218814
   Bpm: 56930
+  Signature: 99999
 - StartTime: 218815
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218817
   Bpm: 23089
+  Signature: 99999
 - StartTime: 218818
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218820
   Bpm: 56894
+  Signature: 99999
 - StartTime: 218821
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218823
   Bpm: 23125.002
+  Signature: 99999
 - StartTime: 218824
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218826
   Bpm: 56858.0039
+  Signature: 99999
 - StartTime: 218827
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218829
   Bpm: 23161
+  Signature: 99999
 - StartTime: 218830
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218832
   Bpm: 56822
+  Signature: 99999
 - StartTime: 218833
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218835
   Bpm: 23197
+  Signature: 99999
 - StartTime: 218836
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218838
   Bpm: 56786
+  Signature: 99999
 - StartTime: 218839
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218841
   Bpm: 23233
+  Signature: 99999
 - StartTime: 218842
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218844
   Bpm: 56750
+  Signature: 99999
 - StartTime: 218845
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218847
   Bpm: 23269
+  Signature: 99999
 - StartTime: 218848
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218850
   Bpm: 56713.9961
+  Signature: 99999
 - StartTime: 218851
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218853
   Bpm: 23305
+  Signature: 99999
 - StartTime: 218854
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218856
   Bpm: 56678.0039
+  Signature: 99999
 - StartTime: 218857
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218859
   Bpm: 23340.998
+  Signature: 99999
 - StartTime: 218860
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218862
   Bpm: 56641.9961
+  Signature: 99999
 - StartTime: 218863
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218865
   Bpm: 23377
+  Signature: 99999
 - StartTime: 218866
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218868
   Bpm: 56606
+  Signature: 99999
 - StartTime: 218869
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218871
   Bpm: 23413
+  Signature: 99999
 - StartTime: 218872
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218874
   Bpm: 56570
+  Signature: 99999
 - StartTime: 218875
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218877
   Bpm: 23449
+  Signature: 99999
 - StartTime: 218878
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218880
   Bpm: 56534
+  Signature: 99999
 - StartTime: 218881
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218883
   Bpm: 23485
+  Signature: 99999
 - StartTime: 218884
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218886
   Bpm: 56497.9961
+  Signature: 99999
 - StartTime: 218887
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218889
   Bpm: 23521
+  Signature: 99999
 - StartTime: 218890
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218892
   Bpm: 56462
+  Signature: 99999
 - StartTime: 218893
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218895
   Bpm: 23557
+  Signature: 99999
 - StartTime: 218896
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218898
   Bpm: 56426
+  Signature: 99999
 - StartTime: 218899
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218901
   Bpm: 23593
+  Signature: 99999
 - StartTime: 218902
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218904
   Bpm: 56389.9961
+  Signature: 99999
 - StartTime: 218905
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218907
   Bpm: 23629
+  Signature: 99999
 - StartTime: 218908
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218910
   Bpm: 56354.0039
+  Signature: 99999
 - StartTime: 218911
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218913
   Bpm: 23665
+  Signature: 99999
 - StartTime: 218914
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218916
   Bpm: 56317.9961
+  Signature: 99999
 - StartTime: 218917
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218919
   Bpm: 23701
+  Signature: 99999
 - StartTime: 218920
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218922
   Bpm: 56282
+  Signature: 99999
 - StartTime: 218923
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218925
   Bpm: 23737
+  Signature: 99999
 - StartTime: 218926
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218928
   Bpm: 56246
+  Signature: 99999
 - StartTime: 218929
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218931
   Bpm: 23773
+  Signature: 99999
 - StartTime: 218932
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218934
   Bpm: 56210
+  Signature: 99999
 - StartTime: 218935
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218937
   Bpm: 23809
+  Signature: 99999
 - StartTime: 218938
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218940
   Bpm: 56174.0039
+  Signature: 99999
 - StartTime: 218941
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218943
   Bpm: 23845
+  Signature: 99999
 - StartTime: 218944
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218946
   Bpm: 56138
+  Signature: 99999
 - StartTime: 218947
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218949
   Bpm: 23881
+  Signature: 99999
 - StartTime: 218950
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218952
   Bpm: 56102.0039
+  Signature: 99999
 - StartTime: 218953
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218955
   Bpm: 23917
+  Signature: 99999
 - StartTime: 218956
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218958
   Bpm: 56066
+  Signature: 99999
 - StartTime: 218959
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218961
   Bpm: 23953
+  Signature: 99999
 - StartTime: 218962
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218964
   Bpm: 56030
+  Signature: 99999
 - StartTime: 218965
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218967
   Bpm: 23989
+  Signature: 99999
 - StartTime: 218968
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218970
   Bpm: 55994.0039
+  Signature: 99999
 - StartTime: 218971
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218973
   Bpm: 24025
+  Signature: 99999
 - StartTime: 218974
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218976
   Bpm: 55958
+  Signature: 99999
 - StartTime: 218977
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218979
   Bpm: 24061
+  Signature: 99999
 - StartTime: 218980
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218982
   Bpm: 55922.0039
+  Signature: 99999
 - StartTime: 218983
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218985
   Bpm: 24097
+  Signature: 99999
 - StartTime: 218986
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218988
   Bpm: 55886
+  Signature: 99999
 - StartTime: 218989
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218991
   Bpm: 24133
+  Signature: 99999
 - StartTime: 218992
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 218994
   Bpm: 55850.0039
+  Signature: 99999
 - StartTime: 218995
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 218997
   Bpm: 24169
+  Signature: 99999
 - StartTime: 218998
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219000
   Bpm: 55814
+  Signature: 99999
 - StartTime: 219001
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219003
   Bpm: 24205
+  Signature: 99999
 - StartTime: 219004
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219006
   Bpm: 55778
+  Signature: 99999
 - StartTime: 219007
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219009
   Bpm: 24241
+  Signature: 99999
 - StartTime: 219010
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219012
   Bpm: 55742
+  Signature: 99999
 - StartTime: 219013
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219015
   Bpm: 24277
+  Signature: 99999
 - StartTime: 219016
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219018
   Bpm: 55706
+  Signature: 99999
 - StartTime: 219019
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219021
   Bpm: 24313
+  Signature: 99999
 - StartTime: 219022
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219024
   Bpm: 55670
+  Signature: 99999
 - StartTime: 219025
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219027
   Bpm: 24349
+  Signature: 99999
 - StartTime: 219028
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219030
   Bpm: 55634.0039
+  Signature: 99999
 - StartTime: 219031
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219033
   Bpm: 24385
+  Signature: 99999
 - StartTime: 219034
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219036
   Bpm: 55598
+  Signature: 99999
 - StartTime: 219037
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219039
   Bpm: 24421
+  Signature: 99999
 - StartTime: 219040
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219042
   Bpm: 55562
+  Signature: 99999
 - StartTime: 219043
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219045
   Bpm: 24457
+  Signature: 99999
 - StartTime: 219046
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219048
   Bpm: 55526
+  Signature: 99999
 - StartTime: 219049
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219051
   Bpm: 24492.998
+  Signature: 99999
 - StartTime: 219052
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219054
   Bpm: 55490
+  Signature: 99999
 - StartTime: 219055
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219057
   Bpm: 24529
+  Signature: 99999
 - StartTime: 219058
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219060
   Bpm: 55454
+  Signature: 99999
 - StartTime: 219061
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219063
   Bpm: 24565
+  Signature: 99999
 - StartTime: 219064
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219066
   Bpm: 55418
+  Signature: 99999
 - StartTime: 219067
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219069
   Bpm: 24601
+  Signature: 99999
 - StartTime: 219070
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219072
   Bpm: 55382
+  Signature: 99999
 - StartTime: 219073
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219075
   Bpm: 24637
+  Signature: 99999
 - StartTime: 219076
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219078
   Bpm: 55346
+  Signature: 99999
 - StartTime: 219079
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219081
   Bpm: 24673
+  Signature: 99999
 - StartTime: 219082
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219084
   Bpm: 55310
+  Signature: 99999
 - StartTime: 219085
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219087
   Bpm: 24709
+  Signature: 99999
 - StartTime: 219088
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219090
   Bpm: 55274
+  Signature: 99999
 - StartTime: 219091
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219093
   Bpm: 24745
+  Signature: 99999
 - StartTime: 219094
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219096
   Bpm: 55237.9961
+  Signature: 99999
 - StartTime: 219097
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219099
   Bpm: 24781
+  Signature: 99999
 - StartTime: 219100
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219102
   Bpm: 55202
+  Signature: 99999
 - StartTime: 219103
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219105
   Bpm: 24817.002
+  Signature: 99999
 - StartTime: 219106
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219108
   Bpm: 55166
+  Signature: 99999
 - StartTime: 219109
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219111
   Bpm: 24853
+  Signature: 99999
 - StartTime: 219112
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219114
   Bpm: 55129.9961
+  Signature: 99999
 - StartTime: 219115
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219117
   Bpm: 24889.002
+  Signature: 99999
 - StartTime: 219118
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219120
   Bpm: 55094
+  Signature: 99999
 - StartTime: 219121
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219123
   Bpm: 24925.002
+  Signature: 99999
 - StartTime: 219124
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219126
   Bpm: 55057.9961
+  Signature: 99999
 - StartTime: 219127
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219129
   Bpm: 24961
+  Signature: 99999
 - StartTime: 219130
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219132
   Bpm: 55022
+  Signature: 99999
 - StartTime: 219133
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219135
   Bpm: 24997
+  Signature: 99999
 - StartTime: 219136
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219138
   Bpm: 54986
+  Signature: 99999
 - StartTime: 219139
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219141
   Bpm: 25032.998
+  Signature: 99999
 - StartTime: 219142
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219144
   Bpm: 54949.9961
+  Signature: 99999
 - StartTime: 219145
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219147
   Bpm: 25069
+  Signature: 99999
 - StartTime: 219148
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219150
   Bpm: 54914
+  Signature: 99999
 - StartTime: 219151
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219153
   Bpm: 25105
+  Signature: 99999
 - StartTime: 219154
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219156
   Bpm: 54878
+  Signature: 99999
 - StartTime: 219157
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219159
   Bpm: 25141
+  Signature: 99999
 - StartTime: 219160
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219162
   Bpm: 54842.0039
+  Signature: 99999
 - StartTime: 219163
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219165
   Bpm: 25177
+  Signature: 99999
 - StartTime: 219166
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219168
   Bpm: 54806
+  Signature: 99999
 - StartTime: 219169
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219171
   Bpm: 25213
+  Signature: 99999
 - StartTime: 219172
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219174
   Bpm: 54770
+  Signature: 99999
 - StartTime: 219175
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219177
   Bpm: 25249
+  Signature: 99999
 - StartTime: 219178
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219180
   Bpm: 54734.0039
+  Signature: 99999
 - StartTime: 219181
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219183
   Bpm: 25285
+  Signature: 99999
 - StartTime: 219184
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219186
   Bpm: 54697.9961
+  Signature: 99999
 - StartTime: 219187
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219189
   Bpm: 25321.002
+  Signature: 99999
 - StartTime: 219190
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219192
   Bpm: 54662
+  Signature: 99999
 - StartTime: 219193
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219195
   Bpm: 25357
+  Signature: 99999
 - StartTime: 219196
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219198
   Bpm: 54626
+  Signature: 99999
 - StartTime: 219199
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219201
   Bpm: 25393
+  Signature: 99999
 - StartTime: 219202
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219204
   Bpm: 54590
+  Signature: 99999
 - StartTime: 219205
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219207
   Bpm: 25428.998
+  Signature: 99999
 - StartTime: 219208
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219210
   Bpm: 54554.0039
+  Signature: 99999
 - StartTime: 219211
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219213
   Bpm: 25465
+  Signature: 99999
 - StartTime: 219214
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219216
   Bpm: 54517.9961
+  Signature: 99999
 - StartTime: 219217
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219219
   Bpm: 25500.998
+  Signature: 99999
 - StartTime: 219220
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219222
   Bpm: 54482
+  Signature: 99999
 - StartTime: 219223
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219225
   Bpm: 25537
+  Signature: 99999
 - StartTime: 219226
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219228
   Bpm: 54446
+  Signature: 99999
 - StartTime: 219229
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219231
   Bpm: 25573
+  Signature: 99999
 - StartTime: 219232
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219234
   Bpm: 54410
+  Signature: 99999
 - StartTime: 219235
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219237
   Bpm: 25609
+  Signature: 99999
 - StartTime: 219238
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219240
   Bpm: 54374
+  Signature: 99999
 - StartTime: 219241
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219243
   Bpm: 25645
+  Signature: 99999
 - StartTime: 219244
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219246
   Bpm: 54338
+  Signature: 99999
 - StartTime: 219247
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219249
   Bpm: 25681
+  Signature: 99999
 - StartTime: 219250
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219252
   Bpm: 54302
+  Signature: 99999
 - StartTime: 219253
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219255
   Bpm: 25717.002
+  Signature: 99999
 - StartTime: 219256
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219258
   Bpm: 54265.9961
+  Signature: 99999
 - StartTime: 219259
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219261
   Bpm: 25753
+  Signature: 99999
 - StartTime: 219262
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219264
   Bpm: 54230
+  Signature: 99999
 - StartTime: 219265
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219267
   Bpm: 25789
+  Signature: 99999
 - StartTime: 219268
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219270
   Bpm: 54194
+  Signature: 99999
 - StartTime: 219271
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219273
   Bpm: 25825
+  Signature: 99999
 - StartTime: 219274
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219276
   Bpm: 54157.9961
+  Signature: 99999
 - StartTime: 219277
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219279
   Bpm: 25860.998
+  Signature: 99999
 - StartTime: 219280
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219282
   Bpm: 54122
+  Signature: 99999
 - StartTime: 219283
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219285
   Bpm: 25897
+  Signature: 99999
 - StartTime: 219286
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219288
   Bpm: 54086
+  Signature: 99999
 - StartTime: 219289
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219291
   Bpm: 25933
+  Signature: 99999
 - StartTime: 219292
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219294
   Bpm: 54050
+  Signature: 99999
 - StartTime: 219295
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219297
   Bpm: 25969.002
+  Signature: 99999
 - StartTime: 219298
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219300
   Bpm: 54014
+  Signature: 99999
 - StartTime: 219301
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219303
   Bpm: 26005
+  Signature: 99999
 - StartTime: 219304
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219306
   Bpm: 53978.0039
+  Signature: 99999
 - StartTime: 219307
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219309
   Bpm: 26041
+  Signature: 99999
 - StartTime: 219310
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219312
   Bpm: 53942.0039
+  Signature: 99999
 - StartTime: 219313
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219315
   Bpm: 26076.998
+  Signature: 99999
 - StartTime: 219316
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219318
   Bpm: 53906
+  Signature: 99999
 - StartTime: 219319
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219321
   Bpm: 26113
+  Signature: 99999
 - StartTime: 219322
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219324
   Bpm: 53870.0039
+  Signature: 99999
 - StartTime: 219325
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219327
   Bpm: 26149
+  Signature: 99999
 - StartTime: 219328
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219330
   Bpm: 53834.0039
+  Signature: 99999
 - StartTime: 219331
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219333
   Bpm: 26185
+  Signature: 99999
 - StartTime: 219334
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219336
   Bpm: 53798
+  Signature: 99999
 - StartTime: 219337
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219339
   Bpm: 26220.998
+  Signature: 99999
 - StartTime: 219340
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219342
   Bpm: 53762.0039
+  Signature: 99999
 - StartTime: 219343
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219345
   Bpm: 26257
+  Signature: 99999
 - StartTime: 219346
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219348
   Bpm: 53725.9961
+  Signature: 99999
 - StartTime: 219349
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219351
   Bpm: 26293
+  Signature: 99999
 - StartTime: 219352
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219354
   Bpm: 53690
+  Signature: 99999
 - StartTime: 219355
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219357
   Bpm: 26329
+  Signature: 99999
 - StartTime: 219358
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219360
   Bpm: 53654
+  Signature: 99999
 - StartTime: 219361
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219363
   Bpm: 26365
+  Signature: 99999
 - StartTime: 219364
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219366
   Bpm: 53618.0039
+  Signature: 99999
 - StartTime: 219367
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219369
   Bpm: 26401
+  Signature: 99999
 - StartTime: 219370
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219372
   Bpm: 53582
+  Signature: 99999
 - StartTime: 219373
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219375
   Bpm: 26437
+  Signature: 99999
 - StartTime: 219376
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219378
   Bpm: 53546
+  Signature: 99999
 - StartTime: 219379
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219381
   Bpm: 26473
+  Signature: 99999
 - StartTime: 219382
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219384
   Bpm: 53509.9961
+  Signature: 99999
 - StartTime: 219385
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219387
   Bpm: 26509
+  Signature: 99999
 - StartTime: 219388
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219390
   Bpm: 53474
+  Signature: 99999
 - StartTime: 219391
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219393
   Bpm: 26544.998
+  Signature: 99999
 - StartTime: 219394
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219396
   Bpm: 53438
+  Signature: 99999
 - StartTime: 219397
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219399
   Bpm: 26581
+  Signature: 99999
 - StartTime: 219400
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219402
   Bpm: 53402
+  Signature: 99999
 - StartTime: 219403
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219405
   Bpm: 26616.998
+  Signature: 99999
 - StartTime: 219406
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219408
   Bpm: 53366
+  Signature: 99999
 - StartTime: 219409
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219411
   Bpm: 26653
+  Signature: 99999
 - StartTime: 219412
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219414
   Bpm: 53330
+  Signature: 99999
 - StartTime: 219415
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219417
   Bpm: 26689
+  Signature: 99999
 - StartTime: 219418
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219420
   Bpm: 53294
+  Signature: 99999
 - StartTime: 219421
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219423
   Bpm: 26725
+  Signature: 99999
 - StartTime: 219424
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219426
   Bpm: 53258
+  Signature: 99999
 - StartTime: 219427
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219429
   Bpm: 26760.998
+  Signature: 99999
 - StartTime: 219430
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219432
   Bpm: 53222
+  Signature: 99999
 - StartTime: 219433
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219435
   Bpm: 26797
+  Signature: 99999
 - StartTime: 219436
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219438
   Bpm: 53186.0039
+  Signature: 99999
 - StartTime: 219439
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219441
   Bpm: 26833.002
+  Signature: 99999
 - StartTime: 219442
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219444
   Bpm: 53150
+  Signature: 99999
 - StartTime: 219445
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219447
   Bpm: 26868.998
+  Signature: 99999
 - StartTime: 219448
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219450
   Bpm: 53114
+  Signature: 99999
 - StartTime: 219451
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219453
   Bpm: 26905
+  Signature: 99999
 - StartTime: 219454
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219456
   Bpm: 53078
+  Signature: 99999
 - StartTime: 219457
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219459
   Bpm: 26940.998
+  Signature: 99999
 - StartTime: 219460
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219462
   Bpm: 53042
+  Signature: 99999
 - StartTime: 219463
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219465
   Bpm: 26977
+  Signature: 99999
 - StartTime: 219466
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219468
   Bpm: 53006.0039
+  Signature: 99999
 - StartTime: 219469
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219471
   Bpm: 27013
+  Signature: 99999
 - StartTime: 219472
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219474
   Bpm: 52970
+  Signature: 99999
 - StartTime: 219475
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219477
   Bpm: 27049
+  Signature: 99999
 - StartTime: 219478
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219480
   Bpm: 52934
+  Signature: 99999
 - StartTime: 219481
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219483
   Bpm: 27085
+  Signature: 99999
 - StartTime: 219484
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219486
   Bpm: 52898
+  Signature: 99999
 - StartTime: 219487
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219489
   Bpm: 27121.002
+  Signature: 99999
 - StartTime: 219490
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219492
   Bpm: 52862
+  Signature: 99999
 - StartTime: 219493
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219495
   Bpm: 27157
+  Signature: 99999
 - StartTime: 219496
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219498
   Bpm: 52826.0039
+  Signature: 99999
 - StartTime: 219499
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219501
   Bpm: 27193
+  Signature: 99999
 - StartTime: 219502
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219504
   Bpm: 52790
+  Signature: 99999
 - StartTime: 219505
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219507
   Bpm: 27229
+  Signature: 99999
 - StartTime: 219508
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219510
   Bpm: 52754
+  Signature: 99999
 - StartTime: 219511
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219513
   Bpm: 27265
+  Signature: 99999
 - StartTime: 219514
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219516
   Bpm: 52718.0039
+  Signature: 99999
 - StartTime: 219517
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219519
   Bpm: 27301
+  Signature: 99999
 - StartTime: 219520
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219522
   Bpm: 52681.9961
+  Signature: 99999
 - StartTime: 219523
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219525
   Bpm: 27337
+  Signature: 99999
 - StartTime: 219526
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219528
   Bpm: 52645.9961
+  Signature: 99999
 - StartTime: 219529
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219531
   Bpm: 27373
+  Signature: 99999
 - StartTime: 219532
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219534
   Bpm: 52609.9961
+  Signature: 99999
 - StartTime: 219535
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219537
   Bpm: 27409.002
+  Signature: 99999
 - StartTime: 219538
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219540
   Bpm: 52573.9961
+  Signature: 99999
 - StartTime: 219541
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219543
   Bpm: 27445
+  Signature: 99999
 - StartTime: 219544
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219546
   Bpm: 52538.0039
+  Signature: 99999
 - StartTime: 219547
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219549
   Bpm: 27481
+  Signature: 99999
 - StartTime: 219550
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219552
   Bpm: 52502.0039
+  Signature: 99999
 - StartTime: 219553
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219555
   Bpm: 27517
+  Signature: 99999
 - StartTime: 219556
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219558
   Bpm: 52466
+  Signature: 99999
 - StartTime: 219559
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219561
   Bpm: 27553
+  Signature: 99999
 - StartTime: 219562
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219564
   Bpm: 52430
+  Signature: 99999
 - StartTime: 219565
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219567
   Bpm: 27588.998
+  Signature: 99999
 - StartTime: 219568
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219570
   Bpm: 52394
+  Signature: 99999
 - StartTime: 219571
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219573
   Bpm: 27624.998
+  Signature: 99999
 - StartTime: 219574
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219576
   Bpm: 52358.0039
+  Signature: 99999
 - StartTime: 219577
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219579
   Bpm: 27661.002
+  Signature: 99999
 - StartTime: 219580
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219582
   Bpm: 52321.9961
+  Signature: 99999
 - StartTime: 219583
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219585
   Bpm: 27697
+  Signature: 99999
 - StartTime: 219586
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219588
   Bpm: 52286
+  Signature: 99999
 - StartTime: 219589
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219591
   Bpm: 27733.002
+  Signature: 99999
 - StartTime: 219592
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219594
   Bpm: 52250
+  Signature: 99999
 - StartTime: 219595
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219597
   Bpm: 27769.002
+  Signature: 99999
 - StartTime: 219598
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219600
   Bpm: 52214
+  Signature: 99999
 - StartTime: 219601
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219603
   Bpm: 27805
+  Signature: 99999
 - StartTime: 219604
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219606
   Bpm: 52177.9961
+  Signature: 99999
 - StartTime: 219607
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219609
   Bpm: 27840.998
+  Signature: 99999
 - StartTime: 219610
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219612
   Bpm: 52142.0039
+  Signature: 99999
 - StartTime: 219613
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219615
   Bpm: 27876.998
+  Signature: 99999
 - StartTime: 219616
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219618
   Bpm: 52105.9961
+  Signature: 99999
 - StartTime: 219619
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219621
   Bpm: 27913
+  Signature: 99999
 - StartTime: 219622
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219624
   Bpm: 52070
+  Signature: 99999
 - StartTime: 219625
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219627
   Bpm: 27949
+  Signature: 99999
 - StartTime: 219628
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219630
   Bpm: 52033.9961
+  Signature: 99999
 - StartTime: 219631
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219633
   Bpm: 27985
+  Signature: 99999
 - StartTime: 219634
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219636
   Bpm: 51998.0039
+  Signature: 99999
 - StartTime: 219637
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219639
   Bpm: 28021.002
+  Signature: 99999
 - StartTime: 219640
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219642
   Bpm: 51962.0039
+  Signature: 99999
 - StartTime: 219643
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219645
   Bpm: 28057
+  Signature: 99999
 - StartTime: 219646
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219648
   Bpm: 51926
+  Signature: 99999
 - StartTime: 219649
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219651
   Bpm: 28093
+  Signature: 99999
 - StartTime: 219652
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219654
   Bpm: 51889.9961
+  Signature: 99999
 - StartTime: 219655
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219657
   Bpm: 28129
+  Signature: 99999
 - StartTime: 219658
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219660
   Bpm: 51854
+  Signature: 99999
 - StartTime: 219661
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219663
   Bpm: 28165
+  Signature: 99999
 - StartTime: 219664
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219666
   Bpm: 51818
+  Signature: 99999
 - StartTime: 219667
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219669
   Bpm: 28200.998
+  Signature: 99999
 - StartTime: 219670
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219672
   Bpm: 51782
+  Signature: 99999
 - StartTime: 219673
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219675
   Bpm: 28236.998
+  Signature: 99999
 - StartTime: 219676
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219678
   Bpm: 51746
+  Signature: 99999
 - StartTime: 219679
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219681
   Bpm: 28273.002
+  Signature: 99999
 - StartTime: 219682
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219684
   Bpm: 51710
+  Signature: 99999
 - StartTime: 219685
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219687
   Bpm: 28309
+  Signature: 99999
 - StartTime: 219688
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219690
   Bpm: 51674
+  Signature: 99999
 - StartTime: 219691
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219693
   Bpm: 28345
+  Signature: 99999
 - StartTime: 219694
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219696
   Bpm: 51638
+  Signature: 99999
 - StartTime: 219697
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219699
   Bpm: 28381
+  Signature: 99999
 - StartTime: 219700
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219702
   Bpm: 51602
+  Signature: 99999
 - StartTime: 219703
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219705
   Bpm: 28416.998
+  Signature: 99999
 - StartTime: 219706
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219708
   Bpm: 51566
+  Signature: 99999
 - StartTime: 219709
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219711
   Bpm: 28452.998
+  Signature: 99999
 - StartTime: 219712
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219714
   Bpm: 51530
+  Signature: 99999
 - StartTime: 219715
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219717
   Bpm: 28489
+  Signature: 99999
 - StartTime: 219718
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219720
   Bpm: 51494
+  Signature: 99999
 - StartTime: 219721
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219723
   Bpm: 28525
+  Signature: 99999
 - StartTime: 219724
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219726
   Bpm: 51458
+  Signature: 99999
 - StartTime: 219727
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219729
   Bpm: 28560.998
+  Signature: 99999
 - StartTime: 219730
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219732
   Bpm: 51422
+  Signature: 99999
 - StartTime: 219733
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219735
   Bpm: 28597
+  Signature: 99999
 - StartTime: 219736
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219738
   Bpm: 51386
+  Signature: 99999
 - StartTime: 219739
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219741
   Bpm: 28633
+  Signature: 99999
 - StartTime: 219742
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219744
   Bpm: 51350
+  Signature: 99999
 - StartTime: 219745
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219747
   Bpm: 28669.002
+  Signature: 99999
 - StartTime: 219748
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219750
   Bpm: 51314
+  Signature: 99999
 - StartTime: 219751
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219753
   Bpm: 28705.002
+  Signature: 99999
 - StartTime: 219754
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219756
   Bpm: 51278
+  Signature: 99999
 - StartTime: 219757
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219759
   Bpm: 28741
+  Signature: 99999
 - StartTime: 219760
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219762
   Bpm: 51241.9961
+  Signature: 99999
 - StartTime: 219763
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219765
   Bpm: 28777
+  Signature: 99999
 - StartTime: 219766
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219768
   Bpm: 51206
+  Signature: 99999
 - StartTime: 219769
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219771
   Bpm: 28813
+  Signature: 99999
 - StartTime: 219772
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219774
   Bpm: 51170.0039
+  Signature: 99999
 - StartTime: 219775
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219777
   Bpm: 28848.998
+  Signature: 99999
 - StartTime: 219778
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219780
   Bpm: 51134
+  Signature: 99999
 - StartTime: 219781
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219783
   Bpm: 28884.998
+  Signature: 99999
 - StartTime: 219784
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219786
   Bpm: 51098
+  Signature: 99999
 - StartTime: 219787
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219789
   Bpm: 28920.998
+  Signature: 99999
 - StartTime: 219790
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219792
   Bpm: 51061.9961
+  Signature: 99999
 - StartTime: 219793
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219795
   Bpm: 28956.998
+  Signature: 99999
 - StartTime: 219796
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219798
   Bpm: 51026
+  Signature: 99999
 - StartTime: 219799
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219801
   Bpm: 28992.998
+  Signature: 99999
 - StartTime: 219802
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219804
   Bpm: 50990
+  Signature: 99999
 - StartTime: 219805
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219807
   Bpm: 29029
+  Signature: 99999
 - StartTime: 219808
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219810
   Bpm: 50954
+  Signature: 99999
 - StartTime: 219811
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219813
   Bpm: 29065.002
+  Signature: 99999
 - StartTime: 219814
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219816
   Bpm: 50918
+  Signature: 99999
 - StartTime: 219817
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219819
   Bpm: 29101.002
+  Signature: 99999
 - StartTime: 219820
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219822
   Bpm: 50881.9961
+  Signature: 99999
 - StartTime: 219823
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219825
   Bpm: 29136.998
+  Signature: 99999
 - StartTime: 219826
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219828
   Bpm: 50846
+  Signature: 99999
 - StartTime: 219829
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219831
   Bpm: 29173.002
+  Signature: 99999
 - StartTime: 219832
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219834
   Bpm: 50810
+  Signature: 99999
 - StartTime: 219835
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219837
   Bpm: 29209.002
+  Signature: 99999
 - StartTime: 219838
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219840
   Bpm: 50774
+  Signature: 99999
 - StartTime: 219841
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219843
   Bpm: 29245.002
+  Signature: 99999
 - StartTime: 219844
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219846
   Bpm: 50738
+  Signature: 99999
 - StartTime: 219847
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219849
   Bpm: 29281
+  Signature: 99999
 - StartTime: 219850
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219852
   Bpm: 50702
+  Signature: 99999
 - StartTime: 219853
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219855
   Bpm: 29317
+  Signature: 99999
 - StartTime: 219856
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219858
   Bpm: 50665.9961
+  Signature: 99999
 - StartTime: 219859
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219861
   Bpm: 29353
+  Signature: 99999
 - StartTime: 219862
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219864
   Bpm: 50630
+  Signature: 99999
 - StartTime: 219865
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219867
   Bpm: 29389
+  Signature: 99999
 - StartTime: 219868
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219870
   Bpm: 50594
+  Signature: 99999
 - StartTime: 219871
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219873
   Bpm: 29424.998
+  Signature: 99999
 - StartTime: 219874
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219876
   Bpm: 50558
+  Signature: 99999
 - StartTime: 219877
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219879
   Bpm: 29461
+  Signature: 99999
 - StartTime: 219880
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219882
   Bpm: 50522
+  Signature: 99999
 - StartTime: 219883
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219885
   Bpm: 29497.002
+  Signature: 99999
 - StartTime: 219886
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219888
   Bpm: 50486
+  Signature: 99999
 - StartTime: 219889
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219891
   Bpm: 29532.998
+  Signature: 99999
 - StartTime: 219892
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219894
   Bpm: 50450
+  Signature: 99999
 - StartTime: 219895
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219897
   Bpm: 29569
+  Signature: 99999
 - StartTime: 219898
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219900
   Bpm: 50414
+  Signature: 99999
 - StartTime: 219901
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219903
   Bpm: 29604.998
+  Signature: 99999
 - StartTime: 219904
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219906
   Bpm: 50378
+  Signature: 99999
 - StartTime: 219907
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219909
   Bpm: 29641.002
+  Signature: 99999
 - StartTime: 219910
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219912
   Bpm: 50342
+  Signature: 99999
 - StartTime: 219913
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219915
   Bpm: 29677.002
+  Signature: 99999
 - StartTime: 219916
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219918
   Bpm: 50306.0039
+  Signature: 99999
 - StartTime: 219919
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219921
   Bpm: 29713
+  Signature: 99999
 - StartTime: 219922
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219924
   Bpm: 50270
+  Signature: 99999
 - StartTime: 219925
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219927
   Bpm: 29749
+  Signature: 99999
 - StartTime: 219928
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219930
   Bpm: 50234
+  Signature: 99999
 - StartTime: 219931
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219933
   Bpm: 29785.002
+  Signature: 99999
 - StartTime: 219934
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219936
   Bpm: 50198
+  Signature: 99999
 - StartTime: 219937
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219939
   Bpm: 29821.002
+  Signature: 99999
 - StartTime: 219940
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219942
   Bpm: 50162
+  Signature: 99999
 - StartTime: 219943
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219945
   Bpm: 29857
+  Signature: 99999
 - StartTime: 219946
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219948
   Bpm: 50126
+  Signature: 99999
 - StartTime: 219949
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219951
   Bpm: 29893.002
+  Signature: 99999
 - StartTime: 219952
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219954
   Bpm: 50090
+  Signature: 99999
 - StartTime: 219955
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219957
   Bpm: 29929
+  Signature: 99999
 - StartTime: 219958
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219960
   Bpm: 50054
+  Signature: 99999
 - StartTime: 219961
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219963
   Bpm: 29965
+  Signature: 99999
 - StartTime: 219964
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219966
   Bpm: 50018
+  Signature: 99999
 - StartTime: 219967
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219969
   Bpm: 30001
+  Signature: 99999
 - StartTime: 219970
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219972
   Bpm: 49982
+  Signature: 99999
 - StartTime: 219973
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219975
   Bpm: 30037
+  Signature: 99999
 - StartTime: 219976
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219978
   Bpm: 49946
+  Signature: 99999
 - StartTime: 219979
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219981
   Bpm: 30073
+  Signature: 99999
 - StartTime: 219982
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219984
   Bpm: 49910
+  Signature: 99999
 - StartTime: 219985
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219987
   Bpm: 30109
+  Signature: 99999
 - StartTime: 219988
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219990
   Bpm: 49874
+  Signature: 99999
 - StartTime: 219991
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219993
   Bpm: 30145
+  Signature: 99999
 - StartTime: 219994
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 219996
   Bpm: 49837.9961
+  Signature: 99999
 - StartTime: 219997
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 219999
   Bpm: 30181
+  Signature: 99999
 - StartTime: 220000
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220002
   Bpm: 49802
+  Signature: 99999
 - StartTime: 220003
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220005
   Bpm: 30217
+  Signature: 99999
 - StartTime: 220006
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220008
   Bpm: 49765.9961
+  Signature: 99999
 - StartTime: 220009
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220011
   Bpm: 30253
+  Signature: 99999
 - StartTime: 220012
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220014
   Bpm: 49730
+  Signature: 99999
 - StartTime: 220015
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220017
   Bpm: 30289
+  Signature: 99999
 - StartTime: 220018
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220020
   Bpm: 49694
+  Signature: 99999
 - StartTime: 220021
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220023
   Bpm: 30325
+  Signature: 99999
 - StartTime: 220024
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220026
   Bpm: 49658.0039
+  Signature: 99999
 - StartTime: 220027
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220029
   Bpm: 30361
+  Signature: 99999
 - StartTime: 220030
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220032
   Bpm: 49622
+  Signature: 99999
 - StartTime: 220033
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220035
   Bpm: 30397
+  Signature: 99999
 - StartTime: 220036
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220038
   Bpm: 49586
+  Signature: 99999
 - StartTime: 220039
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220041
   Bpm: 30433
+  Signature: 99999
 - StartTime: 220042
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220044
   Bpm: 49550
+  Signature: 99999
 - StartTime: 220045
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220047
   Bpm: 30469
+  Signature: 99999
 - StartTime: 220048
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220050
   Bpm: 49514
+  Signature: 99999
 - StartTime: 220051
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220053
   Bpm: 30505
+  Signature: 99999
 - StartTime: 220054
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220056
   Bpm: 49478
+  Signature: 99999
 - StartTime: 220057
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220059
   Bpm: 30541
+  Signature: 99999
 - StartTime: 220060
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220062
   Bpm: 49442
+  Signature: 99999
 - StartTime: 220063
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220065
   Bpm: 30577
+  Signature: 99999
 - StartTime: 220066
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220068
   Bpm: 49406
+  Signature: 99999
 - StartTime: 220069
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220071
   Bpm: 30613
+  Signature: 99999
 - StartTime: 220072
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220074
   Bpm: 49370
+  Signature: 99999
 - StartTime: 220075
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220077
   Bpm: 30649
+  Signature: 99999
 - StartTime: 220078
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220080
   Bpm: 49334
+  Signature: 99999
 - StartTime: 220081
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220083
   Bpm: 30685
+  Signature: 99999
 - StartTime: 220084
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220086
   Bpm: 49298.0039
+  Signature: 99999
 - StartTime: 220087
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220089
   Bpm: 30721
+  Signature: 99999
 - StartTime: 220090
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220092
   Bpm: 49261.9961
+  Signature: 99999
 - StartTime: 220093
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220095
   Bpm: 30757
+  Signature: 99999
 - StartTime: 220096
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220098
   Bpm: 49225.9961
+  Signature: 99999
 - StartTime: 220099
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220101
   Bpm: 30793
+  Signature: 99999
 - StartTime: 220102
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220104
   Bpm: 49190.0039
+  Signature: 99999
 - StartTime: 220105
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220107
   Bpm: 30829
+  Signature: 99999
 - StartTime: 220108
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220110
   Bpm: 49154
+  Signature: 99999
 - StartTime: 220111
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220113
   Bpm: 30865
+  Signature: 99999
 - StartTime: 220114
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220116
   Bpm: 49118
+  Signature: 99999
 - StartTime: 220117
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220119
   Bpm: 30901
+  Signature: 99999
 - StartTime: 220120
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220122
   Bpm: 49082
+  Signature: 99999
 - StartTime: 220123
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220125
   Bpm: 30937
+  Signature: 99999
 - StartTime: 220126
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220128
   Bpm: 49046
+  Signature: 99999
 - StartTime: 220129
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220131
   Bpm: 30973
+  Signature: 99999
 - StartTime: 220132
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220134
   Bpm: 49010
+  Signature: 99999
 - StartTime: 220135
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220137
   Bpm: 31009
+  Signature: 99999
 - StartTime: 220138
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220140
   Bpm: 48974
+  Signature: 99999
 - StartTime: 220141
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220143
   Bpm: 31045
+  Signature: 99999
 - StartTime: 220144
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220146
   Bpm: 48938
+  Signature: 99999
 - StartTime: 220147
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220149
   Bpm: 31081
+  Signature: 99999
 - StartTime: 220150
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220152
   Bpm: 48902
+  Signature: 99999
 - StartTime: 220153
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220155
   Bpm: 31117
+  Signature: 99999
 - StartTime: 220156
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220158
   Bpm: 48866
+  Signature: 99999
 - StartTime: 220159
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220161
   Bpm: 31153
+  Signature: 99999
 - StartTime: 220162
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220164
   Bpm: 48830
+  Signature: 99999
 - StartTime: 220165
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220167
   Bpm: 31189
+  Signature: 99999
 - StartTime: 220168
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220170
   Bpm: 48793.9961
+  Signature: 99999
 - StartTime: 220171
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220173
   Bpm: 31225
+  Signature: 99999
 - StartTime: 220174
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220176
   Bpm: 48758
+  Signature: 99999
 - StartTime: 220177
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220179
   Bpm: 31261
+  Signature: 99999
 - StartTime: 220180
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220182
   Bpm: 48722
+  Signature: 99999
 - StartTime: 220183
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220185
   Bpm: 31297
+  Signature: 99999
 - StartTime: 220186
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220188
   Bpm: 48685.9961
+  Signature: 99999
 - StartTime: 220189
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220191
   Bpm: 31333
+  Signature: 99999
 - StartTime: 220192
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220194
   Bpm: 48650.0039
+  Signature: 99999
 - StartTime: 220195
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220197
   Bpm: 31369
+  Signature: 99999
 - StartTime: 220198
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220200
   Bpm: 48614
+  Signature: 99999
 - StartTime: 220201
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220203
   Bpm: 31405
+  Signature: 99999
 - StartTime: 220204
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220206
   Bpm: 48578
+  Signature: 99999
 - StartTime: 220207
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220209
   Bpm: 31441
+  Signature: 99999
 - StartTime: 220210
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220212
   Bpm: 48542
+  Signature: 99999
 - StartTime: 220213
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220215
   Bpm: 31477
+  Signature: 99999
 - StartTime: 220216
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220218
   Bpm: 48506
+  Signature: 99999
 - StartTime: 220219
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220221
   Bpm: 31513
+  Signature: 99999
 - StartTime: 220222
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220224
   Bpm: 48469.9961
+  Signature: 99999
 - StartTime: 220225
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220227
   Bpm: 31549
+  Signature: 99999
 - StartTime: 220228
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220230
   Bpm: 48434
+  Signature: 99999
 - StartTime: 220231
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220233
   Bpm: 31585
+  Signature: 99999
 - StartTime: 220234
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220236
   Bpm: 48397.9961
+  Signature: 99999
 - StartTime: 220237
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220239
   Bpm: 31621
+  Signature: 99999
 - StartTime: 220240
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220242
   Bpm: 48362
+  Signature: 99999
 - StartTime: 220243
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220245
   Bpm: 31657
+  Signature: 99999
 - StartTime: 220246
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220248
   Bpm: 48326
+  Signature: 99999
 - StartTime: 220249
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220251
   Bpm: 31693
+  Signature: 99999
 - StartTime: 220252
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220254
   Bpm: 48290
+  Signature: 99999
 - StartTime: 220255
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220257
   Bpm: 31729
+  Signature: 99999
 - StartTime: 220258
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220260
   Bpm: 48254
+  Signature: 99999
 - StartTime: 220261
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220263
   Bpm: 31765
+  Signature: 99999
 - StartTime: 220264
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220266
   Bpm: 48218.0039
+  Signature: 99999
 - StartTime: 220267
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220269
   Bpm: 31801
+  Signature: 99999
 - StartTime: 220270
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220272
   Bpm: 48182
+  Signature: 99999
 - StartTime: 220273
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220275
   Bpm: 31837
+  Signature: 99999
 - StartTime: 220276
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220278
   Bpm: 48145.9961
+  Signature: 99999
 - StartTime: 220279
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220281
   Bpm: 31873
+  Signature: 99999
 - StartTime: 220282
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220284
   Bpm: 48110
+  Signature: 99999
 - StartTime: 220285
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220287
   Bpm: 31909
+  Signature: 99999
 - StartTime: 220288
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220290
   Bpm: 48074
+  Signature: 99999
 - StartTime: 220291
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220293
   Bpm: 31945
+  Signature: 99999
 - StartTime: 220294
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220296
   Bpm: 48038
+  Signature: 99999
 - StartTime: 220297
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220299
   Bpm: 31981
+  Signature: 99999
 - StartTime: 220300
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220302
   Bpm: 48002
+  Signature: 99999
 - StartTime: 220303
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220305
   Bpm: 32017
+  Signature: 99999
 - StartTime: 220306
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220308
   Bpm: 47966
+  Signature: 99999
 - StartTime: 220309
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220311
   Bpm: 32052.998
+  Signature: 99999
 - StartTime: 220312
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220314
   Bpm: 47930
+  Signature: 99999
 - StartTime: 220315
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220317
   Bpm: 32089
+  Signature: 99999
 - StartTime: 220318
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220320
   Bpm: 47894
+  Signature: 99999
 - StartTime: 220321
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220323
   Bpm: 32125
+  Signature: 99999
 - StartTime: 220324
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220326
   Bpm: 47858
+  Signature: 99999
 - StartTime: 220327
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220329
   Bpm: 32161
+  Signature: 99999
 - StartTime: 220330
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220332
   Bpm: 47822
+  Signature: 99999
 - StartTime: 220333
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220335
   Bpm: 32197
+  Signature: 99999
 - StartTime: 220336
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220338
   Bpm: 47786
+  Signature: 99999
 - StartTime: 220339
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220341
   Bpm: 32233
+  Signature: 99999
 - StartTime: 220342
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220344
   Bpm: 47750
+  Signature: 99999
 - StartTime: 220345
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220347
   Bpm: 32269
+  Signature: 99999
 - StartTime: 220348
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220350
   Bpm: 47714
+  Signature: 99999
 - StartTime: 220351
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220353
   Bpm: 32305
+  Signature: 99999
 - StartTime: 220354
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220356
   Bpm: 47678
+  Signature: 99999
 - StartTime: 220357
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220359
   Bpm: 32341
+  Signature: 99999
 - StartTime: 220360
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220362
   Bpm: 47642
+  Signature: 99999
 - StartTime: 220363
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220365
   Bpm: 32377
+  Signature: 99999
 - StartTime: 220366
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220368
   Bpm: 47606
+  Signature: 99999
 - StartTime: 220369
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220371
   Bpm: 32413
+  Signature: 99999
 - StartTime: 220372
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220374
   Bpm: 47570
+  Signature: 99999
 - StartTime: 220375
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220377
   Bpm: 32449
+  Signature: 99999
 - StartTime: 220378
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220380
   Bpm: 47534
+  Signature: 99999
 - StartTime: 220381
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220383
   Bpm: 32485
+  Signature: 99999
 - StartTime: 220384
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220386
   Bpm: 47498
+  Signature: 99999
 - StartTime: 220387
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220389
   Bpm: 32521
+  Signature: 99999
 - StartTime: 220390
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220392
   Bpm: 47462
+  Signature: 99999
 - StartTime: 220393
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220395
   Bpm: 32557
+  Signature: 99999
 - StartTime: 220396
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220398
   Bpm: 47426
+  Signature: 99999
 - StartTime: 220399
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220401
   Bpm: 32593
+  Signature: 99999
 - StartTime: 220402
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220404
   Bpm: 47390
+  Signature: 99999
 - StartTime: 220405
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220407
   Bpm: 32629
+  Signature: 99999
 - StartTime: 220408
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220410
   Bpm: 47354
+  Signature: 99999
 - StartTime: 220411
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220413
   Bpm: 32665.002
+  Signature: 99999
 - StartTime: 220414
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220416
   Bpm: 47317.9961
+  Signature: 99999
 - StartTime: 220417
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220419
   Bpm: 32701
+  Signature: 99999
 - StartTime: 220420
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220422
   Bpm: 47282
+  Signature: 99999
 - StartTime: 220423
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220425
   Bpm: 32737
+  Signature: 99999
 - StartTime: 220426
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220428
   Bpm: 47246.0039
+  Signature: 99999
 - StartTime: 220429
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220431
   Bpm: 32773
+  Signature: 99999
 - StartTime: 220432
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220434
   Bpm: 47210
+  Signature: 99999
 - StartTime: 220435
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220437
   Bpm: 32809
+  Signature: 99999
 - StartTime: 220438
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220440
   Bpm: 47174
+  Signature: 99999
 - StartTime: 220441
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220443
   Bpm: 32845
+  Signature: 99999
 - StartTime: 220444
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220446
   Bpm: 47138
+  Signature: 99999
 - StartTime: 220447
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220449
   Bpm: 32881
+  Signature: 99999
 - StartTime: 220450
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220452
   Bpm: 47102
+  Signature: 99999
 - StartTime: 220453
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220455
   Bpm: 32917
+  Signature: 99999
 - StartTime: 220456
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220458
   Bpm: 47066
+  Signature: 99999
 - StartTime: 220459
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220461
   Bpm: 32953
+  Signature: 99999
 - StartTime: 220462
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220464
   Bpm: 47030
+  Signature: 99999
 - StartTime: 220465
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220467
   Bpm: 32989
+  Signature: 99999
 - StartTime: 220468
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220470
   Bpm: 46993.9961
+  Signature: 99999
 - StartTime: 220471
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220473
   Bpm: 33025
+  Signature: 99999
 - StartTime: 220474
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220476
   Bpm: 46958.0039
+  Signature: 99999
 - StartTime: 220477
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220479
   Bpm: 33061
+  Signature: 99999
 - StartTime: 220480
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220482
   Bpm: 46922
+  Signature: 99999
 - StartTime: 220483
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220485
   Bpm: 33097
+  Signature: 99999
 - StartTime: 220486
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220488
   Bpm: 46886
+  Signature: 99999
 - StartTime: 220489
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220491
   Bpm: 33133
+  Signature: 99999
 - StartTime: 220492
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220494
   Bpm: 46850
+  Signature: 99999
 - StartTime: 220495
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220497
   Bpm: 33169
+  Signature: 99999
 - StartTime: 220498
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220500
   Bpm: 46814
+  Signature: 99999
 - StartTime: 220501
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220503
   Bpm: 33205
+  Signature: 99999
 - StartTime: 220504
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220506
   Bpm: 46778
+  Signature: 99999
 - StartTime: 220507
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220509
   Bpm: 33241
+  Signature: 99999
 - StartTime: 220510
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220512
   Bpm: 46742
+  Signature: 99999
 - StartTime: 220513
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220515
   Bpm: 33277
+  Signature: 99999
 - StartTime: 220516
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220518
   Bpm: 46706
+  Signature: 99999
 - StartTime: 220519
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220521
   Bpm: 33313
+  Signature: 99999
 - StartTime: 220522
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220524
   Bpm: 46670
+  Signature: 99999
 - StartTime: 220525
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220527
   Bpm: 33349
+  Signature: 99999
 - StartTime: 220528
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220530
   Bpm: 46634
+  Signature: 99999
 - StartTime: 220531
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220533
   Bpm: 33385
+  Signature: 99999
 - StartTime: 220534
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220536
   Bpm: 46598
+  Signature: 99999
 - StartTime: 220537
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220539
   Bpm: 33421
+  Signature: 99999
 - StartTime: 220540
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220542
   Bpm: 46561.9961
+  Signature: 99999
 - StartTime: 220543
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220545
   Bpm: 33457
+  Signature: 99999
 - StartTime: 220546
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220548
   Bpm: 46526
+  Signature: 99999
 - StartTime: 220549
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220551
   Bpm: 33493
+  Signature: 99999
 - StartTime: 220552
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220554
   Bpm: 46490
+  Signature: 99999
 - StartTime: 220555
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220557
   Bpm: 33529
+  Signature: 99999
 - StartTime: 220558
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220560
   Bpm: 46454
+  Signature: 99999
 - StartTime: 220561
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220563
   Bpm: 33565
+  Signature: 99999
 - StartTime: 220564
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220566
   Bpm: 46418
+  Signature: 99999
 - StartTime: 220567
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220569
   Bpm: 33601
+  Signature: 99999
 - StartTime: 220570
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220572
   Bpm: 46382
+  Signature: 99999
 - StartTime: 220573
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220575
   Bpm: 33637
+  Signature: 99999
 - StartTime: 220576
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220578
   Bpm: 46346
+  Signature: 99999
 - StartTime: 220579
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220581
   Bpm: 33673
+  Signature: 99999
 - StartTime: 220582
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220584
   Bpm: 46310
+  Signature: 99999
 - StartTime: 220585
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220587
   Bpm: 33709
+  Signature: 99999
 - StartTime: 220588
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220590
   Bpm: 46274
+  Signature: 99999
 - StartTime: 220591
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220593
   Bpm: 33745
+  Signature: 99999
 - StartTime: 220594
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220596
   Bpm: 46238
+  Signature: 99999
 - StartTime: 220597
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220599
   Bpm: 33781
+  Signature: 99999
 - StartTime: 220600
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220602
   Bpm: 46201.9961
+  Signature: 99999
 - StartTime: 220603
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220605
   Bpm: 33817
+  Signature: 99999
 - StartTime: 220606
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220608
   Bpm: 46166
+  Signature: 99999
 - StartTime: 220609
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220611
   Bpm: 33853
+  Signature: 99999
 - StartTime: 220612
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220614
   Bpm: 46130
+  Signature: 99999
 - StartTime: 220615
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220617
   Bpm: 33889
+  Signature: 99999
 - StartTime: 220618
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220620
   Bpm: 46094
+  Signature: 99999
 - StartTime: 220621
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220623
   Bpm: 33925
+  Signature: 99999
 - StartTime: 220624
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220626
   Bpm: 46058
+  Signature: 99999
 - StartTime: 220627
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220629
   Bpm: 33961
+  Signature: 99999
 - StartTime: 220630
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220632
   Bpm: 46022
+  Signature: 99999
 - StartTime: 220633
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220635
   Bpm: 33997
+  Signature: 99999
 - StartTime: 220636
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220638
   Bpm: 45986
+  Signature: 99999
 - StartTime: 220639
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220641
   Bpm: 34033
+  Signature: 99999
 - StartTime: 220642
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220644
   Bpm: 45950
+  Signature: 99999
 - StartTime: 220645
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220647
   Bpm: 34069
+  Signature: 99999
 - StartTime: 220648
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220650
   Bpm: 45914
+  Signature: 99999
 - StartTime: 220651
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220653
   Bpm: 34105
+  Signature: 99999
 - StartTime: 220654
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220656
   Bpm: 45878
+  Signature: 99999
 - StartTime: 220657
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220659
   Bpm: 34141
+  Signature: 99999
 - StartTime: 220660
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220662
   Bpm: 45842
+  Signature: 99999
 - StartTime: 220663
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220665
   Bpm: 34177
+  Signature: 99999
 - StartTime: 220666
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220668
   Bpm: 45806
+  Signature: 99999
 - StartTime: 220669
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220671
   Bpm: 34213
+  Signature: 99999
 - StartTime: 220672
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220674
   Bpm: 45770
+  Signature: 99999
 - StartTime: 220675
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220677
   Bpm: 34249
+  Signature: 99999
 - StartTime: 220678
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220680
   Bpm: 45734
+  Signature: 99999
 - StartTime: 220681
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220683
   Bpm: 34285
+  Signature: 99999
 - StartTime: 220684
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220686
   Bpm: 45698
+  Signature: 99999
 - StartTime: 220687
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220689
   Bpm: 34321
+  Signature: 99999
 - StartTime: 220690
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220692
   Bpm: 45662
+  Signature: 99999
 - StartTime: 220693
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220695
   Bpm: 34357
+  Signature: 99999
 - StartTime: 220696
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220698
   Bpm: 45626
+  Signature: 99999
 - StartTime: 220699
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220701
   Bpm: 34393
+  Signature: 99999
 - StartTime: 220702
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220704
   Bpm: 45590
+  Signature: 99999
 - StartTime: 220705
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220707
   Bpm: 34429
+  Signature: 99999
 - StartTime: 220708
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220710
   Bpm: 45554
+  Signature: 99999
 - StartTime: 220711
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220713
   Bpm: 34465
+  Signature: 99999
 - StartTime: 220714
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220716
   Bpm: 45518
+  Signature: 99999
 - StartTime: 220717
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220719
   Bpm: 34501
+  Signature: 99999
 - StartTime: 220720
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220722
   Bpm: 45482
+  Signature: 99999
 - StartTime: 220723
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220725
   Bpm: 34537
+  Signature: 99999
 - StartTime: 220726
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220728
   Bpm: 45446
+  Signature: 99999
 - StartTime: 220729
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220731
   Bpm: 34573
+  Signature: 99999
 - StartTime: 220732
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220734
   Bpm: 45410
+  Signature: 99999
 - StartTime: 220735
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220737
   Bpm: 34609
+  Signature: 99999
 - StartTime: 220738
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220740
   Bpm: 45374
+  Signature: 99999
 - StartTime: 220741
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220743
   Bpm: 34645
+  Signature: 99999
 - StartTime: 220744
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220746
   Bpm: 45338
+  Signature: 99999
 - StartTime: 220747
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220749
   Bpm: 34681
+  Signature: 99999
 - StartTime: 220750
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220752
   Bpm: 45302
+  Signature: 99999
 - StartTime: 220753
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220755
   Bpm: 34717
+  Signature: 99999
 - StartTime: 220756
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220758
   Bpm: 45266
+  Signature: 99999
 - StartTime: 220759
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220761
   Bpm: 34753
+  Signature: 99999
 - StartTime: 220762
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220764
   Bpm: 45230
+  Signature: 99999
 - StartTime: 220765
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220767
   Bpm: 34789
+  Signature: 99999
 - StartTime: 220768
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220770
   Bpm: 45194
+  Signature: 99999
 - StartTime: 220771
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220773
   Bpm: 34825
+  Signature: 99999
 - StartTime: 220774
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220776
   Bpm: 45158
+  Signature: 99999
 - StartTime: 220777
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220779
   Bpm: 34861
+  Signature: 99999
 - StartTime: 220780
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220782
   Bpm: 45122
+  Signature: 99999
 - StartTime: 220783
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220785
   Bpm: 34897
+  Signature: 99999
 - StartTime: 220786
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220788
   Bpm: 45086
+  Signature: 99999
 - StartTime: 220789
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220791
   Bpm: 34933
+  Signature: 99999
 - StartTime: 220792
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220794
   Bpm: 45050
+  Signature: 99999
 - StartTime: 220795
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220797
   Bpm: 34969
+  Signature: 99999
 - StartTime: 220798
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220800
   Bpm: 45014
+  Signature: 99999
 - StartTime: 220801
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220803
   Bpm: 35005
+  Signature: 99999
 - StartTime: 220804
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220806
   Bpm: 44978
+  Signature: 99999
 - StartTime: 220807
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220809
   Bpm: 35041
+  Signature: 99999
 - StartTime: 220810
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220812
   Bpm: 44942
+  Signature: 99999
 - StartTime: 220813
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220815
   Bpm: 35077
+  Signature: 99999
 - StartTime: 220816
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220818
   Bpm: 44906
+  Signature: 99999
 - StartTime: 220819
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220821
   Bpm: 35113
+  Signature: 99999
 - StartTime: 220822
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220824
   Bpm: 44870
+  Signature: 99999
 - StartTime: 220825
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220827
   Bpm: 35149
+  Signature: 99999
 - StartTime: 220828
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220830
   Bpm: 44834
+  Signature: 99999
 - StartTime: 220831
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220833
   Bpm: 35185
+  Signature: 99999
 - StartTime: 220834
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220836
   Bpm: 44798
+  Signature: 99999
 - StartTime: 220837
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220839
   Bpm: 35221
+  Signature: 99999
 - StartTime: 220840
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220842
   Bpm: 44762
+  Signature: 99999
 - StartTime: 220843
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220845
   Bpm: 35257
+  Signature: 99999
 - StartTime: 220846
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220848
   Bpm: 44726
+  Signature: 99999
 - StartTime: 220849
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220851
   Bpm: 35293
+  Signature: 99999
 - StartTime: 220852
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220854
   Bpm: 44690
+  Signature: 99999
 - StartTime: 220855
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220857
   Bpm: 35329
+  Signature: 99999
 - StartTime: 220858
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220860
   Bpm: 44654
+  Signature: 99999
 - StartTime: 220861
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220863
   Bpm: 35365
+  Signature: 99999
 - StartTime: 220864
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220866
   Bpm: 44618
+  Signature: 99999
 - StartTime: 220867
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220869
   Bpm: 35401
+  Signature: 99999
 - StartTime: 220870
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220872
   Bpm: 44582
+  Signature: 99999
 - StartTime: 220873
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220875
   Bpm: 35437
+  Signature: 99999
 - StartTime: 220876
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220878
   Bpm: 44546
+  Signature: 99999
 - StartTime: 220879
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220881
   Bpm: 35473
+  Signature: 99999
 - StartTime: 220882
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220884
   Bpm: 44510
+  Signature: 99999
 - StartTime: 220885
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220887
   Bpm: 35509
+  Signature: 99999
 - StartTime: 220888
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220890
   Bpm: 44474
+  Signature: 99999
 - StartTime: 220891
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220893
   Bpm: 35545
+  Signature: 99999
 - StartTime: 220894
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220896
   Bpm: 44438
+  Signature: 99999
 - StartTime: 220897
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220899
   Bpm: 35581
+  Signature: 99999
 - StartTime: 220900
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220902
   Bpm: 44402
+  Signature: 99999
 - StartTime: 220903
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220905
   Bpm: 35617
+  Signature: 99999
 - StartTime: 220906
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220908
   Bpm: 44366
+  Signature: 99999
 - StartTime: 220909
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220911
   Bpm: 35653
+  Signature: 99999
 - StartTime: 220912
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220914
   Bpm: 44330
+  Signature: 99999
 - StartTime: 220915
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220917
   Bpm: 35689
+  Signature: 99999
 - StartTime: 220918
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220920
   Bpm: 44294
+  Signature: 99999
 - StartTime: 220921
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220923
   Bpm: 35725
+  Signature: 99999
 - StartTime: 220924
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220926
   Bpm: 44258
+  Signature: 99999
 - StartTime: 220927
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220929
   Bpm: 35761
+  Signature: 99999
 - StartTime: 220930
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220932
   Bpm: 44222
+  Signature: 99999
 - StartTime: 220933
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220935
   Bpm: 35797
+  Signature: 99999
 - StartTime: 220936
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220938
   Bpm: 44186
+  Signature: 99999
 - StartTime: 220939
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220941
   Bpm: 35833
+  Signature: 99999
 - StartTime: 220942
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220944
   Bpm: 44150
+  Signature: 99999
 - StartTime: 220945
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220947
   Bpm: 35869
+  Signature: 99999
 - StartTime: 220948
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220950
   Bpm: 44114
+  Signature: 99999
 - StartTime: 220951
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220953
   Bpm: 35905
+  Signature: 99999
 - StartTime: 220954
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220956
   Bpm: 44078
+  Signature: 99999
 - StartTime: 220957
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220959
   Bpm: 35941
+  Signature: 99999
 - StartTime: 220960
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220962
   Bpm: 44042
+  Signature: 99999
 - StartTime: 220963
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220965
   Bpm: 35977
+  Signature: 99999
 - StartTime: 220966
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220968
   Bpm: 44006
+  Signature: 99999
 - StartTime: 220969
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220971
   Bpm: 36013
+  Signature: 99999
 - StartTime: 220972
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220974
   Bpm: 43970
+  Signature: 99999
 - StartTime: 220975
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220977
   Bpm: 36049
+  Signature: 99999
 - StartTime: 220978
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220980
   Bpm: 43934
+  Signature: 99999
 - StartTime: 220981
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220983
   Bpm: 36085
+  Signature: 99999
 - StartTime: 220984
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220986
   Bpm: 43898
+  Signature: 99999
 - StartTime: 220987
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220989
   Bpm: 36121
+  Signature: 99999
 - StartTime: 220990
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220992
   Bpm: 43862
+  Signature: 99999
 - StartTime: 220993
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 220995
   Bpm: 36157
+  Signature: 99999
 - StartTime: 220996
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 220998
   Bpm: 43826
+  Signature: 99999
 - StartTime: 220999
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221001
   Bpm: 36193
+  Signature: 99999
 - StartTime: 221002
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221004
   Bpm: 43790
+  Signature: 99999
 - StartTime: 221005
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221007
   Bpm: 36229
+  Signature: 99999
 - StartTime: 221008
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221010
   Bpm: 43754
+  Signature: 99999
 - StartTime: 221011
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221013
   Bpm: 36265
+  Signature: 99999
 - StartTime: 221014
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221016
   Bpm: 43718
+  Signature: 99999
 - StartTime: 221017
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221019
   Bpm: 36301
+  Signature: 99999
 - StartTime: 221020
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221022
   Bpm: 43682
+  Signature: 99999
 - StartTime: 221023
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221025
   Bpm: 36337
+  Signature: 99999
 - StartTime: 221026
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221028
   Bpm: 43646
+  Signature: 99999
 - StartTime: 221029
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221031
   Bpm: 36373
+  Signature: 99999
 - StartTime: 221032
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221034
   Bpm: 43610
+  Signature: 99999
 - StartTime: 221035
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221037
   Bpm: 36409
+  Signature: 99999
 - StartTime: 221038
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221040
   Bpm: 43574
+  Signature: 99999
 - StartTime: 221041
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221043
   Bpm: 36445
+  Signature: 99999
 - StartTime: 221044
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221046
   Bpm: 43538
+  Signature: 99999
 - StartTime: 221047
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221049
   Bpm: 36481
+  Signature: 99999
 - StartTime: 221050
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221052
   Bpm: 43502
+  Signature: 99999
 - StartTime: 221053
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221055
   Bpm: 36517
+  Signature: 99999
 - StartTime: 221056
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221058
   Bpm: 43466
+  Signature: 99999
 - StartTime: 221059
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221061
   Bpm: 36553
+  Signature: 99999
 - StartTime: 221062
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221064
   Bpm: 43430
+  Signature: 99999
 - StartTime: 221065
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221067
   Bpm: 36589
+  Signature: 99999
 - StartTime: 221068
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221070
   Bpm: 43394
+  Signature: 99999
 - StartTime: 221071
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221073
   Bpm: 36625
+  Signature: 99999
 - StartTime: 221074
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221076
   Bpm: 43358
+  Signature: 99999
 - StartTime: 221077
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221079
   Bpm: 36661
+  Signature: 99999
 - StartTime: 221080
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221082
   Bpm: 43322
+  Signature: 99999
 - StartTime: 221083
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221085
   Bpm: 36697
+  Signature: 99999
 - StartTime: 221086
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221088
   Bpm: 43286
+  Signature: 99999
 - StartTime: 221089
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221091
   Bpm: 36733
+  Signature: 99999
 - StartTime: 221092
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221094
   Bpm: 43250
+  Signature: 99999
 - StartTime: 221095
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221097
   Bpm: 36769
+  Signature: 99999
 - StartTime: 221098
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221100
   Bpm: 43214
+  Signature: 99999
 - StartTime: 221101
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221103
   Bpm: 36805
+  Signature: 99999
 - StartTime: 221104
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221106
   Bpm: 43178
+  Signature: 99999
 - StartTime: 221107
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221109
   Bpm: 36841
+  Signature: 99999
 - StartTime: 221110
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221112
   Bpm: 43142
+  Signature: 99999
 - StartTime: 221113
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221115
   Bpm: 36877
+  Signature: 99999
 - StartTime: 221116
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221118
   Bpm: 43106
+  Signature: 99999
 - StartTime: 221119
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221121
   Bpm: 36913
+  Signature: 99999
 - StartTime: 221122
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221124
   Bpm: 43070
+  Signature: 99999
 - StartTime: 221125
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221127
   Bpm: 36949
+  Signature: 99999
 - StartTime: 221128
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221130
   Bpm: 43034
+  Signature: 99999
 - StartTime: 221131
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221133
   Bpm: 36985
+  Signature: 99999
 - StartTime: 221134
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221136
   Bpm: 42998
+  Signature: 99999
 - StartTime: 221137
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221139
   Bpm: 37021
+  Signature: 99999
 - StartTime: 221140
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221142
   Bpm: 42962
+  Signature: 99999
 - StartTime: 221143
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221145
   Bpm: 37057
+  Signature: 99999
 - StartTime: 221146
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221148
   Bpm: 42926
+  Signature: 99999
 - StartTime: 221149
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221151
   Bpm: 37093
+  Signature: 99999
 - StartTime: 221152
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221154
   Bpm: 42890
+  Signature: 99999
 - StartTime: 221155
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221157
   Bpm: 37129
+  Signature: 99999
 - StartTime: 221158
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221160
   Bpm: 42854
+  Signature: 99999
 - StartTime: 221161
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221163
   Bpm: 37165
+  Signature: 99999
 - StartTime: 221164
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221166
   Bpm: 42818
+  Signature: 99999
 - StartTime: 221167
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221169
   Bpm: 37201
+  Signature: 99999
 - StartTime: 221170
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221172
   Bpm: 42782
+  Signature: 99999
 - StartTime: 221173
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221175
   Bpm: 37237
+  Signature: 99999
 - StartTime: 221176
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221178
   Bpm: 42746
+  Signature: 99999
 - StartTime: 221179
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221181
   Bpm: 37273
+  Signature: 99999
 - StartTime: 221182
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221184
   Bpm: 42710
+  Signature: 99999
 - StartTime: 221185
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221187
   Bpm: 37309
+  Signature: 99999
 - StartTime: 221188
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221190
   Bpm: 42674
+  Signature: 99999
 - StartTime: 221191
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221193
   Bpm: 37345
+  Signature: 99999
 - StartTime: 221194
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221196
   Bpm: 42638
+  Signature: 99999
 - StartTime: 221197
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221199
   Bpm: 37381
+  Signature: 99999
 - StartTime: 221200
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221202
   Bpm: 42602
+  Signature: 99999
 - StartTime: 221203
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221205
   Bpm: 37417
+  Signature: 99999
 - StartTime: 221206
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221208
   Bpm: 42566
+  Signature: 99999
 - StartTime: 221209
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221211
   Bpm: 37453
+  Signature: 99999
 - StartTime: 221212
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221214
   Bpm: 42530
+  Signature: 99999
 - StartTime: 221215
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221217
   Bpm: 37489
+  Signature: 99999
 - StartTime: 221218
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221220
   Bpm: 42494
+  Signature: 99999
 - StartTime: 221221
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221223
   Bpm: 37525
+  Signature: 99999
 - StartTime: 221224
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221226
   Bpm: 42458
+  Signature: 99999
 - StartTime: 221227
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221229
   Bpm: 37561
+  Signature: 99999
 - StartTime: 221230
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221232
   Bpm: 42422
+  Signature: 99999
 - StartTime: 221233
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221235
   Bpm: 37597
+  Signature: 99999
 - StartTime: 221236
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221238
   Bpm: 42386
+  Signature: 99999
 - StartTime: 221239
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221241
   Bpm: 37633
+  Signature: 99999
 - StartTime: 221242
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221244
   Bpm: 42350
+  Signature: 99999
 - StartTime: 221245
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221247
   Bpm: 37669
+  Signature: 99999
 - StartTime: 221248
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221250
   Bpm: 42314
+  Signature: 99999
 - StartTime: 221251
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221253
   Bpm: 37705
+  Signature: 99999
 - StartTime: 221254
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221256
   Bpm: 42278
+  Signature: 99999
 - StartTime: 221257
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221259
   Bpm: 37741
+  Signature: 99999
 - StartTime: 221260
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221262
   Bpm: 42242
+  Signature: 99999
 - StartTime: 221263
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221265
   Bpm: 37777
+  Signature: 99999
 - StartTime: 221266
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221268
   Bpm: 42206
+  Signature: 99999
 - StartTime: 221269
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221271
   Bpm: 37813
+  Signature: 99999
 - StartTime: 221272
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221274
   Bpm: 42170
+  Signature: 99999
 - StartTime: 221275
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221277
   Bpm: 37849
+  Signature: 99999
 - StartTime: 221278
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221280
   Bpm: 42134
+  Signature: 99999
 - StartTime: 221281
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221283
   Bpm: 37885
+  Signature: 99999
 - StartTime: 221284
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221286
   Bpm: 42098
+  Signature: 99999
 - StartTime: 221287
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221289
   Bpm: 37921
+  Signature: 99999
 - StartTime: 221290
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221292
   Bpm: 42062
+  Signature: 99999
 - StartTime: 221293
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221295
   Bpm: 37957
+  Signature: 99999
 - StartTime: 221296
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221298
   Bpm: 42026
+  Signature: 99999
 - StartTime: 221299
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221301
   Bpm: 37993
+  Signature: 99999
 - StartTime: 221302
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221304
   Bpm: 41990
+  Signature: 99999
 - StartTime: 221305
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221307
   Bpm: 38029
+  Signature: 99999
 - StartTime: 221308
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221310
   Bpm: 41954
+  Signature: 99999
 - StartTime: 221311
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221313
   Bpm: 38065
+  Signature: 99999
 - StartTime: 221314
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221316
   Bpm: 41918
+  Signature: 99999
 - StartTime: 221317
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221319
   Bpm: 38101
+  Signature: 99999
 - StartTime: 221320
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221322
   Bpm: 41882
+  Signature: 99999
 - StartTime: 221323
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221325
   Bpm: 38137
+  Signature: 99999
 - StartTime: 221326
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221328
   Bpm: 41846
+  Signature: 99999
 - StartTime: 221329
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221331
   Bpm: 38173
+  Signature: 99999
 - StartTime: 221332
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221334
   Bpm: 41810
+  Signature: 99999
 - StartTime: 221335
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221337
   Bpm: 38209
+  Signature: 99999
 - StartTime: 221338
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221340
   Bpm: 41774
+  Signature: 99999
 - StartTime: 221341
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221343
   Bpm: 38245
+  Signature: 99999
 - StartTime: 221344
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221346
   Bpm: 41738
+  Signature: 99999
 - StartTime: 221347
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221349
   Bpm: 38281
+  Signature: 99999
 - StartTime: 221350
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221352
   Bpm: 41702
+  Signature: 99999
 - StartTime: 221353
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221355
   Bpm: 38317
+  Signature: 99999
 - StartTime: 221356
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221358
   Bpm: 41666
+  Signature: 99999
 - StartTime: 221359
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221361
   Bpm: 38353
+  Signature: 99999
 - StartTime: 221362
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221364
   Bpm: 41630
+  Signature: 99999
 - StartTime: 221365
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221367
   Bpm: 38389
+  Signature: 99999
 - StartTime: 221368
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221370
   Bpm: 41594
+  Signature: 99999
 - StartTime: 221371
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221373
   Bpm: 38425
+  Signature: 99999
 - StartTime: 221374
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221376
   Bpm: 41558
+  Signature: 99999
 - StartTime: 221377
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221379
   Bpm: 38461
+  Signature: 99999
 - StartTime: 221380
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221382
   Bpm: 41522
+  Signature: 99999
 - StartTime: 221383
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221385
   Bpm: 38497
+  Signature: 99999
 - StartTime: 221386
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221388
   Bpm: 41486
+  Signature: 99999
 - StartTime: 221389
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221391
   Bpm: 38533
+  Signature: 99999
 - StartTime: 221392
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221394
   Bpm: 41450
+  Signature: 99999
 - StartTime: 221395
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221397
   Bpm: 38569
+  Signature: 99999
 - StartTime: 221398
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221400
   Bpm: 41414
+  Signature: 99999
 - StartTime: 221401
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221403
   Bpm: 38605
+  Signature: 99999
 - StartTime: 221404
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221406
   Bpm: 41378
+  Signature: 99999
 - StartTime: 221407
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221409
   Bpm: 38641
+  Signature: 99999
 - StartTime: 221410
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221412
   Bpm: 41342
+  Signature: 99999
 - StartTime: 221413
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221415
   Bpm: 38677
+  Signature: 99999
 - StartTime: 221416
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221418
   Bpm: 41306
+  Signature: 99999
 - StartTime: 221419
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221421
   Bpm: 38713
+  Signature: 99999
 - StartTime: 221422
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221424
   Bpm: 41270
+  Signature: 99999
 - StartTime: 221425
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221427
   Bpm: 38749
+  Signature: 99999
 - StartTime: 221428
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221430
   Bpm: 41234
+  Signature: 99999
 - StartTime: 221431
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221433
   Bpm: 38785
+  Signature: 99999
 - StartTime: 221434
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221436
   Bpm: 41198
+  Signature: 99999
 - StartTime: 221437
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221439
   Bpm: 38821
+  Signature: 99999
 - StartTime: 221440
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221442
   Bpm: 41162
+  Signature: 99999
 - StartTime: 221443
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221445
   Bpm: 38857
+  Signature: 99999
 - StartTime: 221446
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221448
   Bpm: 41126
+  Signature: 99999
 - StartTime: 221449
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221451
   Bpm: 38893
+  Signature: 99999
 - StartTime: 221452
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221454
   Bpm: 41090
+  Signature: 99999
 - StartTime: 221455
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221457
   Bpm: 38929
+  Signature: 99999
 - StartTime: 221458
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221460
   Bpm: 41054
+  Signature: 99999
 - StartTime: 221461
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221463
   Bpm: 38965
+  Signature: 99999
 - StartTime: 221464
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221466
   Bpm: 41018
+  Signature: 99999
 - StartTime: 221467
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221469
   Bpm: 39001
+  Signature: 99999
 - StartTime: 221470
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221472
   Bpm: 40982
+  Signature: 99999
 - StartTime: 221473
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221475
   Bpm: 39037
+  Signature: 99999
 - StartTime: 221476
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221478
   Bpm: 40946
+  Signature: 99999
 - StartTime: 221479
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221481
   Bpm: 39073
+  Signature: 99999
 - StartTime: 221482
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221484
   Bpm: 40910
+  Signature: 99999
 - StartTime: 221485
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221487
   Bpm: 39109
+  Signature: 99999
 - StartTime: 221488
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221490
   Bpm: 40874
+  Signature: 99999
 - StartTime: 221491
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221493
   Bpm: 39145
+  Signature: 99999
 - StartTime: 221494
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221496
   Bpm: 40838
+  Signature: 99999
 - StartTime: 221497
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221499
   Bpm: 39181
+  Signature: 99999
 - StartTime: 221500
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221502
   Bpm: 40802
+  Signature: 99999
 - StartTime: 221503
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221505
   Bpm: 39217
+  Signature: 99999
 - StartTime: 221506
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221508
   Bpm: 40766
+  Signature: 99999
 - StartTime: 221509
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221511
   Bpm: 39253
+  Signature: 99999
 - StartTime: 221512
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221514
   Bpm: 40730
+  Signature: 99999
 - StartTime: 221515
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221517
   Bpm: 39289
+  Signature: 99999
 - StartTime: 221518
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221520
   Bpm: 40694
+  Signature: 99999
 - StartTime: 221521
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221523
   Bpm: 39325
+  Signature: 99999
 - StartTime: 221524
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221526
   Bpm: 40658
+  Signature: 99999
 - StartTime: 221527
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221529
   Bpm: 39361
+  Signature: 99999
 - StartTime: 221530
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221532
   Bpm: 40622
+  Signature: 99999
 - StartTime: 221533
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221535
   Bpm: 39397
+  Signature: 99999
 - StartTime: 221536
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221538
   Bpm: 40586
+  Signature: 99999
 - StartTime: 221539
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221541
   Bpm: 39433
+  Signature: 99999
 - StartTime: 221542
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221544
   Bpm: 40550
+  Signature: 99999
 - StartTime: 221545
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221547
   Bpm: 39469
+  Signature: 99999
 - StartTime: 221548
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221550
   Bpm: 40514
+  Signature: 99999
 - StartTime: 221551
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221553
   Bpm: 39505
+  Signature: 99999
 - StartTime: 221554
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221556
   Bpm: 40478
+  Signature: 99999
 - StartTime: 221557
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221559
   Bpm: 39541
+  Signature: 99999
 - StartTime: 221560
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221562
   Bpm: 40442
+  Signature: 99999
 - StartTime: 221563
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221565
   Bpm: 39577
+  Signature: 99999
 - StartTime: 221566
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221568
   Bpm: 40406
+  Signature: 99999
 - StartTime: 221569
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221571
   Bpm: 39613
+  Signature: 99999
 - StartTime: 221572
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221574
   Bpm: 40370
+  Signature: 99999
 - StartTime: 221575
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221577
   Bpm: 39649
+  Signature: 99999
 - StartTime: 221578
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221580
   Bpm: 40334
+  Signature: 99999
 - StartTime: 221581
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221583
   Bpm: 39685
+  Signature: 99999
 - StartTime: 221584
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221586
   Bpm: 40298
+  Signature: 99999
 - StartTime: 221587
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221589
   Bpm: 39721
+  Signature: 99999
 - StartTime: 221590
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221592
   Bpm: 40262
+  Signature: 99999
 - StartTime: 221593
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221595
   Bpm: 39757
+  Signature: 99999
 - StartTime: 221596
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221598
   Bpm: 40226
+  Signature: 99999
 - StartTime: 221599
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221601
   Bpm: 39793
+  Signature: 99999
 - StartTime: 221602
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221604
   Bpm: 40190
+  Signature: 99999
 - StartTime: 221605
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221607
   Bpm: 39829
+  Signature: 99999
 - StartTime: 221608
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221610
   Bpm: 40154
+  Signature: 99999
 - StartTime: 221611
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221613
   Bpm: 39865
+  Signature: 99999
 - StartTime: 221614
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221616
   Bpm: 40118
+  Signature: 99999
 - StartTime: 221617
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221619
   Bpm: 39901
+  Signature: 99999
 - StartTime: 221620
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221622
   Bpm: 40082
+  Signature: 99999
 - StartTime: 221623
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221625
   Bpm: 39937
+  Signature: 99999
 - StartTime: 221626
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221628
   Bpm: 40046
+  Signature: 99999
 - StartTime: 221629
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221631
   Bpm: 39973
+  Signature: 99999
 - StartTime: 221632
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221634
   Bpm: 40010
+  Signature: 99999
 - StartTime: 221635
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221637
   Bpm: 40009
+  Signature: 99999
 - StartTime: 221638
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221640
   Bpm: 39974
+  Signature: 99999
 - StartTime: 221641
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221643
   Bpm: 40045
+  Signature: 99999
 - StartTime: 221644
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221646
   Bpm: 39938
+  Signature: 99999
 - StartTime: 221647
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221649
   Bpm: 40081
+  Signature: 99999
 - StartTime: 221650
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221652
   Bpm: 39902
+  Signature: 99999
 - StartTime: 221653
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221655
   Bpm: 40117
+  Signature: 99999
 - StartTime: 221656
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221658
   Bpm: 39866
+  Signature: 99999
 - StartTime: 221659
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221661
   Bpm: 40153
+  Signature: 99999
 - StartTime: 221662
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221664
   Bpm: 39830
+  Signature: 99999
 - StartTime: 221665
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221667
   Bpm: 40189
+  Signature: 99999
 - StartTime: 221668
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221670
   Bpm: 39794
+  Signature: 99999
 - StartTime: 221671
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221673
   Bpm: 40225
+  Signature: 99999
 - StartTime: 221674
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221676
   Bpm: 39758
+  Signature: 99999
 - StartTime: 221677
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221679
   Bpm: 40261
+  Signature: 99999
 - StartTime: 221680
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221682
   Bpm: 39722
+  Signature: 99999
 - StartTime: 221683
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221685
   Bpm: 40297
+  Signature: 99999
 - StartTime: 221686
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221688
   Bpm: 39686
+  Signature: 99999
 - StartTime: 221689
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221691
   Bpm: 40333
+  Signature: 99999
 - StartTime: 221692
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221694
   Bpm: 39650
+  Signature: 99999
 - StartTime: 221695
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221697
   Bpm: 40369
+  Signature: 99999
 - StartTime: 221698
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221700
   Bpm: 39614
+  Signature: 99999
 - StartTime: 221701
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221703
   Bpm: 40405
+  Signature: 99999
 - StartTime: 221704
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221706
   Bpm: 39578
+  Signature: 99999
 - StartTime: 221707
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221709
   Bpm: 40441
+  Signature: 99999
 - StartTime: 221710
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221712
   Bpm: 39542
+  Signature: 99999
 - StartTime: 221713
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221715
   Bpm: 40477
+  Signature: 99999
 - StartTime: 221716
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221718
   Bpm: 39506
+  Signature: 99999
 - StartTime: 221719
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221721
   Bpm: 40513
+  Signature: 99999
 - StartTime: 221722
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221724
   Bpm: 39470
+  Signature: 99999
 - StartTime: 221725
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221727
   Bpm: 40549
+  Signature: 99999
 - StartTime: 221728
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221730
   Bpm: 39434
+  Signature: 99999
 - StartTime: 221731
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221733
   Bpm: 40585
+  Signature: 99999
 - StartTime: 221734
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221736
   Bpm: 39398
+  Signature: 99999
 - StartTime: 221737
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221739
   Bpm: 40621
+  Signature: 99999
 - StartTime: 221740
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221742
   Bpm: 39362
+  Signature: 99999
 - StartTime: 221743
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221745
   Bpm: 40657
+  Signature: 99999
 - StartTime: 221746
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221748
   Bpm: 39326
+  Signature: 99999
 - StartTime: 221749
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221751
   Bpm: 40693
+  Signature: 99999
 - StartTime: 221752
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221754
   Bpm: 39290
+  Signature: 99999
 - StartTime: 221755
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221757
   Bpm: 40729
+  Signature: 99999
 - StartTime: 221758
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221760
   Bpm: 39254
+  Signature: 99999
 - StartTime: 221761
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221763
   Bpm: 40765
+  Signature: 99999
 - StartTime: 221764
   Bpm: 0.0599999987
+  Signature: 99999
 - StartTime: 221766
   Bpm: 39218
+  Signature: 99999
 - StartTime: 221769
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221771
   Bpm: 40732.1992
+  Signature: 99999
 - StartTime: 221772
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221774
   Bpm: 40630.5
+  Signature: 99999
 - StartTime: 221775
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221777
   Bpm: 40528.8008
+  Signature: 99999
 - StartTime: 221778
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221780
   Bpm: 40427.1016
+  Signature: 99999
 - StartTime: 221781
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221783
   Bpm: 40325.3984
+  Signature: 99999
 - StartTime: 221784
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221786
   Bpm: 40223.7031
+  Signature: 99999
 - StartTime: 221787
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221789
   Bpm: 40122
+  Signature: 99999
 - StartTime: 221790
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221792
   Bpm: 40020.3008
+  Signature: 99999
 - StartTime: 221793
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221795
   Bpm: 39918.6016
+  Signature: 99999
 - StartTime: 221796
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221798
   Bpm: 39816.9023
+  Signature: 99999
 - StartTime: 221799
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221801
   Bpm: 39715.1992
+  Signature: 99999
 - StartTime: 221802
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221804
   Bpm: 39613.5
+  Signature: 99999
 - StartTime: 221805
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221807
   Bpm: 39511.8008
+  Signature: 99999
 - StartTime: 221808
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221810
   Bpm: 39410.1016
+  Signature: 99999
 - StartTime: 221811
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221813
   Bpm: 39308.4023
+  Signature: 99999
 - StartTime: 221814
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221816
   Bpm: 39206.6992
+  Signature: 99999
 - StartTime: 221817
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221819
   Bpm: 39105
+  Signature: 99999
 - StartTime: 221820
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221822
   Bpm: 39003.3008
+  Signature: 99999
 - StartTime: 221823
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221825
   Bpm: 38901.5977
+  Signature: 99999
 - StartTime: 221826
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221828
   Bpm: 38799.8984
+  Signature: 99999
 - StartTime: 221829
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221831
   Bpm: 38698.1992
+  Signature: 99999
 - StartTime: 221832
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221834
   Bpm: 38596.5
+  Signature: 99999
 - StartTime: 221835
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221837
   Bpm: 38494.8008
+  Signature: 99999
 - StartTime: 221838
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221840
   Bpm: 38393.0977
+  Signature: 99999
 - StartTime: 221841
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221843
   Bpm: 38291.3984
+  Signature: 99999
 - StartTime: 221844
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221846
   Bpm: 38189.6992
+  Signature: 99999
 - StartTime: 221847
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221849
   Bpm: 38088
+  Signature: 99999
 - StartTime: 221850
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221852
   Bpm: 37986.3008
+  Signature: 99999
 - StartTime: 221853
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221855
   Bpm: 37884.5977
+  Signature: 99999
 - StartTime: 221856
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221858
   Bpm: 37782.8984
+  Signature: 99999
 - StartTime: 221859
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221861
   Bpm: 37681.1992
+  Signature: 99999
 - StartTime: 221862
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221864
   Bpm: 37579.5
+  Signature: 99999
 - StartTime: 221865
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221867
   Bpm: 37477.8008
+  Signature: 99999
 - StartTime: 221868
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221870
   Bpm: 37376.1016
+  Signature: 99999
 - StartTime: 221871
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221873
   Bpm: 37274.3984
+  Signature: 99999
 - StartTime: 221874
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221876
   Bpm: 37172.7031
+  Signature: 99999
 - StartTime: 221877
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221879
   Bpm: 37071
+  Signature: 99999
 - StartTime: 221880
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221882
   Bpm: 36969.3008
+  Signature: 99999
 - StartTime: 221883
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221885
   Bpm: 36867.6016
+  Signature: 99999
 - StartTime: 221886
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221888
   Bpm: 36765.8984
+  Signature: 99999
 - StartTime: 221889
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221891
   Bpm: 36664.1992
+  Signature: 99999
 - StartTime: 221892
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221894
   Bpm: 36562.5
+  Signature: 99999
 - StartTime: 221895
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221897
   Bpm: 36460.8008
+  Signature: 99999
 - StartTime: 221898
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221900
   Bpm: 36359.1016
+  Signature: 99999
 - StartTime: 221901
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221903
   Bpm: 36257.3984
+  Signature: 99999
 - StartTime: 221904
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221906
   Bpm: 36155.6992
+  Signature: 99999
 - StartTime: 221907
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221909
   Bpm: 36054
+  Signature: 99999
 - StartTime: 221910
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221912
   Bpm: 35952.3008
+  Signature: 99999
 - StartTime: 221913
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221915
   Bpm: 35850.6016
+  Signature: 99999
 - StartTime: 221916
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221918
   Bpm: 35748.8984
+  Signature: 99999
 - StartTime: 221919
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221921
   Bpm: 35647.1992
+  Signature: 99999
 - StartTime: 221922
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221924
   Bpm: 35545.5
+  Signature: 99999
 - StartTime: 221925
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221927
   Bpm: 35443.8008
+  Signature: 99999
 - StartTime: 221928
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221930
   Bpm: 35342.0977
+  Signature: 99999
 - StartTime: 221931
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221933
   Bpm: 35240.4023
+  Signature: 99999
 - StartTime: 221934
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221936
   Bpm: 35138.6992
+  Signature: 99999
 - StartTime: 221937
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221939
   Bpm: 35037
+  Signature: 99999
 - StartTime: 221940
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221942
   Bpm: 34935.3008
+  Signature: 99999
 - StartTime: 221943
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221945
   Bpm: 34833.6016
+  Signature: 99999
 - StartTime: 221946
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221948
   Bpm: 34731.8984
+  Signature: 99999
 - StartTime: 221949
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221951
   Bpm: 34630.1992
+  Signature: 99999
 - StartTime: 221952
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221954
   Bpm: 34528.5
+  Signature: 99999
 - StartTime: 221955
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221957
   Bpm: 34426.8008
+  Signature: 99999
 - StartTime: 221958
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221960
   Bpm: 34325.0977
+  Signature: 99999
 - StartTime: 221961
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221963
   Bpm: 34223.3984
+  Signature: 99999
 - StartTime: 221964
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221966
   Bpm: 34121.6992
+  Signature: 99999
 - StartTime: 221967
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221969
   Bpm: 34020
+  Signature: 99999
 - StartTime: 221970
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221972
   Bpm: 33918.3008
+  Signature: 99999
 - StartTime: 221973
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221975
   Bpm: 33816.6016
+  Signature: 99999
 - StartTime: 221976
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221978
   Bpm: 33714.8984
+  Signature: 99999
 - StartTime: 221979
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221981
   Bpm: 33613.1992
+  Signature: 99999
 - StartTime: 221982
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221984
   Bpm: 33511.5
+  Signature: 99999
 - StartTime: 221985
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221987
   Bpm: 33409.8008
+  Signature: 99999
 - StartTime: 221988
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221990
   Bpm: 33308.1016
+  Signature: 99999
 - StartTime: 221991
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221993
   Bpm: 33206.3984
+  Signature: 99999
 - StartTime: 221994
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221996
   Bpm: 33104.6992
+  Signature: 99999
 - StartTime: 221997
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 221999
   Bpm: 33003
+  Signature: 99999
 - StartTime: 222000
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222002
   Bpm: 32901.3008
+  Signature: 99999
 - StartTime: 222003
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222005
   Bpm: 32799.5977
+  Signature: 99999
 - StartTime: 222006
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222008
   Bpm: 32697.9004
+  Signature: 99999
 - StartTime: 222009
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222011
   Bpm: 32596.1992
+  Signature: 99999
 - StartTime: 222012
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222014
   Bpm: 32494.5
+  Signature: 99999
 - StartTime: 222015
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222017
   Bpm: 32392.8008
+  Signature: 99999
 - StartTime: 222018
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222020
   Bpm: 32291.1016
+  Signature: 99999
 - StartTime: 222021
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222023
   Bpm: 32189.4004
+  Signature: 99999
 - StartTime: 222024
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222026
   Bpm: 32087.6992
+  Signature: 99999
 - StartTime: 222027
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222029
   Bpm: 31986
+  Signature: 99999
 - StartTime: 222030
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222032
   Bpm: 31884.3008
+  Signature: 99999
 - StartTime: 222033
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222035
   Bpm: 31782.6016
+  Signature: 99999
 - StartTime: 222036
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222038
   Bpm: 31680.9004
+  Signature: 99999
 - StartTime: 222039
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222041
   Bpm: 31579.1992
+  Signature: 99999
 - StartTime: 222042
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222044
   Bpm: 31477.5
+  Signature: 99999
 - StartTime: 222045
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222047
   Bpm: 31375.8008
+  Signature: 99999
 - StartTime: 222048
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222050
   Bpm: 31274.0996
+  Signature: 99999
 - StartTime: 222051
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222053
   Bpm: 31172.3984
+  Signature: 99999
 - StartTime: 222054
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222056
   Bpm: 31070.7012
+  Signature: 99999
 - StartTime: 222057
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222059
   Bpm: 30969
+  Signature: 99999
 - StartTime: 222060
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222062
   Bpm: 30867.2988
+  Signature: 99999
 - StartTime: 222063
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222065
   Bpm: 30765.5996
+  Signature: 99999
 - StartTime: 222066
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222068
   Bpm: 30663.9004
+  Signature: 99999
 - StartTime: 222069
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222071
   Bpm: 30562.1992
+  Signature: 99999
 - StartTime: 222072
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222074
   Bpm: 30460.5
+  Signature: 99999
 - StartTime: 222075
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222077
   Bpm: 30358.8008
+  Signature: 99999
 - StartTime: 222078
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222080
   Bpm: 30257.0996
+  Signature: 99999
 - StartTime: 222081
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222083
   Bpm: 30155.4004
+  Signature: 99999
 - StartTime: 222084
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222086
   Bpm: 30053.7012
+  Signature: 99999
 - StartTime: 222087
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222089
   Bpm: 29952.002
+  Signature: 99999
 - StartTime: 222090
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222092
   Bpm: 29850.3008
+  Signature: 99999
 - StartTime: 222093
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222095
   Bpm: 29748.5977
+  Signature: 99999
 - StartTime: 222096
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222098
   Bpm: 29646.9004
+  Signature: 99999
 - StartTime: 222099
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222101
   Bpm: 29545.1992
+  Signature: 99999
 - StartTime: 222102
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222104
   Bpm: 29443.5
+  Signature: 99999
 - StartTime: 222105
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222107
   Bpm: 29341.7988
+  Signature: 99999
 - StartTime: 222108
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222110
   Bpm: 29240.0977
+  Signature: 99999
 - StartTime: 222111
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222113
   Bpm: 29138.3984
+  Signature: 99999
 - StartTime: 222114
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222116
   Bpm: 29036.7012
+  Signature: 99999
 - StartTime: 222117
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222119
   Bpm: 28935.002
+  Signature: 99999
 - StartTime: 222120
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222122
   Bpm: 28833.2988
+  Signature: 99999
 - StartTime: 222123
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222125
   Bpm: 28731.5996
+  Signature: 99999
 - StartTime: 222126
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222128
   Bpm: 28629.8984
+  Signature: 99999
 - StartTime: 222129
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222131
   Bpm: 28528.2012
+  Signature: 99999
 - StartTime: 222132
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222134
   Bpm: 28426.5
+  Signature: 99999
 - StartTime: 222135
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222137
   Bpm: 28324.8008
+  Signature: 99999
 - StartTime: 222138
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222140
   Bpm: 28223.0996
+  Signature: 99999
 - StartTime: 222141
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222143
   Bpm: 28121.4004
+  Signature: 99999
 - StartTime: 222144
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222146
   Bpm: 28019.7012
+  Signature: 99999
 - StartTime: 222147
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222149
   Bpm: 27918
+  Signature: 99999
 - StartTime: 222150
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222152
   Bpm: 27816.3008
+  Signature: 99999
 - StartTime: 222153
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222155
   Bpm: 27714.5996
+  Signature: 99999
 - StartTime: 222156
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222158
   Bpm: 27612.9023
+  Signature: 99999
 - StartTime: 222159
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222161
   Bpm: 27511.2012
+  Signature: 99999
 - StartTime: 222162
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222164
   Bpm: 27409.5
+  Signature: 99999
 - StartTime: 222165
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222167
   Bpm: 27307.7988
+  Signature: 99999
 - StartTime: 222168
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222170
   Bpm: 27206.0996
+  Signature: 99999
 - StartTime: 222171
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222173
   Bpm: 27104.4004
+  Signature: 99999
 - StartTime: 222174
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222176
   Bpm: 27002.6992
+  Signature: 99999
 - StartTime: 222177
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222179
   Bpm: 26901
+  Signature: 99999
 - StartTime: 222180
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222182
   Bpm: 26799.3008
+  Signature: 99999
 - StartTime: 222183
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222185
   Bpm: 26697.5996
+  Signature: 99999
 - StartTime: 222186
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222188
   Bpm: 26595.8984
+  Signature: 99999
 - StartTime: 222189
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222191
   Bpm: 26494.2012
+  Signature: 99999
 - StartTime: 222192
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222194
   Bpm: 26392.5
+  Signature: 99999
 - StartTime: 222195
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222197
   Bpm: 26290.7988
+  Signature: 99999
 - StartTime: 222198
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222200
   Bpm: 26189.0996
+  Signature: 99999
 - StartTime: 222201
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222203
   Bpm: 26087.4004
+  Signature: 99999
 - StartTime: 222204
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222206
   Bpm: 25985.6992
+  Signature: 99999
 - StartTime: 222207
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222209
   Bpm: 25883.998
+  Signature: 99999
 - StartTime: 222210
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222212
   Bpm: 25782.2988
+  Signature: 99999
 - StartTime: 222213
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222215
   Bpm: 25680.5996
+  Signature: 99999
 - StartTime: 222216
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222218
   Bpm: 25578.9004
+  Signature: 99999
 - StartTime: 222219
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222221
   Bpm: 25477.2012
+  Signature: 99999
 - StartTime: 222222
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222224
   Bpm: 25375.5
+  Signature: 99999
 - StartTime: 222225
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222227
   Bpm: 25273.8008
+  Signature: 99999
 - StartTime: 222228
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222230
   Bpm: 25172.0996
+  Signature: 99999
 - StartTime: 222231
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222233
   Bpm: 25070.4004
+  Signature: 99999
 - StartTime: 222234
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222236
   Bpm: 24968.7012
+  Signature: 99999
 - StartTime: 222237
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222239
   Bpm: 24867
+  Signature: 99999
 - StartTime: 222240
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222242
   Bpm: 24765.2988
+  Signature: 99999
 - StartTime: 222243
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222245
   Bpm: 24663.5996
+  Signature: 99999
 - StartTime: 222246
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222248
   Bpm: 24561.9004
+  Signature: 99999
 - StartTime: 222249
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222251
   Bpm: 24460.2012
+  Signature: 99999
 - StartTime: 222252
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222254
   Bpm: 24358.5
+  Signature: 99999
 - StartTime: 222255
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222257
   Bpm: 24256.8008
+  Signature: 99999
 - StartTime: 222258
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222260
   Bpm: 24155.0996
+  Signature: 99999
 - StartTime: 222261
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222263
   Bpm: 24053.4004
+  Signature: 99999
 - StartTime: 222264
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222266
   Bpm: 23951.7012
+  Signature: 99999
 - StartTime: 222267
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222269
   Bpm: 23850
+  Signature: 99999
 - StartTime: 222270
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222272
   Bpm: 23748.3008
+  Signature: 99999
 - StartTime: 222273
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222275
   Bpm: 23646.6016
+  Signature: 99999
 - StartTime: 222276
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222278
   Bpm: 23544.8984
+  Signature: 99999
 - StartTime: 222279
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222281
   Bpm: 23443.1992
+  Signature: 99999
 - StartTime: 222282
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222284
   Bpm: 23341.5
+  Signature: 99999
 - StartTime: 222285
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222287
   Bpm: 23239.8008
+  Signature: 99999
 - StartTime: 222288
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222290
   Bpm: 23138.0996
+  Signature: 99999
 - StartTime: 222291
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222293
   Bpm: 23036.3984
+  Signature: 99999
 - StartTime: 222294
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222296
   Bpm: 22934.6992
+  Signature: 99999
 - StartTime: 222297
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222299
   Bpm: 22833
+  Signature: 99999
 - StartTime: 222300
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222302
   Bpm: 22731.2988
+  Signature: 99999
 - StartTime: 222303
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222305
   Bpm: 22629.5996
+  Signature: 99999
 - StartTime: 222306
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222308
   Bpm: 22527.8984
+  Signature: 99999
 - StartTime: 222309
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222311
   Bpm: 22426.1992
+  Signature: 99999
 - StartTime: 222312
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222314
   Bpm: 22324.5
+  Signature: 99999
 - StartTime: 222315
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222317
   Bpm: 22222.8008
+  Signature: 99999
 - StartTime: 222318
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222320
   Bpm: 22121.0996
+  Signature: 99999
 - StartTime: 222321
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222323
   Bpm: 22019.3984
+  Signature: 99999
 - StartTime: 222324
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222326
   Bpm: 21917.6992
+  Signature: 99999
 - StartTime: 222327
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222329
   Bpm: 21816
+  Signature: 99999
 - StartTime: 222330
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222332
   Bpm: 21714.2988
+  Signature: 99999
 - StartTime: 222333
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222335
   Bpm: 21612.5996
+  Signature: 99999
 - StartTime: 222336
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222338
   Bpm: 21510.9004
+  Signature: 99999
 - StartTime: 222339
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222341
   Bpm: 21409.2012
+  Signature: 99999
 - StartTime: 222342
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222344
   Bpm: 21307.5
+  Signature: 99999
 - StartTime: 222345
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222347
   Bpm: 21205.8008
+  Signature: 99999
 - StartTime: 222348
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222350
   Bpm: 21104.0996
+  Signature: 99999
 - StartTime: 222351
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222353
   Bpm: 21002.4004
+  Signature: 99999
 - StartTime: 222354
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222356
   Bpm: 20900.6992
+  Signature: 99999
 - StartTime: 222357
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222359
   Bpm: 20799
+  Signature: 99999
 - StartTime: 222360
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222362
   Bpm: 20697.2988
+  Signature: 99999
 - StartTime: 222363
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222365
   Bpm: 20595.5996
+  Signature: 99999
 - StartTime: 222366
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222368
   Bpm: 20493.9004
+  Signature: 99999
 - StartTime: 222369
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222371
   Bpm: 20392.1992
+  Signature: 99999
 - StartTime: 222372
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222374
   Bpm: 20290.5
+  Signature: 99999
 - StartTime: 222375
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222377
   Bpm: 20188.8008
+  Signature: 99999
 - StartTime: 222378
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222380
   Bpm: 20087.0996
+  Signature: 99999
 - StartTime: 222381
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222383
   Bpm: 19985.4004
+  Signature: 99999
 - StartTime: 222384
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222386
   Bpm: 19883.6992
+  Signature: 99999
 - StartTime: 222387
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222389
   Bpm: 19782
+  Signature: 99999
 - StartTime: 222390
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222392
   Bpm: 19680.3008
+  Signature: 99999
 - StartTime: 222393
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222395
   Bpm: 19578.5996
+  Signature: 99999
 - StartTime: 222396
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222398
   Bpm: 19476.9004
+  Signature: 99999
 - StartTime: 222399
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222401
   Bpm: 19375.2012
+  Signature: 99999
 - StartTime: 222402
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222404
   Bpm: 19273.5
+  Signature: 99999
 - StartTime: 222405
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222407
   Bpm: 19171.7988
+  Signature: 99999
 - StartTime: 222408
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222410
   Bpm: 19070.1016
+  Signature: 99999
 - StartTime: 222411
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222413
   Bpm: 18968.4004
+  Signature: 99999
 - StartTime: 222414
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222416
   Bpm: 18866.7012
+  Signature: 99999
 - StartTime: 222417
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222419
   Bpm: 18765
+  Signature: 99999
 - StartTime: 222420
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222422
   Bpm: 18663.3008
+  Signature: 99999
 - StartTime: 222423
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222425
   Bpm: 18561.5996
+  Signature: 99999
 - StartTime: 222426
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222428
   Bpm: 18459.9004
+  Signature: 99999
 - StartTime: 222429
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222431
   Bpm: 18358.1992
+  Signature: 99999
 - StartTime: 222432
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222434
   Bpm: 18256.5
+  Signature: 99999
 - StartTime: 222435
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222437
   Bpm: 18154.7988
+  Signature: 99999
 - StartTime: 222438
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222440
   Bpm: 18053.0996
+  Signature: 99999
 - StartTime: 222441
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222443
   Bpm: 17951.4004
+  Signature: 99999
 - StartTime: 222444
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222446
   Bpm: 17849.6992
+  Signature: 99999
 - StartTime: 222447
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222449
   Bpm: 17748
+  Signature: 99999
 - StartTime: 222450
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222452
   Bpm: 17646.2988
+  Signature: 99999
 - StartTime: 222453
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222455
   Bpm: 17544.5996
+  Signature: 99999
 - StartTime: 222456
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222458
   Bpm: 17442.9004
+  Signature: 99999
 - StartTime: 222459
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222461
   Bpm: 17341.2012
+  Signature: 99999
 - StartTime: 222462
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222464
   Bpm: 17239.5
+  Signature: 99999
 - StartTime: 222465
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222467
   Bpm: 17137.8008
+  Signature: 99999
 - StartTime: 222468
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222470
   Bpm: 17036.0996
+  Signature: 99999
 - StartTime: 222471
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222473
   Bpm: 16934.4004
+  Signature: 99999
 - StartTime: 222474
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222476
   Bpm: 16832.6992
+  Signature: 99999
 - StartTime: 222477
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222479
   Bpm: 16731
+  Signature: 99999
 - StartTime: 222480
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222482
   Bpm: 16629.2988
+  Signature: 99999
 - StartTime: 222483
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222485
   Bpm: 16527.5996
+  Signature: 99999
 - StartTime: 222486
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222488
   Bpm: 16425.9004
+  Signature: 99999
 - StartTime: 222489
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222491
   Bpm: 16324.2002
+  Signature: 99999
 - StartTime: 222492
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222494
   Bpm: 16222.5
+  Signature: 99999
 - StartTime: 222495
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222497
   Bpm: 16120.7998
+  Signature: 99999
 - StartTime: 222498
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222500
   Bpm: 16019.1006
+  Signature: 99999
 - StartTime: 222501
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222503
   Bpm: 15917.4004
+  Signature: 99999
 - StartTime: 222504
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222506
   Bpm: 15815.7002
+  Signature: 99999
 - StartTime: 222507
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222509
   Bpm: 15714
+  Signature: 99999
 - StartTime: 222510
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222512
   Bpm: 15612.2998
+  Signature: 99999
 - StartTime: 222513
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222515
   Bpm: 15510.5996
+  Signature: 99999
 - StartTime: 222516
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222518
   Bpm: 15408.8994
+  Signature: 99999
 - StartTime: 222519
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222521
   Bpm: 15307.2002
+  Signature: 99999
 - StartTime: 222522
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222524
   Bpm: 15205.5
+  Signature: 99999
 - StartTime: 222525
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222527
   Bpm: 15103.7998
+  Signature: 99999
 - StartTime: 222528
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222530
   Bpm: 15002.0996
+  Signature: 99999
 - StartTime: 222531
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222533
   Bpm: 14900.3994
+  Signature: 99999
 - StartTime: 222534
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222536
   Bpm: 14798.7012
+  Signature: 99999
 - StartTime: 222537
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222539
   Bpm: 14697.001
+  Signature: 99999
 - StartTime: 222540
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222542
   Bpm: 14595.3008
+  Signature: 99999
 - StartTime: 222543
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222545
   Bpm: 14493.6006
+  Signature: 99999
 - StartTime: 222546
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222548
   Bpm: 14391.9004
+  Signature: 99999
 - StartTime: 222549
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222551
   Bpm: 14290.1992
+  Signature: 99999
 - StartTime: 222552
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222554
   Bpm: 14188.5
+  Signature: 99999
 - StartTime: 222555
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222557
   Bpm: 14086.8008
+  Signature: 99999
 - StartTime: 222558
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222560
   Bpm: 13985.0996
+  Signature: 99999
 - StartTime: 222561
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222563
   Bpm: 13883.4004
+  Signature: 99999
 - StartTime: 222564
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222566
   Bpm: 13781.6992
+  Signature: 99999
 - StartTime: 222567
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222569
   Bpm: 13680
+  Signature: 99999
 - StartTime: 222570
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222572
   Bpm: 13578.3008
+  Signature: 99999
 - StartTime: 222573
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222575
   Bpm: 13476.6006
+  Signature: 99999
 - StartTime: 222576
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222578
   Bpm: 13374.9004
+  Signature: 99999
 - StartTime: 222579
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222581
   Bpm: 13273.1992
+  Signature: 99999
 - StartTime: 222582
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222584
   Bpm: 13171.5
+  Signature: 99999
 - StartTime: 222585
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222587
   Bpm: 13069.7998
+  Signature: 99999
 - StartTime: 222588
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222590
   Bpm: 12968.0996
+  Signature: 99999
 - StartTime: 222591
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222593
   Bpm: 12866.4004
+  Signature: 99999
 - StartTime: 222594
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222596
   Bpm: 12764.7002
+  Signature: 99999
 - StartTime: 222597
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222599
   Bpm: 12663
+  Signature: 99999
 - StartTime: 222600
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222602
   Bpm: 12561.2998
+  Signature: 99999
 - StartTime: 222603
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222605
   Bpm: 12459.6006
+  Signature: 99999
 - StartTime: 222606
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222608
   Bpm: 12357.9004
+  Signature: 99999
 - StartTime: 222609
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222611
   Bpm: 12256.2002
+  Signature: 99999
 - StartTime: 222612
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222614
   Bpm: 12154.5
+  Signature: 99999
 - StartTime: 222615
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222617
   Bpm: 12052.7998
+  Signature: 99999
 - StartTime: 222618
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222620
   Bpm: 11951.1006
+  Signature: 99999
 - StartTime: 222621
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222623
   Bpm: 11849.3994
+  Signature: 99999
 - StartTime: 222624
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222626
   Bpm: 11747.7002
+  Signature: 99999
 - StartTime: 222627
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222629
   Bpm: 11645.999
+  Signature: 99999
 - StartTime: 222630
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222632
   Bpm: 11544.2998
+  Signature: 99999
 - StartTime: 222633
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222635
   Bpm: 11442.5996
+  Signature: 99999
 - StartTime: 222636
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222638
   Bpm: 11340.8994
+  Signature: 99999
 - StartTime: 222639
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222641
   Bpm: 11239.2002
+  Signature: 99999
 - StartTime: 222642
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222644
   Bpm: 11137.5
+  Signature: 99999
 - StartTime: 222645
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222647
   Bpm: 11035.7998
+  Signature: 99999
 - StartTime: 222648
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222650
   Bpm: 10934.0996
+  Signature: 99999
 - StartTime: 222651
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222653
   Bpm: 10832.4004
+  Signature: 99999
 - StartTime: 222654
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222656
   Bpm: 10730.7002
+  Signature: 99999
 - StartTime: 222657
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222659
   Bpm: 10629
+  Signature: 99999
 - StartTime: 222660
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222662
   Bpm: 10527.2998
+  Signature: 99999
 - StartTime: 222663
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222665
   Bpm: 10425.5996
+  Signature: 99999
 - StartTime: 222666
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222668
   Bpm: 10323.9004
+  Signature: 99999
 - StartTime: 222669
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222671
   Bpm: 10222.2002
+  Signature: 99999
 - StartTime: 222672
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222674
   Bpm: 10120.5
+  Signature: 99999
 - StartTime: 222675
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222677
   Bpm: 10018.7998
+  Signature: 99999
 - StartTime: 222678
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222680
   Bpm: 9917.10059
+  Signature: 99999
 - StartTime: 222681
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222683
   Bpm: 9815.40039
+  Signature: 99999
 - StartTime: 222684
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222686
   Bpm: 9713.7002
+  Signature: 99999
 - StartTime: 222687
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222689
   Bpm: 9612
+  Signature: 99999
 - StartTime: 222690
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222692
   Bpm: 9510.2998
+  Signature: 99999
 - StartTime: 222693
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222695
   Bpm: 9408.59961
+  Signature: 99999
 - StartTime: 222696
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222698
   Bpm: 9306.90039
+  Signature: 99999
 - StartTime: 222699
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222701
   Bpm: 9205.2002
+  Signature: 99999
 - StartTime: 222702
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222704
   Bpm: 9103.5
+  Signature: 99999
 - StartTime: 222705
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222707
   Bpm: 9001.7998
+  Signature: 99999
 - StartTime: 222708
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222710
   Bpm: 8900.09961
+  Signature: 99999
 - StartTime: 222711
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222713
   Bpm: 8798.40039
+  Signature: 99999
 - StartTime: 222714
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222716
   Bpm: 8696.7002
+  Signature: 99999
 - StartTime: 222717
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222719
   Bpm: 8595
+  Signature: 99999
 - StartTime: 222720
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222722
   Bpm: 8493.2998
+  Signature: 99999
 - StartTime: 222723
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222725
   Bpm: 8391.59961
+  Signature: 99999
 - StartTime: 222726
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222728
   Bpm: 8289.90039
+  Signature: 99999
 - StartTime: 222729
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222731
   Bpm: 8188.2002
+  Signature: 99999
 - StartTime: 222732
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222734
   Bpm: 8086.5
+  Signature: 99999
 - StartTime: 222735
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222737
   Bpm: 7984.80029
+  Signature: 99999
 - StartTime: 222738
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222740
   Bpm: 7883.1001
+  Signature: 99999
 - StartTime: 222741
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222743
   Bpm: 7781.3999
+  Signature: 99999
 - StartTime: 222744
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222746
   Bpm: 7679.7002
+  Signature: 99999
 - StartTime: 222747
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222749
   Bpm: 7578
+  Signature: 99999
 - StartTime: 222750
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222752
   Bpm: 7476.2998
+  Signature: 99999
 - StartTime: 222753
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222755
   Bpm: 7374.59961
+  Signature: 99999
 - StartTime: 222756
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222758
   Bpm: 7272.89941
+  Signature: 99999
 - StartTime: 222759
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222761
   Bpm: 7171.2002
+  Signature: 99999
 - StartTime: 222762
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222764
   Bpm: 7069.49951
+  Signature: 99999
 - StartTime: 222765
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222767
   Bpm: 6967.80029
+  Signature: 99999
 - StartTime: 222768
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222770
   Bpm: 6866.09961
+  Signature: 99999
 - StartTime: 222771
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222773
   Bpm: 6764.3999
+  Signature: 99999
 - StartTime: 222774
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222776
   Bpm: 6662.7002
+  Signature: 99999
 - StartTime: 222777
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222779
   Bpm: 6561.00049
+  Signature: 99999
 - StartTime: 222780
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222782
   Bpm: 6459.30029
+  Signature: 99999
 - StartTime: 222783
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222785
   Bpm: 6357.59961
+  Signature: 99999
 - StartTime: 222786
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222788
   Bpm: 6255.8999
+  Signature: 99999
 - StartTime: 222789
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222791
   Bpm: 6154.2002
+  Signature: 99999
 - StartTime: 222792
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222794
   Bpm: 6052.50049
+  Signature: 99999
 - StartTime: 222795
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222797
   Bpm: 5950.80029
+  Signature: 99999
 - StartTime: 222798
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222800
   Bpm: 5849.1001
+  Signature: 99999
 - StartTime: 222801
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222803
   Bpm: 5747.40039
+  Signature: 99999
 - StartTime: 222804
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222806
   Bpm: 5645.7002
+  Signature: 99999
 - StartTime: 222807
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222809
   Bpm: 5544
+  Signature: 99999
 - StartTime: 222810
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222812
   Bpm: 5442.2998
+  Signature: 99999
 - StartTime: 222813
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222815
   Bpm: 5340.6001
+  Signature: 99999
 - StartTime: 222816
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222818
   Bpm: 5238.90039
+  Signature: 99999
 - StartTime: 222819
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222821
   Bpm: 5137.2002
+  Signature: 99999
 - StartTime: 222822
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222824
   Bpm: 5035.5
+  Signature: 99999
 - StartTime: 222825
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222827
   Bpm: 4933.7998
+  Signature: 99999
 - StartTime: 222828
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222830
   Bpm: 4832.1001
+  Signature: 99999
 - StartTime: 222831
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222833
   Bpm: 4730.3999
+  Signature: 99999
 - StartTime: 222834
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222836
   Bpm: 4628.7002
+  Signature: 99999
 - StartTime: 222837
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222839
   Bpm: 4527
+  Signature: 99999
 - StartTime: 222840
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222842
   Bpm: 4425.2998
+  Signature: 99999
 - StartTime: 222843
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222845
   Bpm: 4323.6001
+  Signature: 99999
 - StartTime: 222846
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222848
   Bpm: 4221.8999
+  Signature: 99999
 - StartTime: 222849
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222851
   Bpm: 4120.2002
+  Signature: 99999
 - StartTime: 222852
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222854
   Bpm: 4018.5
+  Signature: 99999
 - StartTime: 222855
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222857
   Bpm: 3916.80005
+  Signature: 99999
 - StartTime: 222858
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222860
   Bpm: 3815.1001
+  Signature: 99999
 - StartTime: 222861
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222863
   Bpm: 3713.3999
+  Signature: 99999
 - StartTime: 222864
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222866
   Bpm: 3611.7002
+  Signature: 99999
 - StartTime: 222867
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222869
   Bpm: 3510
+  Signature: 99999
 - StartTime: 222870
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222872
   Bpm: 3408.30005
+  Signature: 99999
 - StartTime: 222873
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222875
   Bpm: 3306.6001
+  Signature: 99999
 - StartTime: 222876
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222878
   Bpm: 3204.90015
+  Signature: 99999
 - StartTime: 222879
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222881
   Bpm: 3103.19995
+  Signature: 99999
 - StartTime: 222882
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222884
   Bpm: 3001.5
+  Signature: 99999
 - StartTime: 222885
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222887
   Bpm: 2899.80005
+  Signature: 99999
 - StartTime: 222888
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222890
   Bpm: 2798.09985
+  Signature: 99999
 - StartTime: 222891
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222893
   Bpm: 2696.3999
+  Signature: 99999
 - StartTime: 222894
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222896
   Bpm: 2594.7002
+  Signature: 99999
 - StartTime: 222897
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222899
   Bpm: 2493
+  Signature: 99999
 - StartTime: 222900
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222902
   Bpm: 2391.30005
+  Signature: 99999
 - StartTime: 222903
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222905
   Bpm: 2289.6001
+  Signature: 99999
 - StartTime: 222906
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222908
   Bpm: 2187.8999
+  Signature: 99999
 - StartTime: 222909
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222911
   Bpm: 2086.19995
+  Signature: 99999
 - StartTime: 222912
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222914
   Bpm: 1984.5
+  Signature: 99999
 - StartTime: 222915
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222917
   Bpm: 1882.80005
+  Signature: 99999
 - StartTime: 222918
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222920
   Bpm: 1781.1001
+  Signature: 99999
 - StartTime: 222921
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222923
   Bpm: 1679.3999
+  Signature: 99999
 - StartTime: 222924
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222926
   Bpm: 1577.69995
+  Signature: 99999
 - StartTime: 222927
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222929
   Bpm: 1476
+  Signature: 99999
 - StartTime: 222930
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222932
   Bpm: 1374.30005
+  Signature: 99999
 - StartTime: 222933
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222935
   Bpm: 1272.59998
+  Signature: 99999
 - StartTime: 222936
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222938
   Bpm: 1170.90002
+  Signature: 99999
 - StartTime: 222939
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222941
   Bpm: 1069.20007
+  Signature: 99999
 - StartTime: 222942
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222944
   Bpm: 967.5
+  Signature: 99999
 - StartTime: 222945
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222947
   Bpm: 865.799988
+  Signature: 99999
 - StartTime: 222948
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222950
   Bpm: 764.100037
+  Signature: 99999
 - StartTime: 222951
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222953
   Bpm: 662.399963
+  Signature: 99999
 - StartTime: 222954
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222956
   Bpm: 560.700012
+  Signature: 99999
 - StartTime: 222957
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222959
   Bpm: 459.000031
+  Signature: 99999
 - StartTime: 222960
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222962
   Bpm: 357.299988
+  Signature: 99999
 - StartTime: 222963
   Bpm: 99999.9922
+  Signature: 99999
 - StartTime: 222965
   Bpm: 255.599991
+  Signature: 99999
 SliderVelocities:
 - StartTime: 969
   Multiplier: 10
@@ -18578,11 +23908,11 @@ SliderVelocities:
 - StartTime: 16169
   Multiplier: 2.5
 - StartTime: 16249
-  Multiplier: 0.629999995
+  Multiplier: 0.625
 - StartTime: 16569
   Multiplier: 2.5
 - StartTime: 16649
-  Multiplier: 0.629999995
+  Multiplier: 0.625
 - StartTime: 16970
   Multiplier: 2
 - StartTime: 17020
@@ -18628,75 +23958,75 @@ SliderVelocities:
 - StartTime: 22169
   Multiplier: 4
 - StartTime: 22173
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 22202
   Multiplier: 4
 - StartTime: 22206
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 22235
   Multiplier: 4
 - StartTime: 22245
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 22302
   Multiplier: 4
 - StartTime: 22304
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 22319
   Multiplier: 4
 - StartTime: 22326
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 22369
   Multiplier: 4
 - StartTime: 22376
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 22419
   Multiplier: 4
 - StartTime: 22426
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 22469
   Multiplier: 4
 - StartTime: 22476
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 22519
   Multiplier: 4
 - StartTime: 22526
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 22569
   Multiplier: 4
 - StartTime: 22578
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 22635
   Multiplier: 4
 - StartTime: 22645
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 22702
   Multiplier: 4
 - StartTime: 22712
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 22769
   Multiplier: 4
 - StartTime: 22784
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 22869
   Multiplier: 4
 - StartTime: 22884
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 22969
   Multiplier: 4
 - StartTime: 22984
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 23069
   Multiplier: 4
 - StartTime: 23084
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 23169
   Multiplier: 4
 - StartTime: 23184
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 23269
   Multiplier: 4
 - StartTime: 23284
-  Multiplier: 0.469999999
+  Multiplier: 0.470588237
 - StartTime: 23369
   Multiplier: 1
 - StartTime: 24170
@@ -18738,11 +24068,11 @@ SliderVelocities:
 - StartTime: 29369
   Multiplier: 2
 - StartTime: 29419
-  Multiplier: 0.670000017
+  Multiplier: 0.669999957
 - StartTime: 29569
   Multiplier: 2
 - StartTime: 29619
-  Multiplier: 0.670000017
+  Multiplier: 0.669999957
 - StartTime: 29769
   Multiplier: 1
 - StartTime: 29969
@@ -18806,53 +24136,53 @@ SliderVelocities:
 - StartTime: 34009
   Multiplier: 0.75
 - StartTime: 34169
-  Multiplier: 6
+  Multiplier: 5.99999952
 - StartTime: 34179
-  Multiplier: 0.439999998
+  Multiplier: 0.444444448
 - StartTime: 34269
-  Multiplier: 6
+  Multiplier: 5.99999952
 - StartTime: 34289
-  Multiplier: 0.439999998
+  Multiplier: 0.444444448
 - StartTime: 34469
-  Multiplier: 6
+  Multiplier: 5.99999952
 - StartTime: 34479
-  Multiplier: 0.439999998
+  Multiplier: 0.444444448
 - StartTime: 34569
   Multiplier: 10
 - StartTime: 34600
-  Multiplier: 0.439999998
+  Multiplier: 0.444444448
 - StartTime: 34669
-  Multiplier: 6
+  Multiplier: 5.99999952
 - StartTime: 34689
-  Multiplier: 0.439999998
+  Multiplier: 0.444444448
 - StartTime: 34869
-  Multiplier: 6
+  Multiplier: 5.99999952
 - StartTime: 34879
-  Multiplier: 0.439999998
+  Multiplier: 0.444444448
 - StartTime: 34970
   Multiplier: 10
 - StartTime: 35001
-  Multiplier: 0.439999998
+  Multiplier: 0.444444448
 - StartTime: 35069
-  Multiplier: 6
+  Multiplier: 5.99999952
 - StartTime: 35089
-  Multiplier: 0.439999998
+  Multiplier: 0.444444448
 - StartTime: 35269
-  Multiplier: 6
+  Multiplier: 5.99999952
 - StartTime: 35279
-  Multiplier: 0.439999998
+  Multiplier: 0.444444448
 - StartTime: 35370
   Multiplier: 10
 - StartTime: 35401
-  Multiplier: 0.439999998
+  Multiplier: 0.444444448
 - StartTime: 35469
-  Multiplier: 6
+  Multiplier: 5.99999952
 - StartTime: 35489
-  Multiplier: 0.439999998
+  Multiplier: 0.444444448
 - StartTime: 35669
-  Multiplier: 6
+  Multiplier: 5.99999952
 - StartTime: 35679
-  Multiplier: 0.439999998
+  Multiplier: 0.444444448
 - StartTime: 35769
   Multiplier: 2
 - StartTime: 35794
@@ -18872,19 +24202,19 @@ SliderVelocities:
 - StartTime: 36142.332
   Multiplier: 1.23000002
 - StartTime: 36195.668
-  Multiplier: 1.22000003
+  Multiplier: 1.21999991
 - StartTime: 36249
-  Multiplier: 1.21000004
+  Multiplier: 1.20999992
 - StartTime: 36302.332
-  Multiplier: 1.20000005
+  Multiplier: 1.19999993
 - StartTime: 36355.668
-  Multiplier: 1.19000006
+  Multiplier: 1.18999994
 - StartTime: 36409
   Multiplier: 1.17999995
 - StartTime: 36462.332
   Multiplier: 1.16999996
 - StartTime: 36515.668
-  Multiplier: 1.15999997
+  Multiplier: 1.16000009
 - StartTime: 36569
   Multiplier: 1.14999998
 - StartTime: 36622.332
@@ -18902,7 +24232,7 @@ SliderVelocities:
 - StartTime: 36942.332
   Multiplier: 1.08000004
 - StartTime: 36995.668
-  Multiplier: 1.07000005
+  Multiplier: 1.06999993
 - StartTime: 37049
   Multiplier: 1.05999994
 - StartTime: 37102.332
@@ -18924,7 +24254,7 @@ SliderVelocities:
 - StartTime: 37529
   Multiplier: 0.970000029
 - StartTime: 37582.332
-  Multiplier: 0.959999979
+  Multiplier: 0.960000038
 - StartTime: 37635.668
   Multiplier: 0.949999988
 - StartTime: 37689
@@ -18932,7 +24262,7 @@ SliderVelocities:
 - StartTime: 37742.332
   Multiplier: 0.930000007
 - StartTime: 37795.668
-  Multiplier: 0.920000017
+  Multiplier: 0.919999957
 - StartTime: 37849
   Multiplier: 0.910000026
 - StartTime: 37902.332
@@ -18940,7 +24270,7 @@ SliderVelocities:
 - StartTime: 37955.668
   Multiplier: 0.889999986
 - StartTime: 38009
-  Multiplier: 0.879999995
+  Multiplier: 0.880000055
 - StartTime: 38062.332
   Multiplier: 0.870000005
 - StartTime: 38115.668
@@ -18960,7 +24290,7 @@ SliderVelocities:
 - StartTime: 38489
   Multiplier: 0.790000021
 - StartTime: 38542.332
-  Multiplier: 0.779999971
+  Multiplier: 0.780000031
 - StartTime: 38595.668
   Multiplier: 0.769999981
 - StartTime: 38649
@@ -18986,31 +24316,31 @@ SliderVelocities:
 - StartTime: 44470
   Multiplier: 2.9000001
 - StartTime: 44490
-  Multiplier: 0.209999993
+  Multiplier: 0.212500006
 - StartTime: 44570
   Multiplier: 2.9000001
 - StartTime: 44590
-  Multiplier: 0.209999993
+  Multiplier: 0.212500006
 - StartTime: 44670
   Multiplier: 0.75
 - StartTime: 44770
   Multiplier: 2.9000001
 - StartTime: 44790
-  Multiplier: 0.209999993
+  Multiplier: 0.212500006
 - StartTime: 44870
   Multiplier: 2.9000001
 - StartTime: 44890
-  Multiplier: 0.209999993
+  Multiplier: 0.212500006
 - StartTime: 44970
   Multiplier: 0.75
 - StartTime: 45070
   Multiplier: 2.9000001
 - StartTime: 45090
-  Multiplier: 0.209999993
+  Multiplier: 0.212500006
 - StartTime: 45170
   Multiplier: 2.9000001
 - StartTime: 45190
-  Multiplier: 0.209999993
+  Multiplier: 0.212500006
 - StartTime: 45270
   Multiplier: 0.75
 - StartTime: 45369
@@ -19050,7 +24380,7 @@ SliderVelocities:
 - StartTime: 47689
   Multiplier: 1.05999994
 - StartTime: 47742.332
-  Multiplier: 1.07000005
+  Multiplier: 1.06999993
 - StartTime: 47795.668
   Multiplier: 1.08000004
 - StartTime: 47849
@@ -19068,19 +24398,19 @@ SliderVelocities:
 - StartTime: 48169
   Multiplier: 1.14999998
 - StartTime: 48222.332
-  Multiplier: 1.15999997
+  Multiplier: 1.16000009
 - StartTime: 48275.668
   Multiplier: 1.16999996
 - StartTime: 48329
   Multiplier: 1.17999995
 - StartTime: 48382.332
-  Multiplier: 1.19000006
+  Multiplier: 1.18999994
 - StartTime: 48435.668
-  Multiplier: 1.20000005
+  Multiplier: 1.19999993
 - StartTime: 48489
-  Multiplier: 1.21000004
+  Multiplier: 1.20999992
 - StartTime: 48542.332
-  Multiplier: 1.22000003
+  Multiplier: 1.21999991
 - StartTime: 48595.668
   Multiplier: 1.23000002
 - StartTime: 48649
@@ -19122,7 +24452,7 @@ SliderVelocities:
 - StartTime: 50572
   Multiplier: 0.769999981
 - StartTime: 50781
-  Multiplier: 0.779999971
+  Multiplier: 0.780000031
 - StartTime: 50995
   Multiplier: 0.790000021
 - StartTime: 51209
@@ -19150,11 +24480,11 @@ SliderVelocities:
 - StartTime: 52707
   Multiplier: 0.870000005
 - StartTime: 52921
-  Multiplier: 0.879999995
+  Multiplier: 0.880000055
 - StartTime: 52969
   Multiplier: 10
 - StartTime: 52974
-  Multiplier: 0.879999995
+  Multiplier: 0.880000055
 - StartTime: 53135
   Multiplier: 0.889999986
 - StartTime: 53349
@@ -19164,7 +24494,7 @@ SliderVelocities:
 - StartTime: 53769
   Multiplier: 10
 - StartTime: 53774
-  Multiplier: 0.920000017
+  Multiplier: 0.919999957
 - StartTime: 53991
   Multiplier: 0.930000007
 - StartTime: 54205
@@ -19176,7 +24506,7 @@ SliderVelocities:
 - StartTime: 54574
   Multiplier: 0.949999988
 - StartTime: 54633
-  Multiplier: 0.959999979
+  Multiplier: 0.960000038
 - StartTime: 54847
   Multiplier: 0.970000029
 - StartTime: 55061
@@ -19216,11 +24546,11 @@ SliderVelocities:
 - StartTime: 56774
   Multiplier: 1.05999994
 - StartTime: 56987
-  Multiplier: 1.07000005
+  Multiplier: 1.06999993
 - StartTime: 57169
   Multiplier: 10
 - StartTime: 57174
-  Multiplier: 1.07000005
+  Multiplier: 1.06999993
 - StartTime: 57201
   Multiplier: 1.08000004
 - StartTime: 57415
@@ -19254,7 +24584,7 @@ SliderVelocities:
 - StartTime: 58869
   Multiplier: 10
 - StartTime: 58874
-  Multiplier: 1.15999997
+  Multiplier: 1.16000009
 - StartTime: 59069
   Multiplier: 10
 - StartTime: 59074
@@ -19266,11 +24596,11 @@ SliderVelocities:
 - StartTime: 59469
   Multiplier: 10
 - StartTime: 59473
-  Multiplier: 1.19000006
+  Multiplier: 1.18999994
 - StartTime: 59669
   Multiplier: 10
 - StartTime: 59674
-  Multiplier: 1.20000005
+  Multiplier: 1.19999993
 - StartTime: 59769
   Multiplier: 10
 - StartTime: 59794
@@ -19294,19 +24624,19 @@ SliderVelocities:
 - StartTime: 60569
   Multiplier: 2
 - StartTime: 60594
-  Multiplier: 0.670000017
+  Multiplier: 0.666666687
 - StartTime: 60669
   Multiplier: 2
 - StartTime: 60694
-  Multiplier: 0.670000017
+  Multiplier: 0.666666687
 - StartTime: 60769
   Multiplier: 2
 - StartTime: 60794
-  Multiplier: 0.670000017
+  Multiplier: 0.666666687
 - StartTime: 60869
   Multiplier: 2
 - StartTime: 60919
-  Multiplier: 0.670000017
+  Multiplier: 0.666666687
 - StartTime: 61069
   Multiplier: 5
 - StartTime: 61094
@@ -19314,7 +24644,7 @@ SliderVelocities:
 - StartTime: 61269
   Multiplier: 2
 - StartTime: 61294
-  Multiplier: 0.670000017
+  Multiplier: 0.669999957
 - StartTime: 61369
   Multiplier: 1
 - StartTime: 67969
@@ -19476,217 +24806,217 @@ SliderVelocities:
 - StartTime: 80569
   Multiplier: 7
 - StartTime: 80579
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 80669
   Multiplier: 3.5
 - StartTime: 80689
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 80869
   Multiplier: 3.5
 - StartTime: 80889
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 81069
   Multiplier: 3.5
 - StartTime: 81089
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 81269
   Multiplier: 7
 - StartTime: 81279
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 81369
   Multiplier: 7
 - StartTime: 81379
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 81469
   Multiplier: 3.5
 - StartTime: 81489
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 81669
   Multiplier: 3.5
 - StartTime: 81689
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 81869
   Multiplier: 3.5
 - StartTime: 81889
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 82069
   Multiplier: 3.5
 - StartTime: 82089
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 82269
   Multiplier: 3.5
 - StartTime: 82289
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 82469
   Multiplier: 3.5
 - StartTime: 82489
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 82669
   Multiplier: 3.5
 - StartTime: 82689
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 82869
   Multiplier: 7
 - StartTime: 82879
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 82969
   Multiplier: 7
 - StartTime: 82979
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 83069
   Multiplier: 3.5
 - StartTime: 83089
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 83269
   Multiplier: 3.5
 - StartTime: 83289
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 83469
   Multiplier: 3.5
 - StartTime: 83489
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 83669
   Multiplier: 3.5
 - StartTime: 83689
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 83869
   Multiplier: 3.5
 - StartTime: 83889
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 84069
   Multiplier: 7
 - StartTime: 84079
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 84169
   Multiplier: 7
 - StartTime: 84179
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 84269
   Multiplier: 3.5
 - StartTime: 84289
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 84469
   Multiplier: 3.5
 - StartTime: 84489
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 84669
   Multiplier: 3.5
 - StartTime: 84689
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 84869
   Multiplier: 7
 - StartTime: 84879
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 84969
   Multiplier: 7
 - StartTime: 84979
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 85069
   Multiplier: 3.5
 - StartTime: 85089
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 85269
   Multiplier: 7
 - StartTime: 85279
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 85369
   Multiplier: 7
 - StartTime: 85379
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 85469
   Multiplier: 3.5
 - StartTime: 85489
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 85669
   Multiplier: 7
 - StartTime: 85679
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 85769
   Multiplier: 7
 - StartTime: 85779
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 85869
   Multiplier: 3.5
 - StartTime: 85889
-  Multiplier: 0.170000002
+  Multiplier: 0.166666672
 - StartTime: 86069
   Multiplier: 7
 - StartTime: 86079
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 86169
   Multiplier: 1
 - StartTime: 88169
   Multiplier: 1
 - StartTime: 88219
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 88369
   Multiplier: 2
 - StartTime: 88394
-  Multiplier: 0.670000017
+  Multiplier: 0.666666687
 - StartTime: 88469
   Multiplier: 1
 - StartTime: 88519
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 88669
   Multiplier: 2
 - StartTime: 88694
-  Multiplier: 0.670000017
+  Multiplier: 0.666666687
 - StartTime: 88769
   Multiplier: 1
 - StartTime: 88819
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 88969
   Multiplier: 1
 - StartTime: 89019
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 89169
   Multiplier: 2
 - StartTime: 89194
-  Multiplier: 0.670000017
+  Multiplier: 0.666666687
 - StartTime: 89269
   Multiplier: 1
 - StartTime: 89319
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 89469
   Multiplier: 2
 - StartTime: 89494
-  Multiplier: 0.670000017
+  Multiplier: 0.666666687
 - StartTime: 89569
   Multiplier: 1
 - StartTime: 89619
-  Multiplier: 0.330000013
+  Multiplier: 0.333333343
 - StartTime: 92569
-  Multiplier: 2.5999999
+  Multiplier: 2.60000014
 - StartTime: 92582
-  Multiplier: 0.600000024
+  Multiplier: 0.599999964
 - StartTime: 92635
-  Multiplier: 2.5999999
+  Multiplier: 2.60000014
 - StartTime: 92648
-  Multiplier: 0.600000024
+  Multiplier: 0.599999964
 - StartTime: 92702
-  Multiplier: 2.5999999
+  Multiplier: 2.60000014
 - StartTime: 92715
-  Multiplier: 0.600000024
+  Multiplier: 0.599999964
 - StartTime: 92769
-  Multiplier: 2.5999999
+  Multiplier: 2.60000014
 - StartTime: 92789
-  Multiplier: 0.600000024
+  Multiplier: 0.599999964
 - StartTime: 92869
-  Multiplier: 2.5999999
+  Multiplier: 2.60000014
 - StartTime: 92889
-  Multiplier: 0.600000024
+  Multiplier: 0.599999964
 - StartTime: 92969
-  Multiplier: 2.5999999
+  Multiplier: 2.60000014
 - StartTime: 92989
-  Multiplier: 0.600000024
+  Multiplier: 0.599999964
 - StartTime: 93069
-  Multiplier: 2.5999999
+  Multiplier: 2.60000014
 - StartTime: 93089
-  Multiplier: 0.600000024
+  Multiplier: 0.599999964
 - StartTime: 93169
-  Multiplier: 2.5999999
+  Multiplier: 2.60000014
 - StartTime: 93209
-  Multiplier: 0.600000024
+  Multiplier: 0.599999964
 - StartTime: 93369
   Multiplier: 9.10000038
 - StartTime: 93374
@@ -19734,59 +25064,59 @@ SliderVelocities:
 - StartTime: 93969
   Multiplier: 2.29999995
 - StartTime: 93994
-  Multiplier: 0.569999993
+  Multiplier: 0.566666663
 - StartTime: 94069
   Multiplier: 1.14999998
 - StartTime: 94119
-  Multiplier: 0.280000001
+  Multiplier: 0.283333331
 - StartTime: 94269
   Multiplier: 2.29999995
 - StartTime: 94294
-  Multiplier: 0.569999993
+  Multiplier: 0.566666663
 - StartTime: 94369
   Multiplier: 1.14999998
 - StartTime: 94419
-  Multiplier: 0.280000001
+  Multiplier: 0.283333331
 - StartTime: 94569
   Multiplier: 1.14999998
 - StartTime: 94619
-  Multiplier: 0.280000001
+  Multiplier: 0.283333331
 - StartTime: 94769
   Multiplier: 2.29999995
 - StartTime: 94794
-  Multiplier: 0.569999993
+  Multiplier: 0.566666663
 - StartTime: 94869
   Multiplier: 1.14999998
 - StartTime: 94919
-  Multiplier: 0.280000001
+  Multiplier: 0.283333331
 - StartTime: 95069
   Multiplier: 2.29999995
 - StartTime: 95094
-  Multiplier: 0.569999993
+  Multiplier: 0.566666663
 - StartTime: 95169
   Multiplier: 1.14999998
 - StartTime: 95219
-  Multiplier: 0.280000001
+  Multiplier: 0.283333331
 - StartTime: 95369
   Multiplier: 1.14999998
 - StartTime: 95419
-  Multiplier: 0.280000001
+  Multiplier: 0.283333331
 - StartTime: 95569
   Multiplier: 2.29999995
 - StartTime: 95594
-  Multiplier: 0.569999993
+  Multiplier: 0.566666663
 - StartTime: 95669
   Multiplier: 1.14999998
 - StartTime: 95719
-  Multiplier: 0.280000001
+  Multiplier: 0.283333331
 - StartTime: 95869
   Multiplier: 2.29999995
 - StartTime: 95894
-  Multiplier: 0.569999993
+  Multiplier: 0.566666663
 - StartTime: 95969
   Multiplier: 1.14999998
 - StartTime: 96019
-  Multiplier: 0.280000001
+  Multiplier: 0.283333331
 - StartTime: 96169
   Multiplier: 9.10000038
 - StartTime: 96174
@@ -19920,91 +25250,91 @@ SliderVelocities:
 - StartTime: 100369
   Multiplier: 2
 - StartTime: 100399
-  Multiplier: 0.569999993
+  Multiplier: 0.571428597
 - StartTime: 100469
   Multiplier: 1
 - StartTime: 100529
-  Multiplier: 0.289999992
+  Multiplier: 0.285714298
 - StartTime: 100669
   Multiplier: 2
 - StartTime: 100699
-  Multiplier: 0.569999993
+  Multiplier: 0.571428597
 - StartTime: 100769
   Multiplier: 1
 - StartTime: 100829
-  Multiplier: 0.289999992
+  Multiplier: 0.285714298
 - StartTime: 100969
   Multiplier: 1
 - StartTime: 101029
-  Multiplier: 0.289999992
+  Multiplier: 0.285714298
 - StartTime: 101169
   Multiplier: 2
 - StartTime: 101199
-  Multiplier: 0.569999993
+  Multiplier: 0.571428597
 - StartTime: 101269
   Multiplier: 1
 - StartTime: 101329
-  Multiplier: 0.289999992
+  Multiplier: 0.285714298
 - StartTime: 101469
   Multiplier: 2
 - StartTime: 101499
-  Multiplier: 0.569999993
+  Multiplier: 0.571428597
 - StartTime: 101569
   Multiplier: 1
 - StartTime: 101629
-  Multiplier: 0.289999992
+  Multiplier: 0.285714298
 - StartTime: 101769
   Multiplier: 1
 - StartTime: 101829
-  Multiplier: 0.289999992
+  Multiplier: 0.285714298
 - StartTime: 101969
   Multiplier: 2
 - StartTime: 101999
-  Multiplier: 0.569999993
+  Multiplier: 0.571428597
 - StartTime: 102069
   Multiplier: 1
 - StartTime: 102129
-  Multiplier: 0.289999992
+  Multiplier: 0.285714298
 - StartTime: 102269
   Multiplier: 2
 - StartTime: 102299
-  Multiplier: 0.569999993
+  Multiplier: 0.571428597
 - StartTime: 102369
   Multiplier: 1
 - StartTime: 102429
-  Multiplier: 0.289999992
+  Multiplier: 0.285714298
 - StartTime: 105370
-  Multiplier: 2.5999999
+  Multiplier: 2.60000014
 - StartTime: 105383
-  Multiplier: 0.600000024
+  Multiplier: 0.599999964
 - StartTime: 105436
-  Multiplier: 2.5999999
+  Multiplier: 2.60000014
 - StartTime: 105449
-  Multiplier: 0.600000024
+  Multiplier: 0.599999964
 - StartTime: 105503
-  Multiplier: 2.5999999
+  Multiplier: 2.60000014
 - StartTime: 105516
-  Multiplier: 0.600000024
+  Multiplier: 0.599999964
 - StartTime: 105570
-  Multiplier: 2.5999999
+  Multiplier: 2.60000014
 - StartTime: 105590
-  Multiplier: 0.600000024
+  Multiplier: 0.599999964
 - StartTime: 105670
-  Multiplier: 2.5999999
+  Multiplier: 2.60000014
 - StartTime: 105690
-  Multiplier: 0.600000024
+  Multiplier: 0.599999964
 - StartTime: 105770
-  Multiplier: 2.5999999
+  Multiplier: 2.60000014
 - StartTime: 105790
-  Multiplier: 0.600000024
+  Multiplier: 0.599999964
 - StartTime: 105870
-  Multiplier: 2.5999999
+  Multiplier: 2.60000014
 - StartTime: 105890
-  Multiplier: 0.600000024
+  Multiplier: 0.599999964
 - StartTime: 105970
-  Multiplier: 2.5999999
+  Multiplier: 2.60000014
 - StartTime: 106010
-  Multiplier: 0.600000024
+  Multiplier: 0.599999964
 - StartTime: 106170
   Multiplier: 9.10000038
 - StartTime: 106175
@@ -20052,135 +25382,135 @@ SliderVelocities:
 - StartTime: 106770
   Multiplier: 2.29999995
 - StartTime: 106795
-  Multiplier: 0.569999993
+  Multiplier: 0.566666663
 - StartTime: 106870
   Multiplier: 1.14999998
 - StartTime: 106920
-  Multiplier: 0.280000001
+  Multiplier: 0.283333331
 - StartTime: 107070
   Multiplier: 2.29999995
 - StartTime: 107095
-  Multiplier: 0.569999993
+  Multiplier: 0.566666663
 - StartTime: 107170
   Multiplier: 1.14999998
 - StartTime: 107220
-  Multiplier: 0.280000001
+  Multiplier: 0.283333331
 - StartTime: 107370
   Multiplier: 1.14999998
 - StartTime: 107420
-  Multiplier: 0.280000001
+  Multiplier: 0.283333331
 - StartTime: 107570
   Multiplier: 2.29999995
 - StartTime: 107595
-  Multiplier: 0.569999993
+  Multiplier: 0.566666663
 - StartTime: 107670
   Multiplier: 1.14999998
 - StartTime: 107720
-  Multiplier: 0.280000001
+  Multiplier: 0.283333331
 - StartTime: 107870
   Multiplier: 2.29999995
 - StartTime: 107895
-  Multiplier: 0.569999993
+  Multiplier: 0.566666663
 - StartTime: 107970
   Multiplier: 1.14999998
 - StartTime: 108020
-  Multiplier: 0.280000001
+  Multiplier: 0.283333331
 - StartTime: 108170
   Multiplier: 1.14999998
 - StartTime: 108220
-  Multiplier: 0.280000001
+  Multiplier: 0.283333331
 - StartTime: 108370
   Multiplier: 2.29999995
 - StartTime: 108395
-  Multiplier: 0.569999993
+  Multiplier: 0.566666663
 - StartTime: 108470
   Multiplier: 1.14999998
 - StartTime: 108520
-  Multiplier: 0.280000001
+  Multiplier: 0.283333331
 - StartTime: 108670
   Multiplier: 2.29999995
 - StartTime: 108695
-  Multiplier: 0.569999993
+  Multiplier: 0.566666663
 - StartTime: 108770
   Multiplier: 1.14999998
 - StartTime: 108820
-  Multiplier: 0.280000001
+  Multiplier: 0.283333331
 - StartTime: 108970
   Multiplier: 1
 - StartTime: 109019
-  Multiplier: 0.370000005
+  Multiplier: 0.366666675
 - StartTime: 109169
   Multiplier: 2
 - StartTime: 109194
-  Multiplier: 0.730000019
+  Multiplier: 0.733333349
 - StartTime: 109269
   Multiplier: 1
 - StartTime: 109319
-  Multiplier: 0.370000005
+  Multiplier: 0.366666675
 - StartTime: 109469
   Multiplier: 2
 - StartTime: 109494
-  Multiplier: 0.730000019
+  Multiplier: 0.733333349
 - StartTime: 109569
   Multiplier: 1
 - StartTime: 109619
-  Multiplier: 0.370000005
+  Multiplier: 0.366666675
 - StartTime: 109769
   Multiplier: 1.10000002
 - StartTime: 109819
-  Multiplier: 0.370000005
+  Multiplier: 0.366666675
 - StartTime: 109969
   Multiplier: 2.20000005
 - StartTime: 109994
-  Multiplier: 0.730000019
+  Multiplier: 0.733333349
 - StartTime: 110069
   Multiplier: 1.10000002
 - StartTime: 110119
-  Multiplier: 0.370000005
+  Multiplier: 0.366666675
 - StartTime: 110269
   Multiplier: 2.20000005
 - StartTime: 110294
-  Multiplier: 0.730000019
+  Multiplier: 0.733333349
 - StartTime: 110369
   Multiplier: 1.10000002
 - StartTime: 110419
-  Multiplier: 0.370000005
+  Multiplier: 0.366666675
 - StartTime: 110569
   Multiplier: 1
 - StartTime: 110619
-  Multiplier: 0.469999999
+  Multiplier: 0.466666639
 - StartTime: 110769
   Multiplier: 2
 - StartTime: 110794
-  Multiplier: 0.930000007
+  Multiplier: 0.933333278
 - StartTime: 110869
   Multiplier: 2
 - StartTime: 110894
-  Multiplier: 0.930000007
+  Multiplier: 0.933333278
 - StartTime: 110969
   Multiplier: 4.5
 - StartTime: 110979
-  Multiplier: 0.889999986
+  Multiplier: 0.888888896
 - StartTime: 111069
   Multiplier: 2.25
 - StartTime: 111089
-  Multiplier: 0.439999998
+  Multiplier: 0.444444448
 - StartTime: 111269
   Multiplier: 4.5
 - StartTime: 111279
-  Multiplier: 0.889999986
+  Multiplier: 0.888888896
 - StartTime: 111369
   Multiplier: 4.5
 - StartTime: 111379
-  Multiplier: 0.889999986
+  Multiplier: 0.888888896
 - StartTime: 111469
   Multiplier: 2.25
 - StartTime: 111489
-  Multiplier: 0.439999998
+  Multiplier: 0.444444448
 - StartTime: 111669
   Multiplier: 4.5
 - StartTime: 111679
-  Multiplier: 0.889999986
+  Multiplier: 0.888888896
 - StartTime: 111769
   Multiplier: 10
 - StartTime: 112170
@@ -20192,1653 +25522,1653 @@ SliderVelocities:
 - StartTime: 113069
   Multiplier: 0.5
 - StartTime: 113320
-  Multiplier: 0.50999999
+  Multiplier: 0.506999969
 - StartTime: 113571
-  Multiplier: 0.50999999
+  Multiplier: 0.513999999
 - StartTime: 113822
-  Multiplier: 0.519999981
+  Multiplier: 0.520999968
 - StartTime: 114073
-  Multiplier: 0.529999971
+  Multiplier: 0.527999997
 - StartTime: 114324
-  Multiplier: 0.529999971
+  Multiplier: 0.534999967
 - StartTime: 114575
-  Multiplier: 0.540000021
+  Multiplier: 0.541999996
 - StartTime: 114826
-  Multiplier: 0.550000012
+  Multiplier: 0.548999965
 - StartTime: 115077
-  Multiplier: 0.560000002
+  Multiplier: 0.555999994
 - StartTime: 115328
-  Multiplier: 0.560000002
+  Multiplier: 0.563000023
 - StartTime: 115579
   Multiplier: 0.569999993
 - StartTime: 115830
-  Multiplier: 0.579999983
+  Multiplier: 0.577000022
 - StartTime: 116081
-  Multiplier: 0.579999983
+  Multiplier: 0.583999991
 - StartTime: 116332
-  Multiplier: 0.589999974
+  Multiplier: 0.590999961
 - StartTime: 116583
-  Multiplier: 0.600000024
+  Multiplier: 0.59799999
 - StartTime: 116834
-  Multiplier: 0.610000014
+  Multiplier: 0.604999959
 - StartTime: 117085
-  Multiplier: 0.610000014
+  Multiplier: 0.611999989
 - StartTime: 117336
-  Multiplier: 0.620000005
+  Multiplier: 0.619000018
 - StartTime: 117587
-  Multiplier: 0.629999995
+  Multiplier: 0.625999987
 - StartTime: 117838
-  Multiplier: 0.629999995
+  Multiplier: 0.632999957
 - StartTime: 118089
   Multiplier: 0.639999986
 - StartTime: 118340
-  Multiplier: 0.649999976
+  Multiplier: 0.646999955
 - StartTime: 118591
-  Multiplier: 0.649999976
+  Multiplier: 0.653999984
 - StartTime: 118842
-  Multiplier: 0.660000026
+  Multiplier: 0.660999954
 - StartTime: 119093
-  Multiplier: 0.670000017
+  Multiplier: 0.668000042
 - StartTime: 119344
-  Multiplier: 0.670000017
+  Multiplier: 0.675000012
 - StartTime: 119595
-  Multiplier: 0.680000007
+  Multiplier: 0.682000041
 - StartTime: 119846
-  Multiplier: 0.689999998
+  Multiplier: 0.68900001
 - StartTime: 120097
-  Multiplier: 0.699999988
+  Multiplier: 0.69599998
 - StartTime: 120348
-  Multiplier: 0.699999988
+  Multiplier: 0.703000009
 - StartTime: 120599
   Multiplier: 0.709999979
 - StartTime: 120850
-  Multiplier: 0.720000029
+  Multiplier: 0.717000008
 - StartTime: 121101
-  Multiplier: 0.720000029
+  Multiplier: 0.723999977
 - StartTime: 121352
-  Multiplier: 0.730000019
+  Multiplier: 0.731000006
 - StartTime: 121603
-  Multiplier: 0.74000001
+  Multiplier: 0.737999976
 - StartTime: 121854
-  Multiplier: 0.74000001
+  Multiplier: 0.744999945
 - StartTime: 122105
-  Multiplier: 0.75
+  Multiplier: 0.751999974
 - StartTime: 122356
-  Multiplier: 0.75999999
+  Multiplier: 0.759000003
 - StartTime: 122607
-  Multiplier: 0.769999981
+  Multiplier: 0.765999973
 - StartTime: 122858
-  Multiplier: 0.769999981
+  Multiplier: 0.773000002
 - StartTime: 123109
-  Multiplier: 0.779999971
+  Multiplier: 0.780000031
 - StartTime: 123360
-  Multiplier: 0.790000021
+  Multiplier: 0.787
 - StartTime: 123611
-  Multiplier: 0.790000021
+  Multiplier: 0.79399997
 - StartTime: 123862
-  Multiplier: 0.800000012
+  Multiplier: 0.800999999
 - StartTime: 124113
-  Multiplier: 0.810000002
+  Multiplier: 0.808000028
 - StartTime: 124364
-  Multiplier: 0.810000002
+  Multiplier: 0.814999998
 - StartTime: 124615
-  Multiplier: 0.819999993
+  Multiplier: 0.821999967
 - StartTime: 124866
-  Multiplier: 0.829999983
+  Multiplier: 0.828999996
 - StartTime: 125117
-  Multiplier: 0.839999974
+  Multiplier: 0.835999966
 - StartTime: 125368
-  Multiplier: 0.839999974
+  Multiplier: 0.842999995
 - StartTime: 125619
   Multiplier: 0.850000024
 - StartTime: 125870
-  Multiplier: 0.860000014
+  Multiplier: 0.856999993
 - StartTime: 126121
-  Multiplier: 0.860000014
+  Multiplier: 0.864000022
 - StartTime: 126372
-  Multiplier: 0.870000005
+  Multiplier: 0.870999992
 - StartTime: 126623
-  Multiplier: 0.879999995
+  Multiplier: 0.877999961
 - StartTime: 126874
-  Multiplier: 0.879999995
+  Multiplier: 0.88500005
 - StartTime: 127125
-  Multiplier: 0.889999986
+  Multiplier: 0.89200002
 - StartTime: 127376
-  Multiplier: 0.899999976
+  Multiplier: 0.898999989
 - StartTime: 127627
-  Multiplier: 0.910000026
+  Multiplier: 0.906000018
 - StartTime: 127878
-  Multiplier: 0.910000026
+  Multiplier: 0.913000047
 - StartTime: 128129
-  Multiplier: 0.920000017
+  Multiplier: 0.919999957
 - StartTime: 128380
-  Multiplier: 0.930000007
+  Multiplier: 0.927000046
 - StartTime: 128631
-  Multiplier: 0.930000007
+  Multiplier: 0.933999956
 - StartTime: 128882
-  Multiplier: 0.939999998
+  Multiplier: 0.940999985
 - StartTime: 129133
-  Multiplier: 0.949999988
+  Multiplier: 0.948000014
 - StartTime: 129384
-  Multiplier: 0.949999988
+  Multiplier: 0.954999983
 - StartTime: 129635
-  Multiplier: 0.959999979
+  Multiplier: 0.962000012
 - StartTime: 129886
-  Multiplier: 0.970000029
+  Multiplier: 0.969000041
 - StartTime: 130137
-  Multiplier: 0.980000019
+  Multiplier: 0.976000011
 - StartTime: 130388
-  Multiplier: 0.980000019
+  Multiplier: 0.98299998
 - StartTime: 130639
   Multiplier: 0.99000001
 - StartTime: 130890
-  Multiplier: 1
+  Multiplier: 0.996999979
 - StartTime: 131141
-  Multiplier: 1
+  Multiplier: 1.00399995
 - StartTime: 131392
-  Multiplier: 1.00999999
+  Multiplier: 1.01099992
 - StartTime: 131643
-  Multiplier: 1.01999998
+  Multiplier: 1.01800001
 - StartTime: 131894
-  Multiplier: 1.02999997
+  Multiplier: 1.02499998
 - StartTime: 132145
-  Multiplier: 1.02999997
+  Multiplier: 1.03200006
 - StartTime: 132396
-  Multiplier: 1.03999996
+  Multiplier: 1.03900003
 - StartTime: 132647
-  Multiplier: 1.04999995
+  Multiplier: 1.046
 - StartTime: 132898
-  Multiplier: 1.04999995
+  Multiplier: 1.05299997
 - StartTime: 133149
   Multiplier: 1.05999994
 - StartTime: 133400
-  Multiplier: 1.07000005
+  Multiplier: 1.06700003
 - StartTime: 133651
-  Multiplier: 1.07000005
+  Multiplier: 1.074
 - StartTime: 133902
-  Multiplier: 1.08000004
+  Multiplier: 1.08100009
 - StartTime: 134153
-  Multiplier: 1.09000003
+  Multiplier: 1.08799994
 - StartTime: 134404
-  Multiplier: 1.09000003
+  Multiplier: 1.09500003
 - StartTime: 134655
-  Multiplier: 1.10000002
+  Multiplier: 1.102
 - StartTime: 134906
-  Multiplier: 1.11000001
+  Multiplier: 1.10899997
 - StartTime: 135157
-  Multiplier: 1.12
+  Multiplier: 1.11599994
 - StartTime: 135408
-  Multiplier: 1.12
+  Multiplier: 1.12300003
 - StartTime: 135659
   Multiplier: 1.13
 - StartTime: 135910
-  Multiplier: 1.13999999
+  Multiplier: 1.13700008
 - StartTime: 136161
-  Multiplier: 1.13999999
+  Multiplier: 1.14399993
 - StartTime: 136412
-  Multiplier: 1.14999998
+  Multiplier: 1.15100002
 - StartTime: 136663
-  Multiplier: 1.15999997
+  Multiplier: 1.15799999
 - StartTime: 136914
-  Multiplier: 1.16999996
+  Multiplier: 1.16500008
 - StartTime: 137165
-  Multiplier: 1.16999996
+  Multiplier: 1.17199993
 - StartTime: 137416
-  Multiplier: 1.17999995
+  Multiplier: 1.17900002
 - StartTime: 137667
-  Multiplier: 1.19000006
+  Multiplier: 1.18599999
 - StartTime: 137918
-  Multiplier: 1.19000006
+  Multiplier: 1.19299996
 - StartTime: 138969
-  Multiplier: 1.20000005
+  Multiplier: 1.19999993
 - StartTime: 162169
   Multiplier: 10
 - StartTime: 162190
-  Multiplier: 0.219999999
+  Multiplier: 0.217391297
 - StartTime: 162435
   Multiplier: 10
 - StartTime: 162445
-  Multiplier: 0.219999999
+  Multiplier: 0.217391297
 - StartTime: 162569
   Multiplier: 10
 - StartTime: 162585
-  Multiplier: 0.219999999
+  Multiplier: 0.217391297
 - StartTime: 162769
   Multiplier: 10
 - StartTime: 162774
-  Multiplier: 0.219999999
+  Multiplier: 0.217391297
 - StartTime: 162835
   Multiplier: 10
 - StartTime: 162837
-  Multiplier: 0.219999999
+  Multiplier: 0.217391297
 - StartTime: 162869
   Multiplier: 10
 - StartTime: 162873
-  Multiplier: 0.219999999
+  Multiplier: 0.217391297
 - StartTime: 162919
   Multiplier: 10
 - StartTime: 162923
-  Multiplier: 0.219999999
+  Multiplier: 0.217391297
 - StartTime: 162969
   Multiplier: 10
 - StartTime: 162979
-  Multiplier: 0.219999999
+  Multiplier: 0.217391297
 - StartTime: 163102
   Multiplier: 10
 - StartTime: 163112
-  Multiplier: 0.219999999
+  Multiplier: 0.217391297
 - StartTime: 163235
   Multiplier: 10
 - StartTime: 163245
-  Multiplier: 0.219999999
+  Multiplier: 0.217391297
 - StartTime: 163369
   Multiplier: 10
 - StartTime: 163390
-  Multiplier: 0.219999999
+  Multiplier: 0.217391297
 - StartTime: 163635
   Multiplier: 10
 - StartTime: 163645
-  Multiplier: 0.219999999
+  Multiplier: 0.217391297
 - StartTime: 163769
   Multiplier: 1
 - StartTime: 163777
-  Multiplier: 1
+  Multiplier: 1.005
 - StartTime: 163785
   Multiplier: 1.00999999
 - StartTime: 163793
-  Multiplier: 1.00999999
+  Multiplier: 1.01499999
 - StartTime: 163801
   Multiplier: 1.01999998
 - StartTime: 163809
-  Multiplier: 1.02999997
+  Multiplier: 1.02499998
 - StartTime: 163817
   Multiplier: 1.02999997
 - StartTime: 163825
-  Multiplier: 1.03999996
+  Multiplier: 1.03500009
 - StartTime: 163833
   Multiplier: 1.03999996
 - StartTime: 163841
-  Multiplier: 1.03999996
+  Multiplier: 1.04499996
 - StartTime: 163849
   Multiplier: 1.04999995
 - StartTime: 163857
-  Multiplier: 1.05999994
+  Multiplier: 1.05500007
 - StartTime: 163865
   Multiplier: 1.05999994
 - StartTime: 163873
-  Multiplier: 1.07000005
+  Multiplier: 1.06500006
 - StartTime: 163881
-  Multiplier: 1.07000005
+  Multiplier: 1.06999993
 - StartTime: 163889
-  Multiplier: 1.08000004
+  Multiplier: 1.07500005
 - StartTime: 163897
   Multiplier: 1.08000004
 - StartTime: 163905
-  Multiplier: 1.08000004
+  Multiplier: 1.08499992
 - StartTime: 163913
   Multiplier: 1.09000003
 - StartTime: 163921
-  Multiplier: 1.09000003
+  Multiplier: 1.09500003
 - StartTime: 163929
   Multiplier: 1.10000002
 - StartTime: 163937
-  Multiplier: 1.11000001
+  Multiplier: 1.10500002
 - StartTime: 163945
   Multiplier: 1.11000001
 - StartTime: 163953
-  Multiplier: 1.12
+  Multiplier: 1.11500001
 - StartTime: 163961
   Multiplier: 1.12
 - StartTime: 163969
-  Multiplier: 1.13
+  Multiplier: 1.125
 - StartTime: 163977
   Multiplier: 1.13
 - StartTime: 163985
-  Multiplier: 1.13999999
+  Multiplier: 1.13499999
 - StartTime: 163993
   Multiplier: 1.13999999
 - StartTime: 164001
-  Multiplier: 1.14999998
+  Multiplier: 1.14499998
 - StartTime: 164009
   Multiplier: 1.14999998
 - StartTime: 164017
-  Multiplier: 1.15999997
+  Multiplier: 1.15499997
 - StartTime: 164025
-  Multiplier: 1.15999997
+  Multiplier: 1.16000009
 - StartTime: 164033
-  Multiplier: 1.16999996
+  Multiplier: 1.16500008
 - StartTime: 164041
   Multiplier: 1.16999996
 - StartTime: 164049
-  Multiplier: 1.16999996
+  Multiplier: 1.17499995
 - StartTime: 164057
   Multiplier: 1.17999995
 - StartTime: 164065
-  Multiplier: 1.19000006
+  Multiplier: 1.18500006
 - StartTime: 164073
-  Multiplier: 1.19000006
+  Multiplier: 1.18999994
 - StartTime: 164081
-  Multiplier: 1.20000005
+  Multiplier: 1.19500005
 - StartTime: 164089
-  Multiplier: 1.20000005
+  Multiplier: 1.19999993
 - StartTime: 164097
-  Multiplier: 1.21000004
+  Multiplier: 1.20500004
 - StartTime: 164105
-  Multiplier: 1.21000004
+  Multiplier: 1.20999992
 - StartTime: 164113
-  Multiplier: 1.22000003
+  Multiplier: 1.21500003
 - StartTime: 164121
-  Multiplier: 1.22000003
+  Multiplier: 1.21999991
 - StartTime: 164129
-  Multiplier: 1.23000002
+  Multiplier: 1.22500002
 - StartTime: 164137
   Multiplier: 1.23000002
 - StartTime: 164145
-  Multiplier: 1.24000001
+  Multiplier: 1.23500001
 - StartTime: 164153
   Multiplier: 1.24000001
 - StartTime: 164161
-  Multiplier: 1.25
+  Multiplier: 1.245
 - StartTime: 164169
   Multiplier: 1.25
 - StartTime: 164177
-  Multiplier: 1.25
+  Multiplier: 1.255
 - StartTime: 164185
   Multiplier: 1.25999999
 - StartTime: 164193
-  Multiplier: 1.26999998
+  Multiplier: 1.26499999
 - StartTime: 164201
   Multiplier: 1.26999998
 - StartTime: 164209
-  Multiplier: 1.26999998
+  Multiplier: 1.27499998
 - StartTime: 164217
   Multiplier: 1.27999997
 - StartTime: 164225
-  Multiplier: 1.27999997
+  Multiplier: 1.28499997
 - StartTime: 164233
   Multiplier: 1.28999996
 - StartTime: 164241
-  Multiplier: 1.29999995
+  Multiplier: 1.29499996
 - StartTime: 164249
   Multiplier: 1.29999995
 - StartTime: 164257
-  Multiplier: 1.30999994
+  Multiplier: 1.30500007
 - StartTime: 164265
-  Multiplier: 1.30999994
+  Multiplier: 1.31000006
 - StartTime: 164273
-  Multiplier: 1.32000005
+  Multiplier: 1.31500006
 - StartTime: 164281
   Multiplier: 1.32000005
 - StartTime: 164289
-  Multiplier: 1.33000004
+  Multiplier: 1.32500005
 - StartTime: 164297
-  Multiplier: 1.33000004
+  Multiplier: 1.32999992
 - StartTime: 164305
-  Multiplier: 1.34000003
+  Multiplier: 1.33500004
 - StartTime: 164313
-  Multiplier: 1.34000003
+  Multiplier: 1.33999991
 - StartTime: 164321
-  Multiplier: 1.35000002
+  Multiplier: 1.34500003
 - StartTime: 164329
   Multiplier: 1.35000002
 - StartTime: 164337
-  Multiplier: 1.36000001
+  Multiplier: 1.35500002
 - StartTime: 164345
   Multiplier: 1.36000001
 - StartTime: 164353
-  Multiplier: 1.37
+  Multiplier: 1.36500001
 - StartTime: 164361
   Multiplier: 1.37
 - StartTime: 164369
-  Multiplier: 1.37
+  Multiplier: 1.375
 - StartTime: 164377
   Multiplier: 1.38
 - StartTime: 164385
-  Multiplier: 1.38999999
+  Multiplier: 1.38499999
 - StartTime: 164393
   Multiplier: 1.38999999
 - StartTime: 164401
-  Multiplier: 1.39999998
+  Multiplier: 1.3950001
 - StartTime: 164409
   Multiplier: 1.39999998
 - StartTime: 164417
-  Multiplier: 1.40999997
+  Multiplier: 1.40499997
 - StartTime: 164425
   Multiplier: 1.40999997
 - StartTime: 164433
-  Multiplier: 1.40999997
+  Multiplier: 1.41499996
 - StartTime: 164441
   Multiplier: 1.41999996
 - StartTime: 164449
-  Multiplier: 1.41999996
+  Multiplier: 1.42500007
 - StartTime: 164457
-  Multiplier: 1.42999995
+  Multiplier: 1.43000007
 - StartTime: 164465
-  Multiplier: 1.44000006
+  Multiplier: 1.43500006
 - StartTime: 164473
   Multiplier: 1.44000006
 - StartTime: 164481
-  Multiplier: 1.44000006
+  Multiplier: 1.44499993
 - StartTime: 164489
   Multiplier: 1.45000005
 - StartTime: 164497
-  Multiplier: 1.46000004
+  Multiplier: 1.45499992
 - StartTime: 164505
   Multiplier: 1.46000004
 - StartTime: 164513
-  Multiplier: 1.47000003
+  Multiplier: 1.46500003
 - StartTime: 164521
-  Multiplier: 1.47000003
+  Multiplier: 1.46999991
 - StartTime: 164529
-  Multiplier: 1.48000002
+  Multiplier: 1.47500002
 - StartTime: 164537
   Multiplier: 1.48000002
 - StartTime: 164545
-  Multiplier: 1.49000001
+  Multiplier: 1.48500001
 - StartTime: 164553
-  Multiplier: 1.49000001
+  Multiplier: 1.48999989
 - StartTime: 164561
-  Multiplier: 1.5
+  Multiplier: 1.495
 - StartTime: 164569
   Multiplier: 1.5
 - StartTime: 164577.672
-  Multiplier: 1.50999999
+  Multiplier: 1.51416659
 - StartTime: 164586.328
-  Multiplier: 1.52999997
+  Multiplier: 1.52833331
 - StartTime: 164595
-  Multiplier: 1.53999996
+  Multiplier: 1.54250002
 - StartTime: 164603.672
-  Multiplier: 1.55999994
+  Multiplier: 1.55666661
 - StartTime: 164612.328
-  Multiplier: 1.57000005
+  Multiplier: 1.57083333
 - StartTime: 164621
-  Multiplier: 1.58000004
+  Multiplier: 1.58499992
 - StartTime: 164629.672
-  Multiplier: 1.60000002
+  Multiplier: 1.59916663
 - StartTime: 164638.328
-  Multiplier: 1.61000001
+  Multiplier: 1.61333334
 - StartTime: 164647
-  Multiplier: 1.63
+  Multiplier: 1.62750006
 - StartTime: 164655.672
-  Multiplier: 1.63999999
+  Multiplier: 1.64166677
 - StartTime: 164664.328
-  Multiplier: 1.65999997
+  Multiplier: 1.65583336
 - StartTime: 164673
   Multiplier: 1.66999996
 - StartTime: 164681.672
-  Multiplier: 1.67999995
+  Multiplier: 1.68416667
 - StartTime: 164690.328
-  Multiplier: 1.70000005
+  Multiplier: 1.69833338
 - StartTime: 164699
-  Multiplier: 1.71000004
+  Multiplier: 1.71249998
 - StartTime: 164707.672
-  Multiplier: 1.73000002
+  Multiplier: 1.72666669
 - StartTime: 164716.328
-  Multiplier: 1.74000001
+  Multiplier: 1.7408334
 - StartTime: 164725
-  Multiplier: 1.75999999
+  Multiplier: 1.755
 - StartTime: 164733.672
-  Multiplier: 1.76999998
+  Multiplier: 1.76916659
 - StartTime: 164742.328
-  Multiplier: 1.77999997
+  Multiplier: 1.7833333
 - StartTime: 164751
-  Multiplier: 1.79999995
+  Multiplier: 1.79750001
 - StartTime: 164759.672
-  Multiplier: 1.80999994
+  Multiplier: 1.81166673
 - StartTime: 164768.328
-  Multiplier: 1.83000004
+  Multiplier: 1.82583332
 - StartTime: 164777
-  Multiplier: 1.84000003
+  Multiplier: 1.83999991
 - StartTime: 164785.672
-  Multiplier: 1.85000002
+  Multiplier: 1.85416675
 - StartTime: 164794.328
-  Multiplier: 1.87
+  Multiplier: 1.86833334
 - StartTime: 164803
-  Multiplier: 1.88
+  Multiplier: 1.88250005
 - StartTime: 164811.672
-  Multiplier: 1.89999998
+  Multiplier: 1.89666665
 - StartTime: 164820.328
-  Multiplier: 1.90999997
+  Multiplier: 1.91083336
 - StartTime: 164829
-  Multiplier: 1.92999995
+  Multiplier: 1.92500007
 - StartTime: 164837.672
-  Multiplier: 1.94000006
+  Multiplier: 1.93916667
 - StartTime: 164846.328
-  Multiplier: 1.95000005
+  Multiplier: 1.95333338
 - StartTime: 164855
-  Multiplier: 1.97000003
+  Multiplier: 1.96750009
 - StartTime: 164863.672
-  Multiplier: 1.98000002
+  Multiplier: 1.98166668
 - StartTime: 164872.328
-  Multiplier: 2
+  Multiplier: 1.99583328
 - StartTime: 164881
   Multiplier: 2.00999999
 - StartTime: 164889.672
-  Multiplier: 2.01999998
+  Multiplier: 2.02416658
 - StartTime: 164898.328
-  Multiplier: 2.03999996
+  Multiplier: 2.03833342
 - StartTime: 164907
-  Multiplier: 2.04999995
+  Multiplier: 2.05250001
 - StartTime: 164915.672
-  Multiplier: 2.06999993
+  Multiplier: 2.0666666
 - StartTime: 164924.328
-  Multiplier: 2.07999992
+  Multiplier: 2.0808332
 - StartTime: 164933
-  Multiplier: 2.0999999
+  Multiplier: 2.09500003
 - StartTime: 164941.672
-  Multiplier: 2.1099999
+  Multiplier: 2.10916662
 - StartTime: 164950.328
-  Multiplier: 2.11999989
+  Multiplier: 2.12333345
 - StartTime: 164959
-  Multiplier: 2.1400001
+  Multiplier: 2.13750005
 - StartTime: 164967.672
-  Multiplier: 2.1500001
+  Multiplier: 2.15166664
 - StartTime: 164976.328
-  Multiplier: 2.17000008
+  Multiplier: 2.16583323
 - StartTime: 164985
   Multiplier: 2.18000007
 - StartTime: 164993.672
-  Multiplier: 2.19000006
+  Multiplier: 2.19416666
 - StartTime: 165002.328
-  Multiplier: 2.21000004
+  Multiplier: 2.20833325
 - StartTime: 165011
-  Multiplier: 2.22000003
+  Multiplier: 2.22249985
 - StartTime: 165019.672
-  Multiplier: 2.24000001
+  Multiplier: 2.23666668
 - StartTime: 165028.328
-  Multiplier: 2.25
+  Multiplier: 2.25083327
 - StartTime: 165037
-  Multiplier: 2.26999998
+  Multiplier: 2.26499987
 - StartTime: 165045.672
-  Multiplier: 2.27999997
+  Multiplier: 2.2791667
 - StartTime: 165054.328
-  Multiplier: 2.28999996
+  Multiplier: 2.29333329
 - StartTime: 165063
-  Multiplier: 2.30999994
+  Multiplier: 2.30750012
 - StartTime: 165071.672
-  Multiplier: 2.31999993
+  Multiplier: 2.32166672
 - StartTime: 165080.328
-  Multiplier: 2.33999991
+  Multiplier: 2.33583331
 - StartTime: 165089
   Multiplier: 2.3499999
 - StartTime: 165097.672
-  Multiplier: 2.3599999
+  Multiplier: 2.36416674
 - StartTime: 165106.328
-  Multiplier: 2.38000011
+  Multiplier: 2.37833333
 - StartTime: 165115
-  Multiplier: 2.3900001
+  Multiplier: 2.39249992
 - StartTime: 165123.672
-  Multiplier: 2.41000009
+  Multiplier: 2.40666676
 - StartTime: 165132.328
-  Multiplier: 2.42000008
+  Multiplier: 2.42083335
 - StartTime: 165141
-  Multiplier: 2.44000006
+  Multiplier: 2.43500018
 - StartTime: 165149.672
-  Multiplier: 2.45000005
+  Multiplier: 2.44916654
 - StartTime: 165158.328
-  Multiplier: 2.46000004
+  Multiplier: 2.46333337
 - StartTime: 165167
-  Multiplier: 2.48000002
+  Multiplier: 2.47749996
 - StartTime: 165175.672
-  Multiplier: 2.49000001
+  Multiplier: 2.49166679
 - StartTime: 165184.328
-  Multiplier: 2.50999999
+  Multiplier: 2.50583339
 - StartTime: 165193
   Multiplier: 2.51999998
 - StartTime: 165201.672
-  Multiplier: 2.52999997
+  Multiplier: 2.53416657
 - StartTime: 165210.328
-  Multiplier: 2.54999995
+  Multiplier: 2.54833341
 - StartTime: 165219
-  Multiplier: 2.55999994
+  Multiplier: 2.5625
 - StartTime: 165227.672
-  Multiplier: 2.57999992
+  Multiplier: 2.57666659
 - StartTime: 165236.328
-  Multiplier: 2.58999991
+  Multiplier: 2.59083343
 - StartTime: 165245
-  Multiplier: 2.6099999
+  Multiplier: 2.60500002
 - StartTime: 165253.672
-  Multiplier: 2.61999989
+  Multiplier: 2.61916661
 - StartTime: 165262.328
-  Multiplier: 2.63000011
+  Multiplier: 2.63333344
 - StartTime: 165271
-  Multiplier: 2.6500001
+  Multiplier: 2.6474998
 - StartTime: 165279.672
-  Multiplier: 2.66000009
+  Multiplier: 2.66166663
 - StartTime: 165288.328
-  Multiplier: 2.68000007
+  Multiplier: 2.67583323
 - StartTime: 165297
   Multiplier: 2.69000006
 - StartTime: 165305.672
-  Multiplier: 2.70000005
+  Multiplier: 2.70416665
 - StartTime: 165314.328
-  Multiplier: 2.72000003
+  Multiplier: 2.71833324
 - StartTime: 165323
-  Multiplier: 2.73000002
+  Multiplier: 2.73250008
 - StartTime: 165331.672
-  Multiplier: 2.75
+  Multiplier: 2.74666667
 - StartTime: 165340.328
-  Multiplier: 2.75999999
+  Multiplier: 2.76083326
 - StartTime: 165349
-  Multiplier: 2.76999998
+  Multiplier: 2.77499986
 - StartTime: 165357.672
-  Multiplier: 2.78999996
+  Multiplier: 2.78916645
 - StartTime: 165366.328
-  Multiplier: 2.79999995
+  Multiplier: 2.80333352
 - StartTime: 165375
-  Multiplier: 2.81999993
+  Multiplier: 2.81749988
 - StartTime: 165383.672
-  Multiplier: 2.82999992
+  Multiplier: 2.83166671
 - StartTime: 165392.328
-  Multiplier: 2.8499999
+  Multiplier: 2.8458333
 - StartTime: 165401
-  Multiplier: 2.8599999
+  Multiplier: 2.86000013
 - StartTime: 165409.672
-  Multiplier: 2.86999989
+  Multiplier: 2.87416673
 - StartTime: 165418.328
-  Multiplier: 2.8900001
+  Multiplier: 2.88833332
 - StartTime: 165427
-  Multiplier: 2.9000001
+  Multiplier: 2.90250015
 - StartTime: 165435.672
-  Multiplier: 2.92000008
+  Multiplier: 2.91666675
 - StartTime: 165444.328
-  Multiplier: 2.93000007
+  Multiplier: 2.93083334
 - StartTime: 165453
-  Multiplier: 2.95000005
+  Multiplier: 2.94500017
 - StartTime: 165461.672
-  Multiplier: 2.96000004
+  Multiplier: 2.95916677
 - StartTime: 165470.328
-  Multiplier: 2.97000003
+  Multiplier: 2.97333336
 - StartTime: 165479
-  Multiplier: 2.99000001
+  Multiplier: 2.98749995
 - StartTime: 165487.672
-  Multiplier: 3
+  Multiplier: 3.00166655
 - StartTime: 165496.328
-  Multiplier: 3.01999998
+  Multiplier: 3.01583314
 - StartTime: 165505
   Multiplier: 3.02999997
 - StartTime: 165513.672
-  Multiplier: 3.03999996
+  Multiplier: 3.0441668
 - StartTime: 165522.328
-  Multiplier: 3.05999994
+  Multiplier: 3.0583334
 - StartTime: 165531
-  Multiplier: 3.06999993
+  Multiplier: 3.07249999
 - StartTime: 165539.672
-  Multiplier: 3.08999991
+  Multiplier: 3.08666682
 - StartTime: 165548.328
-  Multiplier: 3.0999999
+  Multiplier: 3.10083342
 - StartTime: 165557
-  Multiplier: 3.1099999
+  Multiplier: 3.11500001
 - StartTime: 165565.672
-  Multiplier: 3.13000011
+  Multiplier: 3.1291666
 - StartTime: 165574.328
-  Multiplier: 3.1400001
+  Multiplier: 3.1433332
 - StartTime: 165583
-  Multiplier: 3.16000009
+  Multiplier: 3.15750003
 - StartTime: 165591.672
-  Multiplier: 3.17000008
+  Multiplier: 3.17166662
 - StartTime: 165600.328
-  Multiplier: 3.19000006
+  Multiplier: 3.18583322
 - StartTime: 165609
   Multiplier: 3.20000005
 - StartTime: 165617.672
-  Multiplier: 3.21000004
+  Multiplier: 3.21416664
 - StartTime: 165626.328
-  Multiplier: 3.23000002
+  Multiplier: 3.22833323
 - StartTime: 165635
-  Multiplier: 3.24000001
+  Multiplier: 3.24250007
 - StartTime: 165643.672
-  Multiplier: 3.25999999
+  Multiplier: 3.25666666
 - StartTime: 165652.328
-  Multiplier: 3.26999998
+  Multiplier: 3.27083349
 - StartTime: 165661
-  Multiplier: 3.28999996
+  Multiplier: 3.28500009
 - StartTime: 165669.672
-  Multiplier: 3.29999995
+  Multiplier: 3.29916668
 - StartTime: 165678.328
-  Multiplier: 3.30999994
+  Multiplier: 3.31333351
 - StartTime: 165687
-  Multiplier: 3.32999992
+  Multiplier: 3.3275001
 - StartTime: 165695.672
-  Multiplier: 3.33999991
+  Multiplier: 3.3416667
 - StartTime: 165704.328
-  Multiplier: 3.3599999
+  Multiplier: 3.35583329
 - StartTime: 165713
-  Multiplier: 3.36999989
+  Multiplier: 3.37000012
 - StartTime: 165721.672
-  Multiplier: 3.38000011
+  Multiplier: 3.38416672
 - StartTime: 165730.328
-  Multiplier: 3.4000001
+  Multiplier: 3.39833331
 - StartTime: 165739
-  Multiplier: 3.41000009
+  Multiplier: 3.4124999
 - StartTime: 165747.672
-  Multiplier: 3.43000007
+  Multiplier: 3.42666674
 - StartTime: 165756.328
-  Multiplier: 3.44000006
+  Multiplier: 3.44083333
 - StartTime: 165765
-  Multiplier: 3.46000004
+  Multiplier: 3.45500016
 - StartTime: 165773.672
-  Multiplier: 3.47000003
+  Multiplier: 3.46916652
 - StartTime: 165782.328
-  Multiplier: 3.48000002
+  Multiplier: 3.48333335
 - StartTime: 165791
-  Multiplier: 3.5
+  Multiplier: 3.49749994
 - StartTime: 165799.672
-  Multiplier: 3.50999999
+  Multiplier: 3.51166654
 - StartTime: 165808.328
-  Multiplier: 3.52999997
+  Multiplier: 3.52583337
 - StartTime: 165817
-  Multiplier: 3.53999996
+  Multiplier: 3.5400002
 - StartTime: 165825.672
-  Multiplier: 3.54999995
+  Multiplier: 3.55416679
 - StartTime: 165834.328
-  Multiplier: 3.56999993
+  Multiplier: 3.56833339
 - StartTime: 165843
-  Multiplier: 3.57999992
+  Multiplier: 3.58250022
 - StartTime: 165851.672
-  Multiplier: 3.5999999
+  Multiplier: 3.59666657
 - StartTime: 165860.328
-  Multiplier: 3.6099999
+  Multiplier: 3.61083317
 - StartTime: 165869
-  Multiplier: 3.63000011
+  Multiplier: 3.625
 - StartTime: 165877.672
-  Multiplier: 3.6400001
+  Multiplier: 3.63916659
 - StartTime: 165886.328
-  Multiplier: 3.6500001
+  Multiplier: 3.65333343
 - StartTime: 165895
-  Multiplier: 3.67000008
+  Multiplier: 3.66750002
 - StartTime: 165903.672
-  Multiplier: 3.68000007
+  Multiplier: 3.68166661
 - StartTime: 165912.328
-  Multiplier: 3.70000005
+  Multiplier: 3.69583344
 - StartTime: 165921
   Multiplier: 3.71000004
 - StartTime: 165929.672
-  Multiplier: 3.72000003
+  Multiplier: 3.72416663
 - StartTime: 165938.328
-  Multiplier: 3.74000001
+  Multiplier: 3.73833323
 - StartTime: 165947
-  Multiplier: 3.75
+  Multiplier: 3.75250006
 - StartTime: 165955.672
-  Multiplier: 3.76999998
+  Multiplier: 3.76666689
 - StartTime: 165964.328
-  Multiplier: 3.77999997
+  Multiplier: 3.78083324
 - StartTime: 165973
-  Multiplier: 3.78999996
+  Multiplier: 3.79499984
 - StartTime: 165981.672
-  Multiplier: 3.80999994
+  Multiplier: 3.80916667
 - StartTime: 165990.328
-  Multiplier: 3.81999993
+  Multiplier: 3.82333326
 - StartTime: 165999
-  Multiplier: 3.83999991
+  Multiplier: 3.8375001
 - StartTime: 166007.672
-  Multiplier: 3.8499999
+  Multiplier: 3.85166669
 - StartTime: 166016.328
-  Multiplier: 3.86999989
+  Multiplier: 3.86583352
 - StartTime: 166025
   Multiplier: 3.88000011
 - StartTime: 166033.672
-  Multiplier: 3.8900001
+  Multiplier: 3.89416647
 - StartTime: 166042.328
-  Multiplier: 3.91000009
+  Multiplier: 3.90833354
 - StartTime: 166051
-  Multiplier: 3.92000008
+  Multiplier: 3.9224999
 - StartTime: 166059.672
-  Multiplier: 3.94000006
+  Multiplier: 3.93666673
 - StartTime: 166068.328
-  Multiplier: 3.95000005
+  Multiplier: 3.95083332
 - StartTime: 166077
-  Multiplier: 3.96000004
+  Multiplier: 3.96500015
 - StartTime: 166085.672
-  Multiplier: 3.98000002
+  Multiplier: 3.97916675
 - StartTime: 166094.328
-  Multiplier: 3.99000001
+  Multiplier: 3.99333334
 - StartTime: 166103
-  Multiplier: 4.01000023
+  Multiplier: 4.00750017
 - StartTime: 166111.672
-  Multiplier: 4.01999998
+  Multiplier: 4.02166653
 - StartTime: 166120.328
-  Multiplier: 4.03999996
+  Multiplier: 4.03583336
 - StartTime: 166129
-  Multiplier: 4.05000019
+  Multiplier: 4.04999971
 - StartTime: 166137.672
-  Multiplier: 4.05999994
+  Multiplier: 4.06416655
 - StartTime: 166146.328
-  Multiplier: 4.07999992
+  Multiplier: 4.07833338
 - StartTime: 166155
-  Multiplier: 4.09000015
+  Multiplier: 4.09249973
 - StartTime: 166163.672
-  Multiplier: 4.11000013
+  Multiplier: 4.10666656
 - StartTime: 166172.328
-  Multiplier: 4.11999989
+  Multiplier: 4.1208334
 - StartTime: 166181
-  Multiplier: 4.13999987
+  Multiplier: 4.13500023
 - StartTime: 166189.672
-  Multiplier: 4.1500001
+  Multiplier: 4.14916658
 - StartTime: 166198.328
-  Multiplier: 4.15999985
+  Multiplier: 4.16333342
 - StartTime: 166207
-  Multiplier: 4.17999983
+  Multiplier: 4.17750025
 - StartTime: 166215.672
-  Multiplier: 4.19000006
+  Multiplier: 4.1916666
 - StartTime: 166224.328
-  Multiplier: 4.21000004
+  Multiplier: 4.20583344
 - StartTime: 166233
-  Multiplier: 4.21999979
+  Multiplier: 4.22000027
 - StartTime: 166241.672
-  Multiplier: 4.23000002
+  Multiplier: 4.23416662
 - StartTime: 166250.328
-  Multiplier: 4.25
+  Multiplier: 4.24833345
 - StartTime: 166259
-  Multiplier: 4.26000023
+  Multiplier: 4.26249981
 - StartTime: 166267.672
-  Multiplier: 4.28000021
+  Multiplier: 4.27666664
 - StartTime: 166276.328
-  Multiplier: 4.28999996
+  Multiplier: 4.29083347
 - StartTime: 166285
-  Multiplier: 4.30999994
+  Multiplier: 4.30499983
 - StartTime: 166293.672
-  Multiplier: 4.32000017
+  Multiplier: 4.31916666
 - StartTime: 166302.328
-  Multiplier: 4.32999992
+  Multiplier: 4.33333349
 - StartTime: 166311
-  Multiplier: 4.3499999
+  Multiplier: 4.34750032
 - StartTime: 166319.672
-  Multiplier: 4.36000013
+  Multiplier: 4.36166668
 - StartTime: 166328.328
-  Multiplier: 4.38000011
+  Multiplier: 4.37583303
 - StartTime: 166337
   Multiplier: 4.38999987
 - StartTime: 166345.672
-  Multiplier: 4.4000001
+  Multiplier: 4.4041667
 - StartTime: 166354.328
-  Multiplier: 4.42000008
+  Multiplier: 4.41833353
 - StartTime: 166363
-  Multiplier: 4.42999983
+  Multiplier: 4.43250036
 - StartTime: 166371.672
-  Multiplier: 4.44999981
+  Multiplier: 4.44666672
 - StartTime: 166380.328
-  Multiplier: 4.46000004
+  Multiplier: 4.46083355
 - StartTime: 166389
-  Multiplier: 4.48000002
+  Multiplier: 4.4749999
 - StartTime: 166397.672
-  Multiplier: 4.48999977
+  Multiplier: 4.48916674
 - StartTime: 166406.328
-  Multiplier: 4.5
+  Multiplier: 4.50333309
 - StartTime: 166415
-  Multiplier: 4.51999998
+  Multiplier: 4.51749992
 - StartTime: 166423.672
-  Multiplier: 4.53000021
+  Multiplier: 4.53166676
 - StartTime: 166432.328
-  Multiplier: 4.55000019
+  Multiplier: 4.54583311
 - StartTime: 166441
   Multiplier: 4.55999994
 - StartTime: 166449.672
-  Multiplier: 4.57000017
+  Multiplier: 4.57416677
 - StartTime: 166458.328
-  Multiplier: 4.59000015
+  Multiplier: 4.58833313
 - StartTime: 166467
-  Multiplier: 4.5999999
+  Multiplier: 4.60249996
 - StartTime: 166475.672
-  Multiplier: 4.61999989
+  Multiplier: 4.61666679
 - StartTime: 166484.328
-  Multiplier: 4.63000011
+  Multiplier: 4.63083363
 - StartTime: 166493
-  Multiplier: 4.6500001
+  Multiplier: 4.64499998
 - StartTime: 166501.672
-  Multiplier: 4.65999985
+  Multiplier: 4.65916634
 - StartTime: 166510.328
-  Multiplier: 4.67000008
+  Multiplier: 4.67333317
 - StartTime: 166519
-  Multiplier: 4.69000006
+  Multiplier: 4.6875
 - StartTime: 166527.672
-  Multiplier: 4.69999981
+  Multiplier: 4.70166636
 - StartTime: 166536.328
-  Multiplier: 4.71999979
+  Multiplier: 4.71583319
 - StartTime: 166545
   Multiplier: 4.73000002
 - StartTime: 166553.672
-  Multiplier: 4.73999977
+  Multiplier: 4.74416637
 - StartTime: 166562.328
-  Multiplier: 4.76000023
+  Multiplier: 4.75833321
 - StartTime: 166571
-  Multiplier: 4.76999998
+  Multiplier: 4.77250004
 - StartTime: 166579.672
-  Multiplier: 4.78999996
+  Multiplier: 4.78666687
 - StartTime: 166588.328
-  Multiplier: 4.80000019
+  Multiplier: 4.80083323
 - StartTime: 166597
-  Multiplier: 4.82000017
+  Multiplier: 4.81500006
 - StartTime: 166605.672
-  Multiplier: 4.82999992
+  Multiplier: 4.82916689
 - StartTime: 166614.328
-  Multiplier: 4.84000015
+  Multiplier: 4.84333324
 - StartTime: 166623
-  Multiplier: 4.86000013
+  Multiplier: 4.85750008
 - StartTime: 166631.672
-  Multiplier: 4.86999989
+  Multiplier: 4.87166691
 - StartTime: 166640.328
-  Multiplier: 4.88999987
+  Multiplier: 4.88583374
 - StartTime: 166649
   Multiplier: 4.9000001
 - StartTime: 166657.672
-  Multiplier: 4.90999985
+  Multiplier: 4.91416645
 - StartTime: 166666.328
-  Multiplier: 4.92999983
+  Multiplier: 4.92833376
 - StartTime: 166675
-  Multiplier: 4.94000006
+  Multiplier: 4.94250011
 - StartTime: 166683.672
-  Multiplier: 4.96000004
+  Multiplier: 4.95666647
 - StartTime: 166692.328
-  Multiplier: 4.96999979
+  Multiplier: 4.9708333
 - StartTime: 166701
-  Multiplier: 4.98999977
+  Multiplier: 4.98500013
 - StartTime: 166709.672
-  Multiplier: 5
+  Multiplier: 4.99916649
 - StartTime: 166718.328
-  Multiplier: 5.01000023
+  Multiplier: 5.01333332
 - StartTime: 166727
-  Multiplier: 5.03000021
+  Multiplier: 5.02749968
 - StartTime: 166735.672
-  Multiplier: 5.03999996
+  Multiplier: 5.04166651
 - StartTime: 166744.328
-  Multiplier: 5.05999994
+  Multiplier: 5.05583334
 - StartTime: 166753
   Multiplier: 5.07000017
 - StartTime: 166761.672
-  Multiplier: 5.07999992
+  Multiplier: 5.08416653
 - StartTime: 166770.328
-  Multiplier: 5.0999999
+  Multiplier: 5.09833336
 - StartTime: 166779
-  Multiplier: 5.11000013
+  Multiplier: 5.11250019
 - StartTime: 166787.672
-  Multiplier: 5.13000011
+  Multiplier: 5.12666655
 - StartTime: 166796.328
-  Multiplier: 5.13999987
+  Multiplier: 5.14083338
 - StartTime: 166805
-  Multiplier: 5.15999985
+  Multiplier: 5.15500021
 - StartTime: 166813.672
-  Multiplier: 5.17000008
+  Multiplier: 5.16916656
 - StartTime: 166822.328
-  Multiplier: 5.17999983
+  Multiplier: 5.1833334
 - StartTime: 166831
-  Multiplier: 5.19999981
+  Multiplier: 5.19750023
 - StartTime: 166839.672
-  Multiplier: 5.21000004
+  Multiplier: 5.21166658
 - StartTime: 166848.328
-  Multiplier: 5.23000002
+  Multiplier: 5.22583342
 - StartTime: 166857
-  Multiplier: 5.23999977
+  Multiplier: 5.24000025
 - StartTime: 166865.672
-  Multiplier: 5.25
+  Multiplier: 5.2541666
 - StartTime: 166874.328
-  Multiplier: 5.26999998
+  Multiplier: 5.26833344
 - StartTime: 166883
-  Multiplier: 5.28000021
+  Multiplier: 5.28249979
 - StartTime: 166891.672
-  Multiplier: 5.30000019
+  Multiplier: 5.29666662
 - StartTime: 166900.328
-  Multiplier: 5.30999994
+  Multiplier: 5.31083298
 - StartTime: 166909
-  Multiplier: 5.32000017
+  Multiplier: 5.32499981
 - StartTime: 166917.672
-  Multiplier: 5.34000015
+  Multiplier: 5.33916664
 - StartTime: 166926.328
-  Multiplier: 5.3499999
+  Multiplier: 5.353333
 - StartTime: 166935
-  Multiplier: 5.36999989
+  Multiplier: 5.36749983
 - StartTime: 166943.672
-  Multiplier: 5.38000011
+  Multiplier: 5.38166666
 - StartTime: 166952.328
-  Multiplier: 5.4000001
+  Multiplier: 5.39583349
 - StartTime: 166961
   Multiplier: 5.40999985
 - StartTime: 166969.672
-  Multiplier: 5.42000008
+  Multiplier: 5.42416668
 - StartTime: 166978.328
-  Multiplier: 5.44000006
+  Multiplier: 5.43833303
 - StartTime: 166987
-  Multiplier: 5.44999981
+  Multiplier: 5.45250034
 - StartTime: 166995.672
-  Multiplier: 5.46999979
+  Multiplier: 5.4666667
 - StartTime: 167004.328
-  Multiplier: 5.48000002
+  Multiplier: 5.48083305
 - StartTime: 167013
-  Multiplier: 5.5
+  Multiplier: 5.49499989
 - StartTime: 167021.672
-  Multiplier: 5.51000023
+  Multiplier: 5.50916672
 - StartTime: 167030.328
-  Multiplier: 5.51999998
+  Multiplier: 5.52333355
 - StartTime: 167039
-  Multiplier: 5.53999996
+  Multiplier: 5.5374999
 - StartTime: 167047.672
-  Multiplier: 5.55000019
+  Multiplier: 5.55166626
 - StartTime: 167056.328
-  Multiplier: 5.57000017
+  Multiplier: 5.56583357
 - StartTime: 167065
-  Multiplier: 5.57999992
+  Multiplier: 5.5800004
 - StartTime: 167073.672
-  Multiplier: 5.59000015
+  Multiplier: 5.59416676
 - StartTime: 167082.328
-  Multiplier: 5.61000013
+  Multiplier: 5.60833359
 - StartTime: 167091
-  Multiplier: 5.61999989
+  Multiplier: 5.62249994
 - StartTime: 167099.672
-  Multiplier: 5.63999987
+  Multiplier: 5.63666677
 - StartTime: 167108.328
-  Multiplier: 5.6500001
+  Multiplier: 5.65083361
 - StartTime: 167117
-  Multiplier: 5.65999985
+  Multiplier: 5.66499996
 - StartTime: 167125.672
-  Multiplier: 5.67999983
+  Multiplier: 5.67916679
 - StartTime: 167134.328
-  Multiplier: 5.69000006
+  Multiplier: 5.69333315
 - StartTime: 167143
-  Multiplier: 5.71000004
+  Multiplier: 5.70749998
 - StartTime: 167151.672
-  Multiplier: 5.71999979
+  Multiplier: 5.72166681
 - StartTime: 167160.328
-  Multiplier: 5.73999977
+  Multiplier: 5.73583364
 - StartTime: 167169
   Multiplier: 5.75
 - StartTime: 167177.672
-  Multiplier: 5.76000023
+  Multiplier: 5.76416636
 - StartTime: 167186.328
-  Multiplier: 5.78000021
+  Multiplier: 5.77833319
 - StartTime: 167195
-  Multiplier: 5.78999996
+  Multiplier: 5.79250002
 - StartTime: 167203.672
-  Multiplier: 5.80999994
+  Multiplier: 5.80666685
 - StartTime: 167212.328
-  Multiplier: 5.82000017
+  Multiplier: 5.82083368
 - StartTime: 167221
-  Multiplier: 5.82999992
+  Multiplier: 5.83500004
 - StartTime: 167229.672
-  Multiplier: 5.8499999
+  Multiplier: 5.84916639
 - StartTime: 167238.328
-  Multiplier: 5.86000013
+  Multiplier: 5.86333323
 - StartTime: 167247
-  Multiplier: 5.88000011
+  Multiplier: 5.87750006
 - StartTime: 167255.672
-  Multiplier: 5.88999987
+  Multiplier: 5.89166689
 - StartTime: 167264.328
-  Multiplier: 5.90999985
+  Multiplier: 5.90583324
 - StartTime: 167273
   Multiplier: 5.92000008
 - StartTime: 167281.672
-  Multiplier: 5.92999983
+  Multiplier: 5.93416643
 - StartTime: 167290.328
-  Multiplier: 5.94999981
+  Multiplier: 5.94833326
 - StartTime: 167299
-  Multiplier: 5.96000004
+  Multiplier: 5.9625001
 - StartTime: 167307.672
-  Multiplier: 5.98000002
+  Multiplier: 5.97666645
 - StartTime: 167316.328
-  Multiplier: 5.98999977
+  Multiplier: 5.99083328
 - StartTime: 167325
-  Multiplier: 6.01000023
+  Multiplier: 6.00499964
 - StartTime: 167333.672
-  Multiplier: 6.01999998
+  Multiplier: 6.01916647
 - StartTime: 167342.328
-  Multiplier: 6.03000021
+  Multiplier: 6.03333378
 - StartTime: 167351
-  Multiplier: 6.05000019
+  Multiplier: 6.04749966
 - StartTime: 167359.672
-  Multiplier: 6.05999994
+  Multiplier: 6.06166697
 - StartTime: 167368.328
-  Multiplier: 6.07999992
+  Multiplier: 6.0758338
 - StartTime: 167377
   Multiplier: 6.09000015
 - StartTime: 167385.672
-  Multiplier: 6.0999999
+  Multiplier: 6.10416698
 - StartTime: 167394.328
-  Multiplier: 6.11999989
+  Multiplier: 6.11833334
 - StartTime: 167403
-  Multiplier: 6.13000011
+  Multiplier: 6.13249969
 - StartTime: 167411.672
-  Multiplier: 6.1500001
+  Multiplier: 6.146667
 - StartTime: 167420.328
-  Multiplier: 6.15999985
+  Multiplier: 6.16083288
 - StartTime: 167429
-  Multiplier: 6.17000008
+  Multiplier: 6.17499971
 - StartTime: 167437.672
-  Multiplier: 6.19000006
+  Multiplier: 6.18916655
 - StartTime: 167446.328
-  Multiplier: 6.19999981
+  Multiplier: 6.20333338
 - StartTime: 167455
-  Multiplier: 6.21999979
+  Multiplier: 6.21749973
 - StartTime: 167463.672
-  Multiplier: 6.23000002
+  Multiplier: 6.23166656
 - StartTime: 167472.328
-  Multiplier: 6.25
+  Multiplier: 6.2458334
 - StartTime: 167481
   Multiplier: 6.26000023
 - StartTime: 167489.672
-  Multiplier: 6.26999998
+  Multiplier: 6.27416658
 - StartTime: 167498.328
-  Multiplier: 6.28999996
+  Multiplier: 6.28833342
 - StartTime: 167507
-  Multiplier: 6.30000019
+  Multiplier: 6.30250025
 - StartTime: 167515.672
-  Multiplier: 6.32000017
+  Multiplier: 6.3166666
 - StartTime: 167524.328
-  Multiplier: 6.32999992
+  Multiplier: 6.33083344
 - StartTime: 167533
-  Multiplier: 6.3499999
+  Multiplier: 6.34500027
 - StartTime: 167541.672
-  Multiplier: 6.36000013
+  Multiplier: 6.35916662
 - StartTime: 167550.328
-  Multiplier: 6.36999989
+  Multiplier: 6.37333345
 - StartTime: 167559
-  Multiplier: 6.38999987
+  Multiplier: 6.38749981
 - StartTime: 167567.672
-  Multiplier: 6.4000001
+  Multiplier: 6.40166664
 - StartTime: 167576.328
-  Multiplier: 6.42000008
+  Multiplier: 6.415833
 - StartTime: 167585
-  Multiplier: 6.42999983
+  Multiplier: 6.43000031
 - StartTime: 167593.672
-  Multiplier: 6.44000006
+  Multiplier: 6.44416666
 - StartTime: 167602.328
-  Multiplier: 6.46000004
+  Multiplier: 6.45833349
 - StartTime: 167611
-  Multiplier: 6.46999979
+  Multiplier: 6.47249985
 - StartTime: 167619.672
-  Multiplier: 6.48999977
+  Multiplier: 6.48666668
 - StartTime: 167628.328
-  Multiplier: 6.5
+  Multiplier: 6.50083303
 - StartTime: 167637
-  Multiplier: 6.51000023
+  Multiplier: 6.51499987
 - StartTime: 167645.672
-  Multiplier: 6.53000021
+  Multiplier: 6.5291667
 - StartTime: 167654.328
-  Multiplier: 6.53999996
+  Multiplier: 6.54333353
 - StartTime: 167663
-  Multiplier: 6.55999994
+  Multiplier: 6.55749989
 - StartTime: 167671.672
-  Multiplier: 6.57000017
+  Multiplier: 6.57166672
 - StartTime: 167680.328
-  Multiplier: 6.59000015
+  Multiplier: 6.58583355
 - StartTime: 167689
   Multiplier: 6.5999999
 - StartTime: 167697.672
-  Multiplier: 6.61000013
+  Multiplier: 6.61416674
 - StartTime: 167706.328
-  Multiplier: 6.63000011
+  Multiplier: 6.62833309
 - StartTime: 167715
-  Multiplier: 6.63999987
+  Multiplier: 6.64249992
 - StartTime: 167723.672
-  Multiplier: 6.65999985
+  Multiplier: 6.65666676
 - StartTime: 167732.328
-  Multiplier: 6.67000008
+  Multiplier: 6.67083311
 - StartTime: 167741
-  Multiplier: 6.67999983
+  Multiplier: 6.68499994
 - StartTime: 167749.672
-  Multiplier: 6.69999981
+  Multiplier: 6.69916677
 - StartTime: 167758.328
-  Multiplier: 6.71000004
+  Multiplier: 6.71333313
 - StartTime: 167767
-  Multiplier: 6.73000002
+  Multiplier: 6.72749996
 - StartTime: 167775.672
-  Multiplier: 6.73999977
+  Multiplier: 6.74166679
 - StartTime: 167784.328
-  Multiplier: 6.76000023
+  Multiplier: 6.75583315
 - StartTime: 167793
   Multiplier: 6.76999998
 - StartTime: 167801.672
-  Multiplier: 6.78000021
+  Multiplier: 6.78416681
 - StartTime: 167810.328
-  Multiplier: 6.80000019
+  Multiplier: 6.79833317
 - StartTime: 167819
-  Multiplier: 6.80999994
+  Multiplier: 6.8125
 - StartTime: 167827.672
-  Multiplier: 6.82999992
+  Multiplier: 6.82666683
 - StartTime: 167836.328
-  Multiplier: 6.84000015
+  Multiplier: 6.84083319
 - StartTime: 167845
-  Multiplier: 6.86000013
+  Multiplier: 6.85500002
 - StartTime: 167853.672
-  Multiplier: 6.86999989
+  Multiplier: 6.86916637
 - StartTime: 167862.328
-  Multiplier: 6.88000011
+  Multiplier: 6.88333321
 - StartTime: 167871
-  Multiplier: 6.9000001
+  Multiplier: 6.89750004
 - StartTime: 167879.672
-  Multiplier: 6.90999985
+  Multiplier: 6.91166687
 - StartTime: 167888.328
-  Multiplier: 6.92999983
+  Multiplier: 6.92583323
 - StartTime: 167897
   Multiplier: 6.94000006
 - StartTime: 167905.672
-  Multiplier: 6.94999981
+  Multiplier: 6.95416641
 - StartTime: 167914.328
-  Multiplier: 6.96999979
+  Multiplier: 6.96833324
 - StartTime: 167923
-  Multiplier: 6.98000002
+  Multiplier: 6.98250008
 - StartTime: 167931.672
-  Multiplier: 7
+  Multiplier: 6.99666643
 - StartTime: 167940.328
-  Multiplier: 7.01000023
+  Multiplier: 7.01083326
 - StartTime: 167949
-  Multiplier: 7.03000021
+  Multiplier: 7.0250001
 - StartTime: 167957.672
-  Multiplier: 7.03999996
+  Multiplier: 7.03916645
 - StartTime: 167966.328
-  Multiplier: 7.05000019
+  Multiplier: 7.05333376
 - StartTime: 167975
-  Multiplier: 7.07000017
+  Multiplier: 7.06750011
 - StartTime: 167983.672
-  Multiplier: 7.07999992
+  Multiplier: 7.08166647
 - StartTime: 167992.328
-  Multiplier: 7.0999999
+  Multiplier: 7.0958333
 - StartTime: 168001
   Multiplier: 7.11000013
 - StartTime: 168009.672
-  Multiplier: 7.11999989
+  Multiplier: 7.12416649
 - StartTime: 168018.328
-  Multiplier: 7.13999987
+  Multiplier: 7.13833332
 - StartTime: 168027
-  Multiplier: 7.1500001
+  Multiplier: 7.15249968
 - StartTime: 168035.672
-  Multiplier: 7.17000008
+  Multiplier: 7.16666651
 - StartTime: 168044.328
-  Multiplier: 7.17999983
+  Multiplier: 7.18083334
 - StartTime: 168053
-  Multiplier: 7.19000006
+  Multiplier: 7.19500017
 - StartTime: 168061.672
-  Multiplier: 7.21000004
+  Multiplier: 7.20916653
 - StartTime: 168070.328
-  Multiplier: 7.21999979
+  Multiplier: 7.22333336
 - StartTime: 168079
-  Multiplier: 7.23999977
+  Multiplier: 7.23749971
 - StartTime: 168087.672
-  Multiplier: 7.25
+  Multiplier: 7.25166655
 - StartTime: 168096.328
-  Multiplier: 7.26999998
+  Multiplier: 7.26583338
 - StartTime: 168105
   Multiplier: 7.28000021
 - StartTime: 168113.672
-  Multiplier: 7.28999996
+  Multiplier: 7.29416656
 - StartTime: 168122.328
-  Multiplier: 7.30999994
+  Multiplier: 7.3083334
 - StartTime: 168131
-  Multiplier: 7.32000017
+  Multiplier: 7.32250023
 - StartTime: 168139.672
-  Multiplier: 7.34000015
+  Multiplier: 7.33666658
 - StartTime: 168148.328
-  Multiplier: 7.3499999
+  Multiplier: 7.35083342
 - StartTime: 168157
-  Multiplier: 7.36999989
+  Multiplier: 7.36500025
 - StartTime: 168165.672
-  Multiplier: 7.38000011
+  Multiplier: 7.37916708
 - StartTime: 168174.328
-  Multiplier: 7.38999987
+  Multiplier: 7.39333344
 - StartTime: 168183
-  Multiplier: 7.40999985
+  Multiplier: 7.40750027
 - StartTime: 168191.672
-  Multiplier: 7.42000008
+  Multiplier: 7.4216671
 - StartTime: 168200.328
-  Multiplier: 7.44000006
+  Multiplier: 7.43583345
 - StartTime: 168209
   Multiplier: 7.44999981
 - StartTime: 168217.672
-  Multiplier: 7.46000004
+  Multiplier: 7.46416664
 - StartTime: 168226.328
-  Multiplier: 7.48000002
+  Multiplier: 7.47833347
 - StartTime: 168235
-  Multiplier: 7.48999977
+  Multiplier: 7.49250031
 - StartTime: 168243.672
-  Multiplier: 7.51000023
+  Multiplier: 7.50666666
 - StartTime: 168252.328
-  Multiplier: 7.51999998
+  Multiplier: 7.52083302
 - StartTime: 168261
-  Multiplier: 7.53000021
+  Multiplier: 7.53499985
 - StartTime: 168269.672
-  Multiplier: 7.55000019
+  Multiplier: 7.54916668
 - StartTime: 168278.328
-  Multiplier: 7.55999994
+  Multiplier: 7.56333351
 - StartTime: 168287
-  Multiplier: 7.57999992
+  Multiplier: 7.57750034
 - StartTime: 168295.672
-  Multiplier: 7.59000015
+  Multiplier: 7.59166622
 - StartTime: 168304.328
-  Multiplier: 7.61000013
+  Multiplier: 7.60583305
 - StartTime: 168313
   Multiplier: 7.61999989
 - StartTime: 168321.672
-  Multiplier: 7.63000011
+  Multiplier: 7.63416672
 - StartTime: 168330.328
-  Multiplier: 7.6500001
+  Multiplier: 7.64833307
 - StartTime: 168339
-  Multiplier: 7.65999985
+  Multiplier: 7.66250038
 - StartTime: 168347.672
-  Multiplier: 7.67999983
+  Multiplier: 7.67666674
 - StartTime: 168356.328
-  Multiplier: 7.69000006
+  Multiplier: 7.69083357
 - StartTime: 168365
-  Multiplier: 7.69999981
+  Multiplier: 7.70499992
 - StartTime: 168373.672
-  Multiplier: 7.71999979
+  Multiplier: 7.71916676
 - StartTime: 168382.328
-  Multiplier: 7.73000002
+  Multiplier: 7.73333359
 - StartTime: 168391
-  Multiplier: 7.75
+  Multiplier: 7.74749994
 - StartTime: 168399.672
-  Multiplier: 7.76000023
+  Multiplier: 7.7616663
 - StartTime: 168408.328
-  Multiplier: 7.78000021
+  Multiplier: 7.77583313
 - StartTime: 168417
   Multiplier: 7.78999996
 - StartTime: 168425.672
-  Multiplier: 7.80000019
+  Multiplier: 7.80416632
 - StartTime: 168434.328
-  Multiplier: 7.82000017
+  Multiplier: 7.81833315
 - StartTime: 168443
-  Multiplier: 7.82999992
+  Multiplier: 7.83249998
 - StartTime: 168451.672
-  Multiplier: 7.8499999
+  Multiplier: 7.84666634
 - StartTime: 168460.328
-  Multiplier: 7.86000013
+  Multiplier: 7.86083364
 - StartTime: 168469
-  Multiplier: 7.86999989
+  Multiplier: 7.875
 - StartTime: 168477.672
-  Multiplier: 7.88999987
+  Multiplier: 7.88916683
 - StartTime: 168486.328
-  Multiplier: 7.9000001
+  Multiplier: 7.90333319
 - StartTime: 168495
-  Multiplier: 7.92000008
+  Multiplier: 7.9175005
 - StartTime: 168503.672
-  Multiplier: 7.92999983
+  Multiplier: 7.93166637
 - StartTime: 168512.328
-  Multiplier: 7.94999981
+  Multiplier: 7.94583321
 - StartTime: 168521
   Multiplier: 7.96000004
 - StartTime: 168529.672
-  Multiplier: 7.96999979
+  Multiplier: 7.97416687
 - StartTime: 168538.328
-  Multiplier: 7.98999977
+  Multiplier: 7.98833323
 - StartTime: 168547
-  Multiplier: 8
+  Multiplier: 8.00250053
 - StartTime: 168555.672
-  Multiplier: 8.02000046
+  Multiplier: 8.01666641
 - StartTime: 168564.328
-  Multiplier: 8.02999973
+  Multiplier: 8.03083324
 - StartTime: 168573
-  Multiplier: 8.03999996
+  Multiplier: 8.04500008
 - StartTime: 168581.672
-  Multiplier: 8.06000042
+  Multiplier: 8.05916691
 - StartTime: 168590.328
-  Multiplier: 8.06999969
+  Multiplier: 8.07333374
 - StartTime: 168599
-  Multiplier: 8.09000015
+  Multiplier: 8.08749962
 - StartTime: 168607.672
-  Multiplier: 8.10000038
+  Multiplier: 8.10166645
 - StartTime: 168616.328
-  Multiplier: 8.11999989
+  Multiplier: 8.11583328
 - StartTime: 168625
   Multiplier: 8.13000011
 - StartTime: 168633.672
-  Multiplier: 8.14000034
+  Multiplier: 8.14416599
 - StartTime: 168642.328
-  Multiplier: 8.15999985
+  Multiplier: 8.15833378
 - StartTime: 168651
-  Multiplier: 8.17000008
+  Multiplier: 8.17250061
 - StartTime: 168659.672
-  Multiplier: 8.18999958
+  Multiplier: 8.18666649
 - StartTime: 168668.328
-  Multiplier: 8.19999981
+  Multiplier: 8.20083332
 - StartTime: 168677
-  Multiplier: 8.22000027
+  Multiplier: 8.21500015
 - StartTime: 168685.672
-  Multiplier: 8.22999954
+  Multiplier: 8.22916698
 - StartTime: 168694.328
-  Multiplier: 8.23999977
+  Multiplier: 8.24333382
 - StartTime: 168703
-  Multiplier: 8.26000023
+  Multiplier: 8.25749969
 - StartTime: 168711.672
-  Multiplier: 8.27000046
+  Multiplier: 8.27166653
 - StartTime: 168720.328
-  Multiplier: 8.28999996
+  Multiplier: 8.28583336
 - StartTime: 168729
   Multiplier: 8.30000019
 - StartTime: 168737.672
-  Multiplier: 8.31000042
+  Multiplier: 8.31416702
 - StartTime: 168746.328
-  Multiplier: 8.32999992
+  Multiplier: 8.32833385
 - StartTime: 168755
-  Multiplier: 8.34000015
+  Multiplier: 8.34249973
 - StartTime: 168763.672
-  Multiplier: 8.35999966
+  Multiplier: 8.35666656
 - StartTime: 168772.328
-  Multiplier: 8.36999989
+  Multiplier: 8.3708334
 - StartTime: 168781
-  Multiplier: 8.38000011
+  Multiplier: 8.38500023
 - StartTime: 168789.672
-  Multiplier: 8.39999962
+  Multiplier: 8.39916706
 - StartTime: 168798.328
-  Multiplier: 8.40999985
+  Multiplier: 8.41333294
 - StartTime: 168807
-  Multiplier: 8.43000031
+  Multiplier: 8.42749977
 - StartTime: 168815.672
-  Multiplier: 8.43999958
+  Multiplier: 8.4416666
 - StartTime: 168824.328
-  Multiplier: 8.46000004
+  Multiplier: 8.45583344
 - StartTime: 168833
   Multiplier: 8.47000027
 - StartTime: 168841.672
-  Multiplier: 8.47999954
+  Multiplier: 8.4841671
 - StartTime: 168850.328
-  Multiplier: 8.5
+  Multiplier: 8.49833298
 - StartTime: 168859
-  Multiplier: 8.51000023
+  Multiplier: 8.51250076
 - StartTime: 168867.672
-  Multiplier: 8.52999973
+  Multiplier: 8.52666664
 - StartTime: 168876.328
-  Multiplier: 8.53999996
+  Multiplier: 8.54083347
 - StartTime: 168885
-  Multiplier: 8.56000042
+  Multiplier: 8.55500031
 - StartTime: 168893.672
-  Multiplier: 8.56999969
+  Multiplier: 8.56916618
 - StartTime: 168902.328
-  Multiplier: 8.57999992
+  Multiplier: 8.58333397
 - StartTime: 168911
-  Multiplier: 8.60000038
+  Multiplier: 8.59749985
 - StartTime: 168919.672
-  Multiplier: 8.60999966
+  Multiplier: 8.61166668
 - StartTime: 168928.328
-  Multiplier: 8.63000011
+  Multiplier: 8.62583351
 - StartTime: 168937
   Multiplier: 8.64000034
 - StartTime: 168945.672
-  Multiplier: 8.64999962
+  Multiplier: 8.65416718
 - StartTime: 168954.328
-  Multiplier: 8.67000008
+  Multiplier: 8.66833305
 - StartTime: 168963
-  Multiplier: 8.68000031
+  Multiplier: 8.68249989
 - StartTime: 168971.672
-  Multiplier: 8.69999981
+  Multiplier: 8.69666672
 - StartTime: 168980.328
-  Multiplier: 8.71000004
+  Multiplier: 8.71083355
 - StartTime: 168989
-  Multiplier: 8.72000027
+  Multiplier: 8.72500038
 - StartTime: 168997.672
-  Multiplier: 8.73999977
+  Multiplier: 8.73916721
 - StartTime: 169006.328
-  Multiplier: 8.75
+  Multiplier: 8.75333309
 - StartTime: 169015
-  Multiplier: 8.77000046
+  Multiplier: 8.76749992
 - StartTime: 169023.672
-  Multiplier: 8.77999973
+  Multiplier: 8.78166676
 - StartTime: 169032.328
-  Multiplier: 8.80000019
+  Multiplier: 8.79583359
 - StartTime: 169041
   Multiplier: 8.81000042
 - StartTime: 169049.672
-  Multiplier: 8.81999969
+  Multiplier: 8.8241663
 - StartTime: 169058.328
-  Multiplier: 8.84000015
+  Multiplier: 8.83833313
 - StartTime: 169067
-  Multiplier: 8.85000038
+  Multiplier: 8.85249996
 - StartTime: 169075.672
-  Multiplier: 8.86999989
+  Multiplier: 8.86666679
 - StartTime: 169084.328
-  Multiplier: 8.88000011
+  Multiplier: 8.88083363
 - StartTime: 169093
-  Multiplier: 8.89999962
+  Multiplier: 8.89500046
 - StartTime: 169101.672
-  Multiplier: 8.90999985
+  Multiplier: 8.90916634
 - StartTime: 169110.328
-  Multiplier: 8.92000008
+  Multiplier: 8.92333317
 - StartTime: 169119
-  Multiplier: 8.93999958
+  Multiplier: 8.9375
 - StartTime: 169127.672
-  Multiplier: 8.94999981
+  Multiplier: 8.95166683
 - StartTime: 169136.328
-  Multiplier: 8.97000027
+  Multiplier: 8.96583366
 - StartTime: 169145
   Multiplier: 8.97999954
 - StartTime: 169153.672
-  Multiplier: 8.98999977
+  Multiplier: 8.99416637
 - StartTime: 169162.328
-  Multiplier: 9.01000023
+  Multiplier: 9.00833321
 - StartTime: 169171
-  Multiplier: 9.02000046
+  Multiplier: 9.02250004
 - StartTime: 169179.672
-  Multiplier: 9.03999996
+  Multiplier: 9.03666592
 - StartTime: 169188.328
-  Multiplier: 9.05000019
+  Multiplier: 9.0508337
 - StartTime: 169197
-  Multiplier: 9.06999969
+  Multiplier: 9.06499958
 - StartTime: 169205.672
-  Multiplier: 9.07999992
+  Multiplier: 9.07916641
 - StartTime: 169214.328
-  Multiplier: 9.09000015
+  Multiplier: 9.09333324
 - StartTime: 169223
-  Multiplier: 9.10999966
+  Multiplier: 9.10750008
 - StartTime: 169231.672
-  Multiplier: 9.11999989
+  Multiplier: 9.12166691
 - StartTime: 169240.328
-  Multiplier: 9.14000034
+  Multiplier: 9.13583374
 - StartTime: 169249
   Multiplier: 9.14999962
 - StartTime: 169257.672
-  Multiplier: 9.15999985
+  Multiplier: 9.1641674
 - StartTime: 169266.328
-  Multiplier: 9.18000031
+  Multiplier: 9.17833328
 - StartTime: 169275
-  Multiplier: 9.18999958
+  Multiplier: 9.19250011
 - StartTime: 169283.672
-  Multiplier: 9.21000004
+  Multiplier: 9.20666695
 - StartTime: 169292.328
-  Multiplier: 9.22000027
+  Multiplier: 9.22083282
 - StartTime: 169301
-  Multiplier: 9.23999977
+  Multiplier: 9.23500061
 - StartTime: 169309.672
-  Multiplier: 9.25
+  Multiplier: 9.24916649
 - StartTime: 169318.328
-  Multiplier: 9.26000023
+  Multiplier: 9.26333332
 - StartTime: 169327
-  Multiplier: 9.27999973
+  Multiplier: 9.27750015
 - StartTime: 169335.672
-  Multiplier: 9.28999996
+  Multiplier: 9.29166698
 - StartTime: 169344.328
-  Multiplier: 9.31000042
+  Multiplier: 9.30583382
 - StartTime: 169353
-  Multiplier: 9.31999969
+  Multiplier: 9.32000065
 - StartTime: 169361.672
-  Multiplier: 9.32999992
+  Multiplier: 9.33416653
 - StartTime: 169370.328
-  Multiplier: 9.35000038
+  Multiplier: 9.34833336
 - StartTime: 169379
-  Multiplier: 9.35999966
+  Multiplier: 9.36250019
 - StartTime: 169387.672
-  Multiplier: 9.38000011
+  Multiplier: 9.37666607
 - StartTime: 169396.328
-  Multiplier: 9.39000034
+  Multiplier: 9.3908329
 - StartTime: 169405
-  Multiplier: 9.40999985
+  Multiplier: 9.40500069
 - StartTime: 169413.672
-  Multiplier: 9.42000008
+  Multiplier: 9.41916656
 - StartTime: 169422.328
-  Multiplier: 9.43000031
+  Multiplier: 9.4333334
 - StartTime: 169431
-  Multiplier: 9.44999981
+  Multiplier: 9.44749928
 - StartTime: 169439.672
-  Multiplier: 9.46000004
+  Multiplier: 9.46166706
 - StartTime: 169448.328
-  Multiplier: 9.47999954
+  Multiplier: 9.47583294
 - StartTime: 169457
   Multiplier: 9.48999977
 - StartTime: 169465.672
-  Multiplier: 9.5
+  Multiplier: 9.5041666
 - StartTime: 169474.328
-  Multiplier: 9.52000046
+  Multiplier: 9.51833344
 - StartTime: 169483
-  Multiplier: 9.52999973
+  Multiplier: 9.53250027
 - StartTime: 169491.672
-  Multiplier: 9.55000019
+  Multiplier: 9.5466671
 - StartTime: 169500.328
-  Multiplier: 9.56000042
+  Multiplier: 9.56083393
 - StartTime: 169509
-  Multiplier: 9.56999969
+  Multiplier: 9.57500076
 - StartTime: 169517.672
-  Multiplier: 9.59000015
+  Multiplier: 9.58916664
 - StartTime: 169526.328
-  Multiplier: 9.60000038
+  Multiplier: 9.60333347
 - StartTime: 169535
-  Multiplier: 9.61999989
+  Multiplier: 9.61749935
 - StartTime: 169543.672
-  Multiplier: 9.63000011
+  Multiplier: 9.63166714
 - StartTime: 169552.328
-  Multiplier: 9.64999962
+  Multiplier: 9.64583397
 - StartTime: 169561
   Multiplier: 9.65999985
 - StartTime: 169569.672
-  Multiplier: 9.67000008
+  Multiplier: 9.67416668
 - StartTime: 169578.328
-  Multiplier: 9.68999958
+  Multiplier: 9.68833351
 - StartTime: 169587
-  Multiplier: 9.69999981
+  Multiplier: 9.70250034
 - StartTime: 169595.672
-  Multiplier: 9.72000027
+  Multiplier: 9.71666622
 - StartTime: 169604.328
-  Multiplier: 9.72999954
+  Multiplier: 9.73083305
 - StartTime: 169613
-  Multiplier: 9.75
+  Multiplier: 9.74499989
 - StartTime: 169621.672
-  Multiplier: 9.76000023
+  Multiplier: 9.75916672
 - StartTime: 169630.328
-  Multiplier: 9.77000046
+  Multiplier: 9.7733326
 - StartTime: 169639
-  Multiplier: 9.78999996
+  Multiplier: 9.78750038
 - StartTime: 169647.672
-  Multiplier: 9.80000019
+  Multiplier: 9.80166626
 - StartTime: 169656.328
-  Multiplier: 9.81999969
+  Multiplier: 9.81583309
 - StartTime: 169665
   Multiplier: 9.82999992
 - StartTime: 169673.672
-  Multiplier: 9.84000015
+  Multiplier: 9.84416676
 - StartTime: 169682.328
-  Multiplier: 9.85999966
+  Multiplier: 9.85833359
 - StartTime: 169691
-  Multiplier: 9.86999989
+  Multiplier: 9.87250042
 - StartTime: 169699.672
-  Multiplier: 9.89000034
+  Multiplier: 9.8866663
 - StartTime: 169708.328
-  Multiplier: 9.89999962
+  Multiplier: 9.90083313
 - StartTime: 169717
-  Multiplier: 9.90999985
+  Multiplier: 9.91499996
 - StartTime: 169725.672
-  Multiplier: 9.93000031
+  Multiplier: 9.92916679
 - StartTime: 169734.328
-  Multiplier: 9.93999958
+  Multiplier: 9.94333363
 - StartTime: 169743
-  Multiplier: 9.96000004
+  Multiplier: 9.9574995
 - StartTime: 169751.672
-  Multiplier: 9.97000027
+  Multiplier: 9.97166634
 - StartTime: 169760.328
-  Multiplier: 9.98999977
+  Multiplier: 9.98583317
 - StartTime: 169769
   Multiplier: 1
 - StartTime: 169869
@@ -21848,67 +27178,67 @@ SliderVelocities:
 - StartTime: 170169
   Multiplier: 2
 - StartTime: 170184
-  Multiplier: 0.569999993
+  Multiplier: 0.571428597
 - StartTime: 170219
   Multiplier: 2
 - StartTime: 170234
-  Multiplier: 0.569999993
+  Multiplier: 0.571428597
 - StartTime: 170269
   Multiplier: 2
 - StartTime: 170284
-  Multiplier: 0.569999993
+  Multiplier: 0.571428597
 - StartTime: 170319
   Multiplier: 2
 - StartTime: 170334
-  Multiplier: 0.569999993
+  Multiplier: 0.571428597
 - StartTime: 170369
   Multiplier: 2
 - StartTime: 170384
-  Multiplier: 0.569999993
+  Multiplier: 0.571428597
 - StartTime: 170419
   Multiplier: 2
 - StartTime: 170434
-  Multiplier: 0.569999993
+  Multiplier: 0.571428597
 - StartTime: 170469
   Multiplier: 2
 - StartTime: 170484
-  Multiplier: 0.569999993
+  Multiplier: 0.571428597
 - StartTime: 170519
   Multiplier: 2
 - StartTime: 170534
-  Multiplier: 0.569999993
+  Multiplier: 0.571428597
 - StartTime: 170569
   Multiplier: 10
 - StartTime: 170573
-  Multiplier: 0.109999999
+  Multiplier: 0.109890111
 - StartTime: 170619
   Multiplier: 10
 - StartTime: 170623
-  Multiplier: 0.109999999
+  Multiplier: 0.109890111
 - StartTime: 170669
   Multiplier: 10
 - StartTime: 170673
-  Multiplier: 0.109999999
+  Multiplier: 0.109890111
 - StartTime: 170719
   Multiplier: 10
 - StartTime: 170723
-  Multiplier: 0.109999999
+  Multiplier: 0.109890111
 - StartTime: 170769
   Multiplier: 10
 - StartTime: 170773
-  Multiplier: 0.109999999
+  Multiplier: 0.109890111
 - StartTime: 170819
   Multiplier: 10
 - StartTime: 170820
-  Multiplier: 0.109999999
+  Multiplier: 0.109890111
 - StartTime: 170835
   Multiplier: 10
 - StartTime: 170838
-  Multiplier: 0.109999999
+  Multiplier: 0.109890111
 - StartTime: 170869
   Multiplier: 10
 - StartTime: 170878
-  Multiplier: 0.109999999
+  Multiplier: 0.109890111
 - StartTime: 173635
   Multiplier: 9.10000038
 - StartTime: 173641
@@ -22048,1231 +27378,1231 @@ SliderVelocities:
 - StartTime: 176970
   Multiplier: 1
 - StartTime: 176978
-  Multiplier: 1
+  Multiplier: 1.005
 - StartTime: 176986
   Multiplier: 1.00999999
 - StartTime: 176994
-  Multiplier: 1.00999999
+  Multiplier: 1.01499999
 - StartTime: 177002
   Multiplier: 1.01999998
 - StartTime: 177010
-  Multiplier: 1.02999997
+  Multiplier: 1.02499998
 - StartTime: 177018
   Multiplier: 1.02999997
 - StartTime: 177026
-  Multiplier: 1.03999996
+  Multiplier: 1.03500009
 - StartTime: 177034
   Multiplier: 1.03999996
 - StartTime: 177042
-  Multiplier: 1.03999996
+  Multiplier: 1.04499996
 - StartTime: 177050
   Multiplier: 1.04999995
 - StartTime: 177058
-  Multiplier: 1.05999994
+  Multiplier: 1.05500007
 - StartTime: 177066
   Multiplier: 1.05999994
 - StartTime: 177074
-  Multiplier: 1.07000005
+  Multiplier: 1.06500006
 - StartTime: 177082
-  Multiplier: 1.07000005
+  Multiplier: 1.06999993
 - StartTime: 177090
-  Multiplier: 1.08000004
+  Multiplier: 1.07500005
 - StartTime: 177098
   Multiplier: 1.08000004
 - StartTime: 177106
-  Multiplier: 1.08000004
+  Multiplier: 1.08499992
 - StartTime: 177114
   Multiplier: 1.09000003
 - StartTime: 177122
-  Multiplier: 1.09000003
+  Multiplier: 1.09500003
 - StartTime: 177130
   Multiplier: 1.10000002
 - StartTime: 177138
-  Multiplier: 1.11000001
+  Multiplier: 1.10500002
 - StartTime: 177146
   Multiplier: 1.11000001
 - StartTime: 177154
-  Multiplier: 1.12
+  Multiplier: 1.11500001
 - StartTime: 177162
   Multiplier: 1.12
 - StartTime: 177170
-  Multiplier: 1.13
+  Multiplier: 1.125
 - StartTime: 177178
   Multiplier: 1.13
 - StartTime: 177186
-  Multiplier: 1.13999999
+  Multiplier: 1.13499999
 - StartTime: 177194
   Multiplier: 1.13999999
 - StartTime: 177202
-  Multiplier: 1.14999998
+  Multiplier: 1.14499998
 - StartTime: 177210
   Multiplier: 1.14999998
 - StartTime: 177218
-  Multiplier: 1.15999997
+  Multiplier: 1.15499997
 - StartTime: 177226
-  Multiplier: 1.15999997
+  Multiplier: 1.16000009
 - StartTime: 177234
-  Multiplier: 1.16999996
+  Multiplier: 1.16500008
 - StartTime: 177242
   Multiplier: 1.16999996
 - StartTime: 177250
-  Multiplier: 1.16999996
+  Multiplier: 1.17499995
 - StartTime: 177258
   Multiplier: 1.17999995
 - StartTime: 177266
-  Multiplier: 1.19000006
+  Multiplier: 1.18500006
 - StartTime: 177274
-  Multiplier: 1.19000006
+  Multiplier: 1.18999994
 - StartTime: 177282
-  Multiplier: 1.20000005
+  Multiplier: 1.19500005
 - StartTime: 177290
-  Multiplier: 1.20000005
+  Multiplier: 1.19999993
 - StartTime: 177298
-  Multiplier: 1.21000004
+  Multiplier: 1.20500004
 - StartTime: 177306
-  Multiplier: 1.21000004
+  Multiplier: 1.20999992
 - StartTime: 177314
-  Multiplier: 1.22000003
+  Multiplier: 1.21500003
 - StartTime: 177322
-  Multiplier: 1.22000003
+  Multiplier: 1.21999991
 - StartTime: 177330
-  Multiplier: 1.23000002
+  Multiplier: 1.22500002
 - StartTime: 177338
   Multiplier: 1.23000002
 - StartTime: 177346
-  Multiplier: 1.24000001
+  Multiplier: 1.23500001
 - StartTime: 177354
   Multiplier: 1.24000001
 - StartTime: 177362
-  Multiplier: 1.25
+  Multiplier: 1.245
 - StartTime: 177370
   Multiplier: 1.25
 - StartTime: 177378
-  Multiplier: 1.25
+  Multiplier: 1.255
 - StartTime: 177386
   Multiplier: 1.25999999
 - StartTime: 177394
-  Multiplier: 1.26999998
+  Multiplier: 1.26499999
 - StartTime: 177402
   Multiplier: 1.26999998
 - StartTime: 177410
-  Multiplier: 1.26999998
+  Multiplier: 1.27499998
 - StartTime: 177418
   Multiplier: 1.27999997
 - StartTime: 177426
-  Multiplier: 1.27999997
+  Multiplier: 1.28499997
 - StartTime: 177434
   Multiplier: 1.28999996
 - StartTime: 177442
-  Multiplier: 1.29999995
+  Multiplier: 1.29499996
 - StartTime: 177450
   Multiplier: 1.29999995
 - StartTime: 177458
-  Multiplier: 1.30999994
+  Multiplier: 1.30500007
 - StartTime: 177466
-  Multiplier: 1.30999994
+  Multiplier: 1.31000006
 - StartTime: 177474
-  Multiplier: 1.32000005
+  Multiplier: 1.31500006
 - StartTime: 177482
   Multiplier: 1.32000005
 - StartTime: 177490
-  Multiplier: 1.33000004
+  Multiplier: 1.32500005
 - StartTime: 177498
-  Multiplier: 1.33000004
+  Multiplier: 1.32999992
 - StartTime: 177506
-  Multiplier: 1.34000003
+  Multiplier: 1.33500004
 - StartTime: 177514
-  Multiplier: 1.34000003
+  Multiplier: 1.33999991
 - StartTime: 177522
-  Multiplier: 1.35000002
+  Multiplier: 1.34500003
 - StartTime: 177530
   Multiplier: 1.35000002
 - StartTime: 177538
-  Multiplier: 1.36000001
+  Multiplier: 1.35500002
 - StartTime: 177546
   Multiplier: 1.36000001
 - StartTime: 177554
-  Multiplier: 1.37
+  Multiplier: 1.36500001
 - StartTime: 177562
   Multiplier: 1.37
 - StartTime: 177570
-  Multiplier: 1.37
+  Multiplier: 1.375
 - StartTime: 177578
   Multiplier: 1.38
 - StartTime: 177586
-  Multiplier: 1.38999999
+  Multiplier: 1.38499999
 - StartTime: 177594
   Multiplier: 1.38999999
 - StartTime: 177602
-  Multiplier: 1.39999998
+  Multiplier: 1.3950001
 - StartTime: 177610
   Multiplier: 1.39999998
 - StartTime: 177618
-  Multiplier: 1.40999997
+  Multiplier: 1.40499997
 - StartTime: 177626
   Multiplier: 1.40999997
 - StartTime: 177634
-  Multiplier: 1.40999997
+  Multiplier: 1.41499996
 - StartTime: 177642
   Multiplier: 1.41999996
 - StartTime: 177650
-  Multiplier: 1.41999996
+  Multiplier: 1.42500007
 - StartTime: 177658
-  Multiplier: 1.42999995
+  Multiplier: 1.43000007
 - StartTime: 177666
-  Multiplier: 1.44000006
+  Multiplier: 1.43500006
 - StartTime: 177674
   Multiplier: 1.44000006
 - StartTime: 177682
-  Multiplier: 1.44000006
+  Multiplier: 1.44499993
 - StartTime: 177690
   Multiplier: 1.45000005
 - StartTime: 177698
-  Multiplier: 1.46000004
+  Multiplier: 1.45499992
 - StartTime: 177706
   Multiplier: 1.46000004
 - StartTime: 177714
-  Multiplier: 1.47000003
+  Multiplier: 1.46500003
 - StartTime: 177722
-  Multiplier: 1.47000003
+  Multiplier: 1.46999991
 - StartTime: 177730
-  Multiplier: 1.48000002
+  Multiplier: 1.47500002
 - StartTime: 177738
   Multiplier: 1.48000002
 - StartTime: 177746
-  Multiplier: 1.49000001
+  Multiplier: 1.48500001
 - StartTime: 177754
-  Multiplier: 1.49000001
+  Multiplier: 1.48999989
 - StartTime: 177762
-  Multiplier: 1.5
+  Multiplier: 1.495
 - StartTime: 177770
   Multiplier: 1.5
 - StartTime: 177778
-  Multiplier: 1.50999999
+  Multiplier: 1.51416659
 - StartTime: 177787
-  Multiplier: 1.52999997
+  Multiplier: 1.52833331
 - StartTime: 177796
-  Multiplier: 1.53999996
+  Multiplier: 1.54250002
 - StartTime: 177804
-  Multiplier: 1.55999994
+  Multiplier: 1.55666661
 - StartTime: 177813
-  Multiplier: 1.57000005
+  Multiplier: 1.57083333
 - StartTime: 177822
-  Multiplier: 1.58000004
+  Multiplier: 1.58499992
 - StartTime: 177830
-  Multiplier: 1.60000002
+  Multiplier: 1.59916663
 - StartTime: 177839
-  Multiplier: 1.61000001
+  Multiplier: 1.61333334
 - StartTime: 177848
-  Multiplier: 1.63
+  Multiplier: 1.62750006
 - StartTime: 177856
-  Multiplier: 1.63999999
+  Multiplier: 1.64166677
 - StartTime: 177865
-  Multiplier: 1.65999997
+  Multiplier: 1.65583336
 - StartTime: 177874
   Multiplier: 1.66999996
 - StartTime: 177882
-  Multiplier: 1.67999995
+  Multiplier: 1.68416667
 - StartTime: 177891
-  Multiplier: 1.70000005
+  Multiplier: 1.69833338
 - StartTime: 177900
-  Multiplier: 1.71000004
+  Multiplier: 1.71249998
 - StartTime: 177908
-  Multiplier: 1.73000002
+  Multiplier: 1.72666669
 - StartTime: 177917
-  Multiplier: 1.74000001
+  Multiplier: 1.7408334
 - StartTime: 177926
-  Multiplier: 1.75999999
+  Multiplier: 1.755
 - StartTime: 177934
-  Multiplier: 1.76999998
+  Multiplier: 1.76916659
 - StartTime: 177943
-  Multiplier: 1.77999997
+  Multiplier: 1.7833333
 - StartTime: 177952
-  Multiplier: 1.79999995
+  Multiplier: 1.79750001
 - StartTime: 177960
-  Multiplier: 1.80999994
+  Multiplier: 1.81166673
 - StartTime: 177969
-  Multiplier: 1.83000004
+  Multiplier: 1.82583332
 - StartTime: 177978
-  Multiplier: 1.84000003
+  Multiplier: 1.83999991
 - StartTime: 177986
-  Multiplier: 1.85000002
+  Multiplier: 1.85416675
 - StartTime: 177995
-  Multiplier: 1.87
+  Multiplier: 1.86833334
 - StartTime: 178004
-  Multiplier: 1.88
+  Multiplier: 1.88250005
 - StartTime: 178012
-  Multiplier: 1.89999998
+  Multiplier: 1.89666665
 - StartTime: 178021
-  Multiplier: 1.90999997
+  Multiplier: 1.91083336
 - StartTime: 178030
-  Multiplier: 1.92999995
+  Multiplier: 1.92500007
 - StartTime: 178038
-  Multiplier: 1.94000006
+  Multiplier: 1.93916667
 - StartTime: 178047
-  Multiplier: 1.95000005
+  Multiplier: 1.95333338
 - StartTime: 178056
-  Multiplier: 1.97000003
+  Multiplier: 1.96750009
 - StartTime: 178064
-  Multiplier: 1.98000002
+  Multiplier: 1.98166668
 - StartTime: 178073
-  Multiplier: 2
+  Multiplier: 1.99583328
 - StartTime: 178082
   Multiplier: 2.00999999
 - StartTime: 178090
-  Multiplier: 2.01999998
+  Multiplier: 2.02416658
 - StartTime: 178099
-  Multiplier: 2.03999996
+  Multiplier: 2.03833342
 - StartTime: 178108
-  Multiplier: 2.04999995
+  Multiplier: 2.05250001
 - StartTime: 178116
-  Multiplier: 2.06999993
+  Multiplier: 2.0666666
 - StartTime: 178125
-  Multiplier: 2.07999992
+  Multiplier: 2.0808332
 - StartTime: 178134
-  Multiplier: 2.0999999
+  Multiplier: 2.09500003
 - StartTime: 178142
-  Multiplier: 2.1099999
+  Multiplier: 2.10916662
 - StartTime: 178151
-  Multiplier: 2.11999989
+  Multiplier: 2.12333345
 - StartTime: 178160
-  Multiplier: 2.1400001
+  Multiplier: 2.13750005
 - StartTime: 178168
-  Multiplier: 2.1500001
+  Multiplier: 2.15166664
 - StartTime: 178177
-  Multiplier: 2.17000008
+  Multiplier: 2.16583323
 - StartTime: 178186
   Multiplier: 2.18000007
 - StartTime: 178194
-  Multiplier: 2.19000006
+  Multiplier: 2.19416666
 - StartTime: 178203
-  Multiplier: 2.21000004
+  Multiplier: 2.20833325
 - StartTime: 178212
-  Multiplier: 2.22000003
+  Multiplier: 2.22249985
 - StartTime: 178220
-  Multiplier: 2.24000001
+  Multiplier: 2.23666668
 - StartTime: 178229
-  Multiplier: 2.25
+  Multiplier: 2.25083327
 - StartTime: 178238
-  Multiplier: 2.26999998
+  Multiplier: 2.26499987
 - StartTime: 178246
-  Multiplier: 2.27999997
+  Multiplier: 2.2791667
 - StartTime: 178255
-  Multiplier: 2.28999996
+  Multiplier: 2.29333329
 - StartTime: 178264
-  Multiplier: 2.30999994
+  Multiplier: 2.30750012
 - StartTime: 178272
-  Multiplier: 2.31999993
+  Multiplier: 2.32166672
 - StartTime: 178281
-  Multiplier: 2.33999991
+  Multiplier: 2.33583331
 - StartTime: 178290
   Multiplier: 2.3499999
 - StartTime: 178298
-  Multiplier: 2.3599999
+  Multiplier: 2.36416674
 - StartTime: 178307
-  Multiplier: 2.38000011
+  Multiplier: 2.37833333
 - StartTime: 178316
-  Multiplier: 2.3900001
+  Multiplier: 2.39249992
 - StartTime: 178324
-  Multiplier: 2.41000009
+  Multiplier: 2.40666676
 - StartTime: 178333
-  Multiplier: 2.42000008
+  Multiplier: 2.42083335
 - StartTime: 178342
-  Multiplier: 2.44000006
+  Multiplier: 2.43500018
 - StartTime: 178350
-  Multiplier: 2.45000005
+  Multiplier: 2.44916654
 - StartTime: 178359
-  Multiplier: 2.46000004
+  Multiplier: 2.46333337
 - StartTime: 178368
-  Multiplier: 2.48000002
+  Multiplier: 2.47749996
 - StartTime: 178376
-  Multiplier: 2.49000001
+  Multiplier: 2.49166679
 - StartTime: 178385
-  Multiplier: 2.50999999
+  Multiplier: 2.50583339
 - StartTime: 178394
   Multiplier: 2.51999998
 - StartTime: 178402
-  Multiplier: 2.52999997
+  Multiplier: 2.53416657
 - StartTime: 178411
-  Multiplier: 2.54999995
+  Multiplier: 2.54833341
 - StartTime: 178420
-  Multiplier: 2.55999994
+  Multiplier: 2.5625
 - StartTime: 178428
-  Multiplier: 2.57999992
+  Multiplier: 2.57666659
 - StartTime: 178437
-  Multiplier: 2.58999991
+  Multiplier: 2.59083343
 - StartTime: 178446
-  Multiplier: 2.6099999
+  Multiplier: 2.60500002
 - StartTime: 178454
-  Multiplier: 2.61999989
+  Multiplier: 2.61916661
 - StartTime: 178463
-  Multiplier: 2.63000011
+  Multiplier: 2.63333344
 - StartTime: 178472
-  Multiplier: 2.6500001
+  Multiplier: 2.6474998
 - StartTime: 178480
-  Multiplier: 2.66000009
+  Multiplier: 2.66166663
 - StartTime: 178489
-  Multiplier: 2.68000007
+  Multiplier: 2.67583323
 - StartTime: 178498
   Multiplier: 2.69000006
 - StartTime: 178506
-  Multiplier: 2.70000005
+  Multiplier: 2.70416665
 - StartTime: 178515
-  Multiplier: 2.72000003
+  Multiplier: 2.71833324
 - StartTime: 178524
-  Multiplier: 2.73000002
+  Multiplier: 2.73250008
 - StartTime: 178532
-  Multiplier: 2.75
+  Multiplier: 2.74666667
 - StartTime: 178541
-  Multiplier: 2.75999999
+  Multiplier: 2.76083326
 - StartTime: 178550
-  Multiplier: 2.76999998
+  Multiplier: 2.77499986
 - StartTime: 178558
-  Multiplier: 2.78999996
+  Multiplier: 2.78916645
 - StartTime: 178567
-  Multiplier: 2.79999995
+  Multiplier: 2.80333352
 - StartTime: 178576
-  Multiplier: 2.81999993
+  Multiplier: 2.81749988
 - StartTime: 178584
-  Multiplier: 2.82999992
+  Multiplier: 2.83166671
 - StartTime: 178593
-  Multiplier: 2.8499999
+  Multiplier: 2.8458333
 - StartTime: 178602
-  Multiplier: 2.8599999
+  Multiplier: 2.86000013
 - StartTime: 178610
-  Multiplier: 2.86999989
+  Multiplier: 2.87416673
 - StartTime: 178619
-  Multiplier: 2.8900001
+  Multiplier: 2.88833332
 - StartTime: 178628
-  Multiplier: 2.9000001
+  Multiplier: 2.90250015
 - StartTime: 178636
-  Multiplier: 2.92000008
+  Multiplier: 2.91666675
 - StartTime: 178645
-  Multiplier: 2.93000007
+  Multiplier: 2.93083334
 - StartTime: 178654
-  Multiplier: 2.95000005
+  Multiplier: 2.94500017
 - StartTime: 178662
-  Multiplier: 2.96000004
+  Multiplier: 2.95916677
 - StartTime: 178671
-  Multiplier: 2.97000003
+  Multiplier: 2.97333336
 - StartTime: 178680
-  Multiplier: 2.99000001
+  Multiplier: 2.98749995
 - StartTime: 178688
-  Multiplier: 3
+  Multiplier: 3.00166655
 - StartTime: 178697
-  Multiplier: 3.01999998
+  Multiplier: 3.01583314
 - StartTime: 178706
   Multiplier: 3.02999997
 - StartTime: 178714
-  Multiplier: 3.03999996
+  Multiplier: 3.0441668
 - StartTime: 178723
-  Multiplier: 3.05999994
+  Multiplier: 3.0583334
 - StartTime: 178732
-  Multiplier: 3.06999993
+  Multiplier: 3.07249999
 - StartTime: 178740
-  Multiplier: 3.08999991
+  Multiplier: 3.08666682
 - StartTime: 178749
-  Multiplier: 3.0999999
+  Multiplier: 3.10083342
 - StartTime: 178758
-  Multiplier: 3.1099999
+  Multiplier: 3.11500001
 - StartTime: 178766
-  Multiplier: 3.13000011
+  Multiplier: 3.1291666
 - StartTime: 178775
-  Multiplier: 3.1400001
+  Multiplier: 3.1433332
 - StartTime: 178784
-  Multiplier: 3.16000009
+  Multiplier: 3.15750003
 - StartTime: 178792
-  Multiplier: 3.17000008
+  Multiplier: 3.17166662
 - StartTime: 178801
-  Multiplier: 3.19000006
+  Multiplier: 3.18583322
 - StartTime: 178810
   Multiplier: 3.20000005
 - StartTime: 178818
-  Multiplier: 3.21000004
+  Multiplier: 3.21416664
 - StartTime: 178827
-  Multiplier: 3.23000002
+  Multiplier: 3.22833323
 - StartTime: 178836
-  Multiplier: 3.24000001
+  Multiplier: 3.24250007
 - StartTime: 178844
-  Multiplier: 3.25999999
+  Multiplier: 3.25666666
 - StartTime: 178853
-  Multiplier: 3.26999998
+  Multiplier: 3.27083349
 - StartTime: 178862
-  Multiplier: 3.28999996
+  Multiplier: 3.28500009
 - StartTime: 178870
-  Multiplier: 3.29999995
+  Multiplier: 3.29916668
 - StartTime: 178879
-  Multiplier: 3.30999994
+  Multiplier: 3.31333351
 - StartTime: 178888
-  Multiplier: 3.32999992
+  Multiplier: 3.3275001
 - StartTime: 178896
-  Multiplier: 3.33999991
+  Multiplier: 3.3416667
 - StartTime: 178905
-  Multiplier: 3.3599999
+  Multiplier: 3.35583329
 - StartTime: 178914
-  Multiplier: 3.36999989
+  Multiplier: 3.37000012
 - StartTime: 178922
-  Multiplier: 3.38000011
+  Multiplier: 3.38416672
 - StartTime: 178931
-  Multiplier: 3.4000001
+  Multiplier: 3.39833331
 - StartTime: 178940
-  Multiplier: 3.41000009
+  Multiplier: 3.4124999
 - StartTime: 178948
-  Multiplier: 3.43000007
+  Multiplier: 3.42666674
 - StartTime: 178957
-  Multiplier: 3.44000006
+  Multiplier: 3.44083333
 - StartTime: 178966
-  Multiplier: 3.46000004
+  Multiplier: 3.45500016
 - StartTime: 178974
-  Multiplier: 3.47000003
+  Multiplier: 3.46916652
 - StartTime: 178983
-  Multiplier: 3.48000002
+  Multiplier: 3.48333335
 - StartTime: 178992
-  Multiplier: 3.5
+  Multiplier: 3.49749994
 - StartTime: 179000
-  Multiplier: 3.50999999
+  Multiplier: 3.51166654
 - StartTime: 179009
-  Multiplier: 3.52999997
+  Multiplier: 3.52583337
 - StartTime: 179018
-  Multiplier: 3.53999996
+  Multiplier: 3.5400002
 - StartTime: 179026
-  Multiplier: 3.54999995
+  Multiplier: 3.55416679
 - StartTime: 179035
-  Multiplier: 3.56999993
+  Multiplier: 3.56833339
 - StartTime: 179044
-  Multiplier: 3.57999992
+  Multiplier: 3.58250022
 - StartTime: 179052
-  Multiplier: 3.5999999
+  Multiplier: 3.59666657
 - StartTime: 179061
-  Multiplier: 3.6099999
+  Multiplier: 3.61083317
 - StartTime: 179070
-  Multiplier: 3.63000011
+  Multiplier: 3.625
 - StartTime: 179078
-  Multiplier: 3.6400001
+  Multiplier: 3.63916659
 - StartTime: 179087
-  Multiplier: 3.6500001
+  Multiplier: 3.65333343
 - StartTime: 179096
-  Multiplier: 3.67000008
+  Multiplier: 3.66750002
 - StartTime: 179104
-  Multiplier: 3.68000007
+  Multiplier: 3.68166661
 - StartTime: 179113
-  Multiplier: 3.70000005
+  Multiplier: 3.69583344
 - StartTime: 179122
   Multiplier: 3.71000004
 - StartTime: 179130
-  Multiplier: 3.72000003
+  Multiplier: 3.72416663
 - StartTime: 179139
-  Multiplier: 3.74000001
+  Multiplier: 3.73833323
 - StartTime: 179148
-  Multiplier: 3.75
+  Multiplier: 3.75250006
 - StartTime: 179156
-  Multiplier: 3.76999998
+  Multiplier: 3.76666689
 - StartTime: 179165
-  Multiplier: 3.77999997
+  Multiplier: 3.78083324
 - StartTime: 179174
-  Multiplier: 3.78999996
+  Multiplier: 3.79499984
 - StartTime: 179182
-  Multiplier: 3.80999994
+  Multiplier: 3.80916667
 - StartTime: 179191
-  Multiplier: 3.81999993
+  Multiplier: 3.82333326
 - StartTime: 179200
-  Multiplier: 3.83999991
+  Multiplier: 3.8375001
 - StartTime: 179208
-  Multiplier: 3.8499999
+  Multiplier: 3.85166669
 - StartTime: 179217
-  Multiplier: 3.86999989
+  Multiplier: 3.86583352
 - StartTime: 179226
   Multiplier: 3.88000011
 - StartTime: 179234
-  Multiplier: 3.8900001
+  Multiplier: 3.89416647
 - StartTime: 179243
-  Multiplier: 3.91000009
+  Multiplier: 3.90833354
 - StartTime: 179252
-  Multiplier: 3.92000008
+  Multiplier: 3.9224999
 - StartTime: 179260
-  Multiplier: 3.94000006
+  Multiplier: 3.93666673
 - StartTime: 179269
-  Multiplier: 3.95000005
+  Multiplier: 3.95083332
 - StartTime: 179278
-  Multiplier: 3.96000004
+  Multiplier: 3.96500015
 - StartTime: 179286
-  Multiplier: 3.98000002
+  Multiplier: 3.97916675
 - StartTime: 179295
-  Multiplier: 3.99000001
+  Multiplier: 3.99333334
 - StartTime: 179304
-  Multiplier: 4.01000023
+  Multiplier: 4.00750017
 - StartTime: 179312
-  Multiplier: 4.01999998
+  Multiplier: 4.02166653
 - StartTime: 179321
-  Multiplier: 4.03999996
+  Multiplier: 4.03583336
 - StartTime: 179330
-  Multiplier: 4.05000019
+  Multiplier: 4.04999971
 - StartTime: 179338
-  Multiplier: 4.05999994
+  Multiplier: 4.06416655
 - StartTime: 179347
-  Multiplier: 4.07999992
+  Multiplier: 4.07833338
 - StartTime: 179356
-  Multiplier: 4.09000015
+  Multiplier: 4.09249973
 - StartTime: 179364
-  Multiplier: 4.11000013
+  Multiplier: 4.10666656
 - StartTime: 179373
-  Multiplier: 4.11999989
+  Multiplier: 4.1208334
 - StartTime: 179382
-  Multiplier: 4.13999987
+  Multiplier: 4.13500023
 - StartTime: 179390
-  Multiplier: 4.1500001
+  Multiplier: 4.14916658
 - StartTime: 179399
-  Multiplier: 4.15999985
+  Multiplier: 4.16333342
 - StartTime: 179408
-  Multiplier: 4.17999983
+  Multiplier: 4.17750025
 - StartTime: 179416
-  Multiplier: 4.19000006
+  Multiplier: 4.1916666
 - StartTime: 179425
-  Multiplier: 4.21000004
+  Multiplier: 4.20583344
 - StartTime: 179434
-  Multiplier: 4.21999979
+  Multiplier: 4.22000027
 - StartTime: 179442
-  Multiplier: 4.23000002
+  Multiplier: 4.23416662
 - StartTime: 179451
-  Multiplier: 4.25
+  Multiplier: 4.24833345
 - StartTime: 179460
-  Multiplier: 4.26000023
+  Multiplier: 4.26249981
 - StartTime: 179468
-  Multiplier: 4.28000021
+  Multiplier: 4.27666664
 - StartTime: 179477
-  Multiplier: 4.28999996
+  Multiplier: 4.29083347
 - StartTime: 179486
-  Multiplier: 4.30999994
+  Multiplier: 4.30499983
 - StartTime: 179494
-  Multiplier: 4.32000017
+  Multiplier: 4.31916666
 - StartTime: 179503
-  Multiplier: 4.32999992
+  Multiplier: 4.33333349
 - StartTime: 179512
-  Multiplier: 4.3499999
+  Multiplier: 4.34750032
 - StartTime: 179520
-  Multiplier: 4.36000013
+  Multiplier: 4.36166668
 - StartTime: 179529
-  Multiplier: 4.38000011
+  Multiplier: 4.37583303
 - StartTime: 179538
   Multiplier: 4.38999987
 - StartTime: 179546
-  Multiplier: 4.4000001
+  Multiplier: 4.4041667
 - StartTime: 179555
-  Multiplier: 4.42000008
+  Multiplier: 4.41833353
 - StartTime: 179564
-  Multiplier: 4.42999983
+  Multiplier: 4.43250036
 - StartTime: 179572
-  Multiplier: 4.44999981
+  Multiplier: 4.44666672
 - StartTime: 179581
-  Multiplier: 4.46000004
+  Multiplier: 4.46083355
 - StartTime: 179590
-  Multiplier: 4.48000002
+  Multiplier: 4.4749999
 - StartTime: 179598
-  Multiplier: 4.48999977
+  Multiplier: 4.48916674
 - StartTime: 179607
-  Multiplier: 4.5
+  Multiplier: 4.50333309
 - StartTime: 179616
-  Multiplier: 4.51999998
+  Multiplier: 4.51749992
 - StartTime: 179624
-  Multiplier: 4.53000021
+  Multiplier: 4.53166676
 - StartTime: 179633
-  Multiplier: 4.55000019
+  Multiplier: 4.54583311
 - StartTime: 179642
   Multiplier: 4.55999994
 - StartTime: 179650
-  Multiplier: 4.57000017
+  Multiplier: 4.57416677
 - StartTime: 179659
-  Multiplier: 4.59000015
+  Multiplier: 4.58833313
 - StartTime: 179668
-  Multiplier: 4.5999999
+  Multiplier: 4.60249996
 - StartTime: 179676
-  Multiplier: 4.61999989
+  Multiplier: 4.61666679
 - StartTime: 179685
-  Multiplier: 4.63000011
+  Multiplier: 4.63083363
 - StartTime: 179694
-  Multiplier: 4.6500001
+  Multiplier: 4.64499998
 - StartTime: 179702
-  Multiplier: 4.65999985
+  Multiplier: 4.65916634
 - StartTime: 179711
-  Multiplier: 4.67000008
+  Multiplier: 4.67333317
 - StartTime: 179720
-  Multiplier: 4.69000006
+  Multiplier: 4.6875
 - StartTime: 179728
-  Multiplier: 4.69999981
+  Multiplier: 4.70166636
 - StartTime: 179737
-  Multiplier: 4.71999979
+  Multiplier: 4.71583319
 - StartTime: 179746
   Multiplier: 4.73000002
 - StartTime: 179754
-  Multiplier: 4.73999977
+  Multiplier: 4.74416637
 - StartTime: 179763
-  Multiplier: 4.76000023
+  Multiplier: 4.75833321
 - StartTime: 179772
-  Multiplier: 4.76999998
+  Multiplier: 4.77250004
 - StartTime: 179780
-  Multiplier: 4.78999996
+  Multiplier: 4.78666687
 - StartTime: 179789
-  Multiplier: 4.80000019
+  Multiplier: 4.80083323
 - StartTime: 179798
-  Multiplier: 4.82000017
+  Multiplier: 4.81500006
 - StartTime: 179806
-  Multiplier: 4.82999992
+  Multiplier: 4.82916689
 - StartTime: 179815
-  Multiplier: 4.84000015
+  Multiplier: 4.84333324
 - StartTime: 179824
-  Multiplier: 4.86000013
+  Multiplier: 4.85750008
 - StartTime: 179832
-  Multiplier: 4.86999989
+  Multiplier: 4.87166691
 - StartTime: 179841
-  Multiplier: 4.88999987
+  Multiplier: 4.88583374
 - StartTime: 179850
   Multiplier: 4.9000001
 - StartTime: 179858
-  Multiplier: 4.90999985
+  Multiplier: 4.91416645
 - StartTime: 179867
-  Multiplier: 4.92999983
+  Multiplier: 4.92833376
 - StartTime: 179876
-  Multiplier: 4.94000006
+  Multiplier: 4.94250011
 - StartTime: 179884
-  Multiplier: 4.96000004
+  Multiplier: 4.95666647
 - StartTime: 179893
-  Multiplier: 4.96999979
+  Multiplier: 4.9708333
 - StartTime: 179902
-  Multiplier: 4.98999977
+  Multiplier: 4.98500013
 - StartTime: 179910
-  Multiplier: 5
+  Multiplier: 4.99916649
 - StartTime: 179919
-  Multiplier: 5.01000023
+  Multiplier: 5.01333332
 - StartTime: 179928
-  Multiplier: 5.03000021
+  Multiplier: 5.02749968
 - StartTime: 179936
-  Multiplier: 5.03999996
+  Multiplier: 5.04166651
 - StartTime: 179945
-  Multiplier: 5.05999994
+  Multiplier: 5.05583334
 - StartTime: 179954
   Multiplier: 5.07000017
 - StartTime: 179962
-  Multiplier: 5.07999992
+  Multiplier: 5.08416653
 - StartTime: 179971
-  Multiplier: 5.0999999
+  Multiplier: 5.09833336
 - StartTime: 179980
-  Multiplier: 5.11000013
+  Multiplier: 5.11250019
 - StartTime: 179988
-  Multiplier: 5.13000011
+  Multiplier: 5.12666655
 - StartTime: 179997
-  Multiplier: 5.13999987
+  Multiplier: 5.14083338
 - StartTime: 180006
-  Multiplier: 5.15999985
+  Multiplier: 5.15500021
 - StartTime: 180014
-  Multiplier: 5.17000008
+  Multiplier: 5.16916656
 - StartTime: 180023
-  Multiplier: 5.17999983
+  Multiplier: 5.1833334
 - StartTime: 180032
-  Multiplier: 5.19999981
+  Multiplier: 5.19750023
 - StartTime: 180040
-  Multiplier: 5.21000004
+  Multiplier: 5.21166658
 - StartTime: 180049
-  Multiplier: 5.23000002
+  Multiplier: 5.22583342
 - StartTime: 180058
-  Multiplier: 5.23999977
+  Multiplier: 5.24000025
 - StartTime: 180066
-  Multiplier: 5.25
+  Multiplier: 5.2541666
 - StartTime: 180075
-  Multiplier: 5.26999998
+  Multiplier: 5.26833344
 - StartTime: 180084
-  Multiplier: 5.28000021
+  Multiplier: 5.28249979
 - StartTime: 180092
-  Multiplier: 5.30000019
+  Multiplier: 5.29666662
 - StartTime: 180101
-  Multiplier: 5.30999994
+  Multiplier: 5.31083298
 - StartTime: 180110
-  Multiplier: 5.32000017
+  Multiplier: 5.32499981
 - StartTime: 180118
-  Multiplier: 5.34000015
+  Multiplier: 5.33916664
 - StartTime: 180127
-  Multiplier: 5.3499999
+  Multiplier: 5.353333
 - StartTime: 180136
-  Multiplier: 5.36999989
+  Multiplier: 5.36749983
 - StartTime: 180144
-  Multiplier: 5.38000011
+  Multiplier: 5.38166666
 - StartTime: 180153
-  Multiplier: 5.4000001
+  Multiplier: 5.39583349
 - StartTime: 180162
   Multiplier: 5.40999985
 - StartTime: 180170
-  Multiplier: 5.42000008
+  Multiplier: 5.42416668
 - StartTime: 180179
-  Multiplier: 5.44000006
+  Multiplier: 5.43833303
 - StartTime: 180188
-  Multiplier: 5.44999981
+  Multiplier: 5.45250034
 - StartTime: 180196
-  Multiplier: 5.46999979
+  Multiplier: 5.4666667
 - StartTime: 180205
-  Multiplier: 5.48000002
+  Multiplier: 5.48083305
 - StartTime: 180214
-  Multiplier: 5.5
+  Multiplier: 5.49499989
 - StartTime: 180222
-  Multiplier: 5.51000023
+  Multiplier: 5.50916672
 - StartTime: 180231
-  Multiplier: 5.51999998
+  Multiplier: 5.52333355
 - StartTime: 180240
-  Multiplier: 5.53999996
+  Multiplier: 5.5374999
 - StartTime: 180248
-  Multiplier: 5.55000019
+  Multiplier: 5.55166626
 - StartTime: 180257
-  Multiplier: 5.57000017
+  Multiplier: 5.56583357
 - StartTime: 180266
-  Multiplier: 5.57999992
+  Multiplier: 5.5800004
 - StartTime: 180274
-  Multiplier: 5.59000015
+  Multiplier: 5.59416676
 - StartTime: 180283
-  Multiplier: 5.61000013
+  Multiplier: 5.60833359
 - StartTime: 180292
-  Multiplier: 5.61999989
+  Multiplier: 5.62249994
 - StartTime: 180300
-  Multiplier: 5.63999987
+  Multiplier: 5.63666677
 - StartTime: 180309
-  Multiplier: 5.6500001
+  Multiplier: 5.65083361
 - StartTime: 180318
-  Multiplier: 5.65999985
+  Multiplier: 5.66499996
 - StartTime: 180326
-  Multiplier: 5.67999983
+  Multiplier: 5.67916679
 - StartTime: 180335
-  Multiplier: 5.69000006
+  Multiplier: 5.69333315
 - StartTime: 180344
-  Multiplier: 5.71000004
+  Multiplier: 5.70749998
 - StartTime: 180352
-  Multiplier: 5.71999979
+  Multiplier: 5.72166681
 - StartTime: 180361
-  Multiplier: 5.73999977
+  Multiplier: 5.73583364
 - StartTime: 180370
   Multiplier: 5.75
 - StartTime: 180378
-  Multiplier: 5.76000023
+  Multiplier: 5.76416636
 - StartTime: 180387
-  Multiplier: 5.78000021
+  Multiplier: 5.77833319
 - StartTime: 180396
-  Multiplier: 5.78999996
+  Multiplier: 5.79250002
 - StartTime: 180404
-  Multiplier: 5.80999994
+  Multiplier: 5.80666685
 - StartTime: 180413
-  Multiplier: 5.82000017
+  Multiplier: 5.82083368
 - StartTime: 180422
-  Multiplier: 5.82999992
+  Multiplier: 5.83500004
 - StartTime: 180430
-  Multiplier: 5.8499999
+  Multiplier: 5.84916639
 - StartTime: 180439
-  Multiplier: 5.86000013
+  Multiplier: 5.86333323
 - StartTime: 180448
-  Multiplier: 5.88000011
+  Multiplier: 5.87750006
 - StartTime: 180456
-  Multiplier: 5.88999987
+  Multiplier: 5.89166689
 - StartTime: 180465
-  Multiplier: 5.90999985
+  Multiplier: 5.90583324
 - StartTime: 180474
   Multiplier: 5.92000008
 - StartTime: 180482
-  Multiplier: 5.92999983
+  Multiplier: 5.93416643
 - StartTime: 180491
-  Multiplier: 5.94999981
+  Multiplier: 5.94833326
 - StartTime: 180500
-  Multiplier: 5.96000004
+  Multiplier: 5.9625001
 - StartTime: 180508
-  Multiplier: 5.98000002
+  Multiplier: 5.97666645
 - StartTime: 180517
-  Multiplier: 5.98999977
+  Multiplier: 5.99083328
 - StartTime: 180526
-  Multiplier: 6.01000023
+  Multiplier: 6.00499964
 - StartTime: 180534
-  Multiplier: 6.01999998
+  Multiplier: 6.01916647
 - StartTime: 180543
-  Multiplier: 6.03000021
+  Multiplier: 6.03333378
 - StartTime: 180552
-  Multiplier: 6.05000019
+  Multiplier: 6.04749966
 - StartTime: 180560
-  Multiplier: 6.05999994
+  Multiplier: 6.06166697
 - StartTime: 180569
-  Multiplier: 6.07999992
+  Multiplier: 6.0758338
 - StartTime: 180578
   Multiplier: 6.09000015
 - StartTime: 180586
-  Multiplier: 6.0999999
+  Multiplier: 6.10416698
 - StartTime: 180595
-  Multiplier: 6.11999989
+  Multiplier: 6.11833334
 - StartTime: 180604
-  Multiplier: 6.13000011
+  Multiplier: 6.13249969
 - StartTime: 180612
-  Multiplier: 6.1500001
+  Multiplier: 6.146667
 - StartTime: 180621
-  Multiplier: 6.15999985
+  Multiplier: 6.16083288
 - StartTime: 180630
-  Multiplier: 6.17000008
+  Multiplier: 6.17499971
 - StartTime: 180638
-  Multiplier: 6.19000006
+  Multiplier: 6.18916655
 - StartTime: 180647
-  Multiplier: 6.19999981
+  Multiplier: 6.20333338
 - StartTime: 180656
-  Multiplier: 6.21999979
+  Multiplier: 6.21749973
 - StartTime: 180664
-  Multiplier: 6.23000002
+  Multiplier: 6.23166656
 - StartTime: 180673
-  Multiplier: 6.25
+  Multiplier: 6.2458334
 - StartTime: 180682
   Multiplier: 6.26000023
 - StartTime: 180690
-  Multiplier: 6.26999998
+  Multiplier: 6.27416658
 - StartTime: 180699
-  Multiplier: 6.28999996
+  Multiplier: 6.28833342
 - StartTime: 180708
-  Multiplier: 6.30000019
+  Multiplier: 6.30250025
 - StartTime: 180716
-  Multiplier: 6.32000017
+  Multiplier: 6.3166666
 - StartTime: 180725
-  Multiplier: 6.32999992
+  Multiplier: 6.33083344
 - StartTime: 180734
-  Multiplier: 6.3499999
+  Multiplier: 6.34500027
 - StartTime: 180742
-  Multiplier: 6.36000013
+  Multiplier: 6.35916662
 - StartTime: 180751
-  Multiplier: 6.36999989
+  Multiplier: 6.37333345
 - StartTime: 180760
-  Multiplier: 6.38999987
+  Multiplier: 6.38749981
 - StartTime: 180768
-  Multiplier: 6.4000001
+  Multiplier: 6.40166664
 - StartTime: 180777
-  Multiplier: 6.42000008
+  Multiplier: 6.415833
 - StartTime: 180786
-  Multiplier: 6.42999983
+  Multiplier: 6.43000031
 - StartTime: 180794
-  Multiplier: 6.44000006
+  Multiplier: 6.44416666
 - StartTime: 180803
-  Multiplier: 6.46000004
+  Multiplier: 6.45833349
 - StartTime: 180812
-  Multiplier: 6.46999979
+  Multiplier: 6.47249985
 - StartTime: 180820
-  Multiplier: 6.48999977
+  Multiplier: 6.48666668
 - StartTime: 180829
-  Multiplier: 6.5
+  Multiplier: 6.50083303
 - StartTime: 180838
-  Multiplier: 6.51000023
+  Multiplier: 6.51499987
 - StartTime: 180846
-  Multiplier: 6.53000021
+  Multiplier: 6.5291667
 - StartTime: 180855
-  Multiplier: 6.53999996
+  Multiplier: 6.54333353
 - StartTime: 180864
-  Multiplier: 6.55999994
+  Multiplier: 6.55749989
 - StartTime: 180872
-  Multiplier: 6.57000017
+  Multiplier: 6.57166672
 - StartTime: 180881
-  Multiplier: 6.59000015
+  Multiplier: 6.58583355
 - StartTime: 180890
   Multiplier: 6.5999999
 - StartTime: 180898
-  Multiplier: 6.61000013
+  Multiplier: 6.61416674
 - StartTime: 180907
-  Multiplier: 6.63000011
+  Multiplier: 6.62833309
 - StartTime: 180916
-  Multiplier: 6.63999987
+  Multiplier: 6.64249992
 - StartTime: 180924
-  Multiplier: 6.65999985
+  Multiplier: 6.65666676
 - StartTime: 180933
-  Multiplier: 6.67000008
+  Multiplier: 6.67083311
 - StartTime: 180942
-  Multiplier: 6.67999983
+  Multiplier: 6.68499994
 - StartTime: 180950
-  Multiplier: 6.69999981
+  Multiplier: 6.69916677
 - StartTime: 180959
-  Multiplier: 6.71000004
+  Multiplier: 6.71333313
 - StartTime: 180968
-  Multiplier: 6.73000002
+  Multiplier: 6.72749996
 - StartTime: 180976
-  Multiplier: 6.73999977
+  Multiplier: 6.74166679
 - StartTime: 180985
-  Multiplier: 6.76000023
+  Multiplier: 6.75583315
 - StartTime: 180994
   Multiplier: 6.76999998
 - StartTime: 181002
-  Multiplier: 6.78000021
+  Multiplier: 6.78416681
 - StartTime: 181011
-  Multiplier: 6.80000019
+  Multiplier: 6.79833317
 - StartTime: 181020
-  Multiplier: 6.80999994
+  Multiplier: 6.8125
 - StartTime: 181028
-  Multiplier: 6.82999992
+  Multiplier: 6.82666683
 - StartTime: 181037
-  Multiplier: 6.84000015
+  Multiplier: 6.84083319
 - StartTime: 181046
-  Multiplier: 6.86000013
+  Multiplier: 6.85500002
 - StartTime: 181054
-  Multiplier: 6.86999989
+  Multiplier: 6.86916637
 - StartTime: 181063
-  Multiplier: 6.88000011
+  Multiplier: 6.88333321
 - StartTime: 181072
-  Multiplier: 6.9000001
+  Multiplier: 6.89750004
 - StartTime: 181080
-  Multiplier: 6.90999985
+  Multiplier: 6.91166687
 - StartTime: 181089
-  Multiplier: 6.92999983
+  Multiplier: 6.92583323
 - StartTime: 181098
   Multiplier: 6.94000006
 - StartTime: 181106
-  Multiplier: 6.94999981
+  Multiplier: 6.95416641
 - StartTime: 181115
-  Multiplier: 6.96999979
+  Multiplier: 6.96833324
 - StartTime: 181124
-  Multiplier: 6.98000002
+  Multiplier: 6.98250008
 - StartTime: 181132
-  Multiplier: 7
+  Multiplier: 6.99666643
 - StartTime: 181141
-  Multiplier: 7.01000023
+  Multiplier: 7.01083326
 - StartTime: 181150
-  Multiplier: 7.03000021
+  Multiplier: 7.0250001
 - StartTime: 181158
-  Multiplier: 7.03999996
+  Multiplier: 7.03916645
 - StartTime: 181167
-  Multiplier: 7.05000019
+  Multiplier: 7.05333376
 - StartTime: 181176
-  Multiplier: 7.07000017
+  Multiplier: 7.06750011
 - StartTime: 181184
-  Multiplier: 7.07999992
+  Multiplier: 7.08166647
 - StartTime: 181193
-  Multiplier: 7.0999999
+  Multiplier: 7.0958333
 - StartTime: 181202
   Multiplier: 7.11000013
 - StartTime: 181210
-  Multiplier: 7.11999989
+  Multiplier: 7.12416649
 - StartTime: 181219
-  Multiplier: 7.13999987
+  Multiplier: 7.13833332
 - StartTime: 181228
-  Multiplier: 7.1500001
+  Multiplier: 7.15249968
 - StartTime: 181236
-  Multiplier: 7.17000008
+  Multiplier: 7.16666651
 - StartTime: 181245
-  Multiplier: 7.17999983
+  Multiplier: 7.18083334
 - StartTime: 181254
-  Multiplier: 7.19000006
+  Multiplier: 7.19500017
 - StartTime: 181262
-  Multiplier: 7.21000004
+  Multiplier: 7.20916653
 - StartTime: 181271
-  Multiplier: 7.21999979
+  Multiplier: 7.22333336
 - StartTime: 181280
-  Multiplier: 7.23999977
+  Multiplier: 7.23749971
 - StartTime: 181288
-  Multiplier: 7.25
+  Multiplier: 7.25166655
 - StartTime: 181297
-  Multiplier: 7.26999998
+  Multiplier: 7.26583338
 - StartTime: 181306
   Multiplier: 7.28000021
 - StartTime: 181314
-  Multiplier: 7.28999996
+  Multiplier: 7.29416656
 - StartTime: 181323
-  Multiplier: 7.30999994
+  Multiplier: 7.3083334
 - StartTime: 181332
-  Multiplier: 7.32000017
+  Multiplier: 7.32250023
 - StartTime: 181340
-  Multiplier: 7.34000015
+  Multiplier: 7.33666658
 - StartTime: 181349
-  Multiplier: 7.3499999
+  Multiplier: 7.35083342
 - StartTime: 181358
-  Multiplier: 7.36999989
+  Multiplier: 7.36500025
 - StartTime: 181366
-  Multiplier: 7.38000011
+  Multiplier: 7.37916708
 - StartTime: 181375
-  Multiplier: 7.38999987
+  Multiplier: 7.39333344
 - StartTime: 181384
-  Multiplier: 7.40999985
+  Multiplier: 7.40750027
 - StartTime: 181392
-  Multiplier: 7.42000008
+  Multiplier: 7.4216671
 - StartTime: 181401
-  Multiplier: 7.44000006
+  Multiplier: 7.43583345
 - StartTime: 181410
   Multiplier: 7.44999981
 - StartTime: 181418
-  Multiplier: 7.46000004
+  Multiplier: 7.46416664
 - StartTime: 181427
-  Multiplier: 7.48000002
+  Multiplier: 7.47833347
 - StartTime: 181436
-  Multiplier: 7.48999977
+  Multiplier: 7.49250031
 - StartTime: 181444
-  Multiplier: 7.51000023
+  Multiplier: 7.50666666
 - StartTime: 181453
-  Multiplier: 7.51999998
+  Multiplier: 7.52083302
 - StartTime: 181462
-  Multiplier: 7.53000021
+  Multiplier: 7.53499985
 - StartTime: 181470
-  Multiplier: 7.55000019
+  Multiplier: 7.54916668
 - StartTime: 181479
-  Multiplier: 7.55999994
+  Multiplier: 7.56333351
 - StartTime: 181488
-  Multiplier: 7.57999992
+  Multiplier: 7.57750034
 - StartTime: 181496
-  Multiplier: 7.59000015
+  Multiplier: 7.59166622
 - StartTime: 181505
-  Multiplier: 7.61000013
+  Multiplier: 7.60583305
 - StartTime: 181514
   Multiplier: 7.61999989
 - StartTime: 181522
-  Multiplier: 7.63000011
+  Multiplier: 7.63416672
 - StartTime: 181531
-  Multiplier: 7.6500001
+  Multiplier: 7.64833307
 - StartTime: 181540
-  Multiplier: 7.65999985
+  Multiplier: 7.66250038
 - StartTime: 181548
-  Multiplier: 7.67999983
+  Multiplier: 7.67666674
 - StartTime: 181557
-  Multiplier: 7.69000006
+  Multiplier: 7.69083357
 - StartTime: 181566
-  Multiplier: 7.69999981
+  Multiplier: 7.70499992
 - StartTime: 181574
-  Multiplier: 7.71999979
+  Multiplier: 7.71916676
 - StartTime: 181583
-  Multiplier: 7.73000002
+  Multiplier: 7.73333359
 - StartTime: 181592
-  Multiplier: 7.75
+  Multiplier: 7.74749994
 - StartTime: 181600
-  Multiplier: 7.76000023
+  Multiplier: 7.7616663
 - StartTime: 181609
-  Multiplier: 7.78000021
+  Multiplier: 7.77583313
 - StartTime: 181618
   Multiplier: 7.78999996
 - StartTime: 181626
-  Multiplier: 7.80000019
+  Multiplier: 7.80416632
 - StartTime: 181635
-  Multiplier: 7.82000017
+  Multiplier: 7.81833315
 - StartTime: 181644
-  Multiplier: 7.82999992
+  Multiplier: 7.83249998
 - StartTime: 181652
-  Multiplier: 7.8499999
+  Multiplier: 7.84666634
 - StartTime: 181661
-  Multiplier: 7.86000013
+  Multiplier: 7.86083364
 - StartTime: 181670
-  Multiplier: 7.86999989
+  Multiplier: 7.875
 - StartTime: 181678
-  Multiplier: 7.88999987
+  Multiplier: 7.88916683
 - StartTime: 181687
-  Multiplier: 7.9000001
+  Multiplier: 7.90333319
 - StartTime: 181696
-  Multiplier: 7.92000008
+  Multiplier: 7.9175005
 - StartTime: 181704
-  Multiplier: 7.92999983
+  Multiplier: 7.93166637
 - StartTime: 181713
-  Multiplier: 7.94999981
+  Multiplier: 7.94583321
 - StartTime: 181722
   Multiplier: 7.96000004
 - StartTime: 181730
-  Multiplier: 7.96999979
+  Multiplier: 7.97416687
 - StartTime: 181739
-  Multiplier: 7.98999977
+  Multiplier: 7.98833323
 - StartTime: 181748
-  Multiplier: 8
+  Multiplier: 8.00250053
 - StartTime: 181756
-  Multiplier: 8.02000046
+  Multiplier: 8.01666641
 - StartTime: 181765
-  Multiplier: 8.02999973
+  Multiplier: 8.03083324
 - StartTime: 181774
-  Multiplier: 8.03999996
+  Multiplier: 8.04500008
 - StartTime: 181782
-  Multiplier: 8.06000042
+  Multiplier: 8.05916691
 - StartTime: 181791
-  Multiplier: 8.06999969
+  Multiplier: 8.07333374
 - StartTime: 181800
-  Multiplier: 8.09000015
+  Multiplier: 8.08749962
 - StartTime: 181808
-  Multiplier: 8.10000038
+  Multiplier: 8.10166645
 - StartTime: 181817
-  Multiplier: 8.11999989
+  Multiplier: 8.11583328
 - StartTime: 181826
   Multiplier: 8.13000011
 - StartTime: 181834
-  Multiplier: 8.14000034
+  Multiplier: 8.14416599
 - StartTime: 181843
-  Multiplier: 8.15999985
+  Multiplier: 8.15833378
 - StartTime: 181852
-  Multiplier: 8.17000008
+  Multiplier: 8.17250061
 - StartTime: 181860
-  Multiplier: 8.18999958
+  Multiplier: 8.18666649
 - StartTime: 181869
-  Multiplier: 8.19999981
+  Multiplier: 8.20083332
 - StartTime: 181878
-  Multiplier: 8.22000027
+  Multiplier: 8.21500015
 - StartTime: 181886
-  Multiplier: 8.22999954
+  Multiplier: 8.22916698
 - StartTime: 181895
-  Multiplier: 8.23999977
+  Multiplier: 8.24333382
 - StartTime: 181904
-  Multiplier: 8.26000023
+  Multiplier: 8.25749969
 - StartTime: 181912
-  Multiplier: 8.27000046
+  Multiplier: 8.27166653
 - StartTime: 181921
-  Multiplier: 8.28999996
+  Multiplier: 8.28583336
 - StartTime: 181930
   Multiplier: 8.30000019
 - StartTime: 181938
-  Multiplier: 8.31000042
+  Multiplier: 8.31416702
 - StartTime: 181947
-  Multiplier: 8.32999992
+  Multiplier: 8.32833385
 - StartTime: 181956
-  Multiplier: 8.34000015
+  Multiplier: 8.34249973
 - StartTime: 181964
-  Multiplier: 8.35999966
+  Multiplier: 8.35666656
 - StartTime: 181973
-  Multiplier: 8.36999989
+  Multiplier: 8.3708334
 - StartTime: 181982
-  Multiplier: 8.38000011
+  Multiplier: 8.38500023
 - StartTime: 181990
-  Multiplier: 8.39999962
+  Multiplier: 8.39916706
 - StartTime: 181999
-  Multiplier: 8.40999985
+  Multiplier: 8.41333294
 - StartTime: 182008
-  Multiplier: 8.43000031
+  Multiplier: 8.42749977
 - StartTime: 182016
-  Multiplier: 8.43999958
+  Multiplier: 8.4416666
 - StartTime: 182025
-  Multiplier: 8.46000004
+  Multiplier: 8.45583344
 - StartTime: 182034
   Multiplier: 8.47000027
 - StartTime: 182042
-  Multiplier: 8.47999954
+  Multiplier: 8.4841671
 - StartTime: 182051
-  Multiplier: 8.5
+  Multiplier: 8.49833298
 - StartTime: 182060
-  Multiplier: 8.51000023
+  Multiplier: 8.51250076
 - StartTime: 182068
-  Multiplier: 8.52999973
+  Multiplier: 8.52666664
 - StartTime: 182077
-  Multiplier: 8.53999996
+  Multiplier: 8.54083347
 - StartTime: 182086
-  Multiplier: 8.56000042
+  Multiplier: 8.55500031
 - StartTime: 182094
-  Multiplier: 8.56999969
+  Multiplier: 8.56916618
 - StartTime: 182103
-  Multiplier: 8.57999992
+  Multiplier: 8.58333397
 - StartTime: 182112
-  Multiplier: 8.60000038
+  Multiplier: 8.59749985
 - StartTime: 182120
-  Multiplier: 8.60999966
+  Multiplier: 8.61166668
 - StartTime: 182129
-  Multiplier: 8.63000011
+  Multiplier: 8.62583351
 - StartTime: 182138
   Multiplier: 8.64000034
 - StartTime: 182146
-  Multiplier: 8.64999962
+  Multiplier: 8.65416718
 - StartTime: 182155
-  Multiplier: 8.67000008
+  Multiplier: 8.66833305
 - StartTime: 182164
-  Multiplier: 8.68000031
+  Multiplier: 8.68249989
 - StartTime: 182969
-  Multiplier: 4.57999992
+  Multiplier: 4.5842104
 - StartTime: 182982
-  Multiplier: 0.0500000007
+  Multiplier: 0.100000001
 - StartTime: 183102
   Multiplier: 9.10000038
 - StartTime: 183108
   Multiplier: 0.100000001
 - StartTime: 183169
-  Multiplier: 9.23999977
+  Multiplier: 9.2378788
 - StartTime: 183175
-  Multiplier: 0.100000001
+  Multiplier: 0.101515152
 - StartTime: 183235
   Multiplier: 9.10000038
 - StartTime: 183241
@@ -23282,13 +28612,13 @@ SliderVelocities:
 - StartTime: 183308
   Multiplier: 0.100000001
 - StartTime: 183369
-  Multiplier: 18.4799995
+  Multiplier: 10
 - StartTime: 183372
-  Multiplier: 0.200000003
+  Multiplier: 0.203030303
 - StartTime: 183402
-  Multiplier: 18.4799995
+  Multiplier: 10
 - StartTime: 183405
-  Multiplier: 0.200000003
+  Multiplier: 0.203030303
 - StartTime: 183435
   Multiplier: 9.10000038
 - StartTime: 183441
@@ -23298,9 +28628,9 @@ SliderVelocities:
 - StartTime: 183508
   Multiplier: 0.100000001
 - StartTime: 183569
-  Multiplier: 9.23999977
+  Multiplier: 9.2378788
 - StartTime: 183575
-  Multiplier: 0.100000001
+  Multiplier: 0.101515152
 - StartTime: 183635
   Multiplier: 9.10000038
 - StartTime: 183641
@@ -23310,9 +28640,9 @@ SliderVelocities:
 - StartTime: 183708
   Multiplier: 0.100000001
 - StartTime: 183769
-  Multiplier: 9.23999977
+  Multiplier: 9.2378788
 - StartTime: 183775
-  Multiplier: 0.100000001
+  Multiplier: 0.101515152
 - StartTime: 183835
   Multiplier: 9.10000038
 - StartTime: 183841
@@ -23322,9 +28652,9 @@ SliderVelocities:
 - StartTime: 183908
   Multiplier: 0.100000001
 - StartTime: 183969
-  Multiplier: 9.23999977
+  Multiplier: 9.2378788
 - StartTime: 183975
-  Multiplier: 0.100000001
+  Multiplier: 0.101515152
 - StartTime: 184035
   Multiplier: 9.10000038
 - StartTime: 184041
@@ -23334,9 +28664,9 @@ SliderVelocities:
 - StartTime: 184108
   Multiplier: 0.100000001
 - StartTime: 184169
-  Multiplier: 9.23999977
+  Multiplier: 9.2378788
 - StartTime: 184175
-  Multiplier: 0.100000001
+  Multiplier: 0.101515152
 - StartTime: 184235
   Multiplier: 9.10000038
 - StartTime: 184241
@@ -23346,21 +28676,21 @@ SliderVelocities:
 - StartTime: 184308
   Multiplier: 0.100000001
 - StartTime: 184369
-  Multiplier: 9.23999977
+  Multiplier: 9.2378788
 - StartTime: 184375
-  Multiplier: 0.100000001
+  Multiplier: 0.101515152
 - StartTime: 184435
   Multiplier: 9.10000038
 - StartTime: 184441
   Multiplier: 0.100000001
 - StartTime: 184502
-  Multiplier: 2.27999997
+  Multiplier: 2.28352046
 - StartTime: 184528
-  Multiplier: 0.0299999993
-- StartTime: 184769
-  Multiplier: 9.23999977
-- StartTime: 184775
   Multiplier: 0.100000001
+- StartTime: 184769
+  Multiplier: 9.2378788
+- StartTime: 184775
+  Multiplier: 0.101515152
 - StartTime: 184835
   Multiplier: 9.10000038
 - StartTime: 184841
@@ -23370,9 +28700,9 @@ SliderVelocities:
 - StartTime: 184908
   Multiplier: 0.100000001
 - StartTime: 184969
-  Multiplier: 9.23999977
+  Multiplier: 9.2378788
 - StartTime: 184975
-  Multiplier: 0.100000001
+  Multiplier: 0.101515152
 - StartTime: 185035
   Multiplier: 9.10000038
 - StartTime: 185041
@@ -23382,9 +28712,9 @@ SliderVelocities:
 - StartTime: 185108
   Multiplier: 0.100000001
 - StartTime: 185169
-  Multiplier: 9.23999977
+  Multiplier: 9.2378788
 - StartTime: 185175
-  Multiplier: 0.100000001
+  Multiplier: 0.101515152
 - StartTime: 185235
   Multiplier: 9.10000038
 - StartTime: 185241
@@ -23394,9 +28724,9 @@ SliderVelocities:
 - StartTime: 185308
   Multiplier: 0.100000001
 - StartTime: 185369
-  Multiplier: 9.23999977
+  Multiplier: 9.2378788
 - StartTime: 185375
-  Multiplier: 0.100000001
+  Multiplier: 0.101515152
 - StartTime: 185435
   Multiplier: 9.10000038
 - StartTime: 185441
@@ -23406,9 +28736,9 @@ SliderVelocities:
 - StartTime: 185508
   Multiplier: 0.100000001
 - StartTime: 185569
-  Multiplier: 9.23999977
+  Multiplier: 9.2378788
 - StartTime: 185575
-  Multiplier: 0.100000001
+  Multiplier: 0.101515152
 - StartTime: 185635
   Multiplier: 9.10000038
 - StartTime: 185641
@@ -23418,9 +28748,9 @@ SliderVelocities:
 - StartTime: 185708
   Multiplier: 0.100000001
 - StartTime: 185769
-  Multiplier: 9.23999977
+  Multiplier: 9.2378788
 - StartTime: 185775
-  Multiplier: 0.100000001
+  Multiplier: 0.101515152
 - StartTime: 185835
   Multiplier: 9.10000038
 - StartTime: 185841
@@ -23430,21 +28760,21 @@ SliderVelocities:
 - StartTime: 185908
   Multiplier: 0.100000001
 - StartTime: 185969
-  Multiplier: 9.23999977
+  Multiplier: 9.2378788
 - StartTime: 185975
-  Multiplier: 0.100000001
+  Multiplier: 0.101515152
 - StartTime: 186035
   Multiplier: 9.10000038
 - StartTime: 186041
   Multiplier: 0.100000001
 - StartTime: 186102
-  Multiplier: 2.27999997
+  Multiplier: 2.28352046
 - StartTime: 186128
-  Multiplier: 0.0299999993
-- StartTime: 186369
-  Multiplier: 9.23999977
-- StartTime: 186375
   Multiplier: 0.100000001
+- StartTime: 186369
+  Multiplier: 9.2378788
+- StartTime: 186375
+  Multiplier: 0.101515152
 - StartTime: 186435
   Multiplier: 9.10000038
 - StartTime: 186441
@@ -23454,17 +28784,17 @@ SliderVelocities:
 - StartTime: 186508
   Multiplier: 0.100000001
 - StartTime: 186569
-  Multiplier: 9.23999977
+  Multiplier: 9.2378788
 - StartTime: 186575
-  Multiplier: 0.100000001
+  Multiplier: 0.101515152
 - StartTime: 186635
   Multiplier: 4.55000019
 - StartTime: 186648
-  Multiplier: 0.0500000007
-- StartTime: 186769
-  Multiplier: 9.23999977
-- StartTime: 186775
   Multiplier: 0.100000001
+- StartTime: 186769
+  Multiplier: 9.2378788
+- StartTime: 186775
+  Multiplier: 0.101515152
 - StartTime: 186835
   Multiplier: 9.10000038
 - StartTime: 186841
@@ -23474,13 +28804,13 @@ SliderVelocities:
 - StartTime: 186908
   Multiplier: 0.100000001
 - StartTime: 186969
-  Multiplier: 3.04999995
+  Multiplier: 3.04850006
 - StartTime: 186989
-  Multiplier: 0.0299999993
-- StartTime: 187169
-  Multiplier: 9.23999977
-- StartTime: 187175
   Multiplier: 0.100000001
+- StartTime: 187169
+  Multiplier: 9.2378788
+- StartTime: 187175
+  Multiplier: 0.101515152
 - StartTime: 187235
   Multiplier: 9.10000038
 - StartTime: 187241
@@ -23490,17 +28820,17 @@ SliderVelocities:
 - StartTime: 187308
   Multiplier: 0.100000001
 - StartTime: 187369
-  Multiplier: 9.23999977
+  Multiplier: 9.2378788
 - StartTime: 187375
-  Multiplier: 0.100000001
+  Multiplier: 0.101515152
 - StartTime: 187435
   Multiplier: 4.55000019
 - StartTime: 187448
-  Multiplier: 0.0500000007
-- StartTime: 187569
-  Multiplier: 9.23999977
-- StartTime: 187575
   Multiplier: 0.100000001
+- StartTime: 187569
+  Multiplier: 9.2378788
+- StartTime: 187575
+  Multiplier: 0.101515152
 - StartTime: 187635
   Multiplier: 9.10000038
 - StartTime: 187641
@@ -23510,13 +28840,13 @@ SliderVelocities:
 - StartTime: 187708
   Multiplier: 0.100000001
 - StartTime: 187769
-  Multiplier: 3.04999995
+  Multiplier: 3.04850006
 - StartTime: 187789
-  Multiplier: 0.0299999993
-- StartTime: 187969
-  Multiplier: 9.23999977
-- StartTime: 187975
   Multiplier: 0.100000001
+- StartTime: 187969
+  Multiplier: 9.2378788
+- StartTime: 187975
+  Multiplier: 0.101515152
 - StartTime: 188035
   Multiplier: 9.10000038
 - StartTime: 188041
@@ -23526,13 +28856,13 @@ SliderVelocities:
 - StartTime: 188108
   Multiplier: 0.100000001
 - StartTime: 188169
-  Multiplier: 3.04999995
+  Multiplier: 3.04850006
 - StartTime: 188189
-  Multiplier: 0.0299999993
-- StartTime: 188369
-  Multiplier: 9.23999977
-- StartTime: 188375
   Multiplier: 0.100000001
+- StartTime: 188369
+  Multiplier: 9.2378788
+- StartTime: 188375
+  Multiplier: 0.101515152
 - StartTime: 188435
   Multiplier: 9.10000038
 - StartTime: 188441
@@ -23542,17 +28872,17 @@ SliderVelocities:
 - StartTime: 188508
   Multiplier: 0.100000001
 - StartTime: 188569
-  Multiplier: 4.57999992
+  Multiplier: 4.5842104
 - StartTime: 188582
-  Multiplier: 0.0500000007
+  Multiplier: 0.100000001
 - StartTime: 188702
-  Multiplier: 4.57999992
+  Multiplier: 4.5842104
 - StartTime: 188715
-  Multiplier: 0.0500000007
+  Multiplier: 0.100000001
 - StartTime: 188835
   Multiplier: 4.55000019
 - StartTime: 188848
-  Multiplier: 0.0500000007
+  Multiplier: 0.100000001
 - StartTime: 189770
   Multiplier: 2
 - StartTime: 189820
@@ -23598,11 +28928,11 @@ SliderVelocities:
 - StartTime: 195369
   Multiplier: 2.29999995
 - StartTime: 195489
-  Multiplier: 0.439999998
+  Multiplier: 0.442857116
 - StartTime: 195769
   Multiplier: 2.29999995
 - StartTime: 195889
-  Multiplier: 0.439999998
+  Multiplier: 0.442857116
 - StartTime: 196170
   Multiplier: 2
 - StartTime: 196220
@@ -23706,19 +29036,19 @@ SliderVelocities:
 - StartTime: 202201
   Multiplier: 0.100000001
 - StartTime: 202269
-  Multiplier: 8.10000038
+  Multiplier: 8.09999943
 - StartTime: 202276
   Multiplier: 0.100000001
 - StartTime: 202344
-  Multiplier: 8.10000038
+  Multiplier: 8.09999943
 - StartTime: 202351
   Multiplier: 0.100000001
 - StartTime: 202419
-  Multiplier: 8.10000038
+  Multiplier: 8.09999943
 - StartTime: 202426
   Multiplier: 0.100000001
 - StartTime: 202494
-  Multiplier: 8.10000038
+  Multiplier: 8.09999943
 - StartTime: 202501
   Multiplier: 0.100000001
 - StartTime: 202569
@@ -23764,7380 +29094,5069 @@ SliderVelocities:
 - StartTime: 207769
   Multiplier: 1
 - StartTime: 207785
-  Multiplier: 1
+  Multiplier: 1.00012004
 - StartTime: 207801
-  Multiplier: 1
+  Multiplier: 1.00047994
 - StartTime: 207817
-  Multiplier: 1
+  Multiplier: 1.00108004
 - StartTime: 207833
-  Multiplier: 1
+  Multiplier: 1.00191998
 - StartTime: 207849
-  Multiplier: 1
+  Multiplier: 1.00300002
 - StartTime: 207865
-  Multiplier: 1
+  Multiplier: 1.00432003
 - StartTime: 207881
-  Multiplier: 1.00999999
+  Multiplier: 1.00588
 - StartTime: 207897
-  Multiplier: 1.00999999
+  Multiplier: 1.00767994
 - StartTime: 207913
-  Multiplier: 1.00999999
+  Multiplier: 1.00972009
 - StartTime: 207929
-  Multiplier: 1.00999999
+  Multiplier: 1.01199996
 - StartTime: 207945
-  Multiplier: 1.00999999
+  Multiplier: 1.01452005
 - StartTime: 207961
-  Multiplier: 1.01999998
+  Multiplier: 1.01727998
 - StartTime: 207977
-  Multiplier: 1.01999998
+  Multiplier: 1.02028
 - StartTime: 207993
-  Multiplier: 1.01999998
+  Multiplier: 1.02351999
 - StartTime: 208009
-  Multiplier: 1.02999997
+  Multiplier: 1.02699995
 - StartTime: 208025
-  Multiplier: 1.02999997
+  Multiplier: 1.03072
 - StartTime: 208041
-  Multiplier: 1.02999997
+  Multiplier: 1.03468001
 - StartTime: 208057
-  Multiplier: 1.03999996
+  Multiplier: 1.03887999
 - StartTime: 208073
-  Multiplier: 1.03999996
+  Multiplier: 1.04332006
 - StartTime: 208089
-  Multiplier: 1.04999995
+  Multiplier: 1.04799998
 - StartTime: 208105
-  Multiplier: 1.04999995
+  Multiplier: 1.05291998
 - StartTime: 208121
-  Multiplier: 1.05999994
+  Multiplier: 1.05807996
 - StartTime: 208137
-  Multiplier: 1.05999994
+  Multiplier: 1.06348002
 - StartTime: 208153
-  Multiplier: 1.07000005
+  Multiplier: 1.06912005
 - StartTime: 208169
-  Multiplier: 1.08000004
+  Multiplier: 1.07500005
 - StartTime: 208185
-  Multiplier: 1.08000004
+  Multiplier: 1.08112001
 - StartTime: 208201
-  Multiplier: 1.09000003
+  Multiplier: 1.08748007
 - StartTime: 208217
-  Multiplier: 1.09000003
+  Multiplier: 1.09407997
 - StartTime: 208233
-  Multiplier: 1.10000002
+  Multiplier: 1.10091996
 - StartTime: 208249
-  Multiplier: 1.11000001
+  Multiplier: 1.10800004
 - StartTime: 208265
-  Multiplier: 1.12
+  Multiplier: 1.11531997
 - StartTime: 208281
-  Multiplier: 1.12
+  Multiplier: 1.12287998
 - StartTime: 208297
-  Multiplier: 1.13
+  Multiplier: 1.13067997
 - StartTime: 208313
-  Multiplier: 1.13999999
+  Multiplier: 1.13872004
 - StartTime: 208329
-  Multiplier: 1.14999998
+  Multiplier: 1.14699996
 - StartTime: 208345
-  Multiplier: 1.15999997
+  Multiplier: 1.15552008
 - StartTime: 208361
-  Multiplier: 1.15999997
+  Multiplier: 1.16428006
 - StartTime: 208377
-  Multiplier: 1.16999996
+  Multiplier: 1.17328
 - StartTime: 208393
-  Multiplier: 1.17999995
+  Multiplier: 1.18252003
 - StartTime: 208409
-  Multiplier: 1.19000006
+  Multiplier: 1.19200003
 - StartTime: 208425
-  Multiplier: 1.20000005
+  Multiplier: 1.20172
 - StartTime: 208441
-  Multiplier: 1.21000004
+  Multiplier: 1.21167994
 - StartTime: 208457
-  Multiplier: 1.22000003
+  Multiplier: 1.22188008
 - StartTime: 208473
-  Multiplier: 1.23000002
+  Multiplier: 1.23232007
 - StartTime: 208489
-  Multiplier: 1.24000001
+  Multiplier: 1.24300003
 - StartTime: 208505
-  Multiplier: 1.25
+  Multiplier: 1.25392008
 - StartTime: 208521
-  Multiplier: 1.26999998
+  Multiplier: 1.26507998
 - StartTime: 208537
-  Multiplier: 1.27999997
+  Multiplier: 1.27647996
 - StartTime: 208553
-  Multiplier: 1.28999996
+  Multiplier: 1.28812003
 - StartTime: 208569
   Multiplier: 8
 - StartTime: 208582
-  Multiplier: 0.560000002
+  Multiplier: 0.555555582
 - StartTime: 208702
-  Multiplier: 3.99000001
+  Multiplier: 3.98501873
 - StartTime: 208728
-  Multiplier: 0.280000001
+  Multiplier: 0.276737392
 - StartTime: 208969
   Multiplier: 4
 - StartTime: 208995
-  Multiplier: 0.280000001
+  Multiplier: 0.277777791
 - StartTime: 209235
-  Multiplier: 3.99000001
+  Multiplier: 3.98501873
 - StartTime: 209261
-  Multiplier: 0.280000001
+  Multiplier: 0.276737392
 - StartTime: 209502
-  Multiplier: 3.99000001
+  Multiplier: 3.98501873
 - StartTime: 209528
-  Multiplier: 0.280000001
+  Multiplier: 0.276737392
 - StartTime: 209769
   Multiplier: 4
 - StartTime: 209795
-  Multiplier: 0.280000001
+  Multiplier: 0.277777791
 - StartTime: 210035
-  Multiplier: 3.99000001
+  Multiplier: 3.98501873
 - StartTime: 210061
-  Multiplier: 0.280000001
+  Multiplier: 0.276737392
 - StartTime: 210302
-  Multiplier: 3.99000001
+  Multiplier: 3.98501873
 - StartTime: 210328
-  Multiplier: 0.280000001
+  Multiplier: 0.276737392
 - StartTime: 210569
   Multiplier: 4
 - StartTime: 210595
-  Multiplier: 0.280000001
+  Multiplier: 0.277777791
 - StartTime: 210835
-  Multiplier: 3.99000001
+  Multiplier: 3.98501873
 - StartTime: 210861
-  Multiplier: 0.280000001
+  Multiplier: 0.276737392
 - StartTime: 211102
-  Multiplier: 3.99000001
+  Multiplier: 3.98501873
 - StartTime: 211128
-  Multiplier: 0.280000001
+  Multiplier: 0.276737392
 - StartTime: 211369
   Multiplier: 4
 - StartTime: 211395
-  Multiplier: 0.280000001
+  Multiplier: 0.277777791
 - StartTime: 211635
-  Multiplier: 3.99000001
+  Multiplier: 3.98501873
 - StartTime: 211661
-  Multiplier: 0.280000001
+  Multiplier: 0.276737392
 - StartTime: 211902
-  Multiplier: 3.99000001
+  Multiplier: 3.98501873
 - StartTime: 211928
-  Multiplier: 0.280000001
+  Multiplier: 0.276737392
 - StartTime: 212169
   Multiplier: 4
 - StartTime: 212195
-  Multiplier: 0.280000001
+  Multiplier: 0.277777791
 - StartTime: 212435
-  Multiplier: 3.99000001
+  Multiplier: 3.98501873
 - StartTime: 212461
-  Multiplier: 0.280000001
+  Multiplier: 0.276737392
 - StartTime: 212702
-  Multiplier: 3.99000001
+  Multiplier: 3.98501873
 - StartTime: 212728
-  Multiplier: 0.280000001
+  Multiplier: 0.276737392
 - StartTime: 212969
   Multiplier: 4
 - StartTime: 212995
-  Multiplier: 0.280000001
+  Multiplier: 0.277777791
 - StartTime: 213235
-  Multiplier: 7.94000006
+  Multiplier: 7.94029856
 - StartTime: 213248
-  Multiplier: 0.550000012
+  Multiplier: 0.551409662
 HitObjects:
 - StartTime: 969
   Lane: 4
-  HitSound: Normal
 - StartTime: 969
   Lane: 2
-  HitSound: Normal
 - StartTime: 969
   Lane: 1
-  HitSound: Normal
 - StartTime: 969
   Lane: 3
   EndTime: 1369
-  HitSound: Normal
 - StartTime: 1369
   Lane: 2
-  HitSound: Normal
 - StartTime: 1569
   Lane: 2
-  HitSound: Normal
 - StartTime: 1769
   Lane: 4
-  HitSound: Normal
 - StartTime: 1769
   Lane: 1
-  HitSound: Normal
 - StartTime: 1769
   Lane: 2
-  HitSound: Normal
 - StartTime: 1769
   Lane: 3
   EndTime: 2169
-  HitSound: Normal
 - StartTime: 2169
   Lane: 1
-  HitSound: Normal
 - StartTime: 2369
   Lane: 1
-  HitSound: Normal
 - StartTime: 2569
   Lane: 4
-  HitSound: Normal
 - StartTime: 2569
   Lane: 3
-  HitSound: Normal
 - StartTime: 2569
   Lane: 1
-  HitSound: Normal
 - StartTime: 2569
   Lane: 2
   EndTime: 2969
-  HitSound: Normal
 - StartTime: 2969
   Lane: 1
-  HitSound: Normal
 - StartTime: 3169
   Lane: 1
-  HitSound: Normal
 - StartTime: 3369
   Lane: 1
-  HitSound: Normal
 - StartTime: 3369
   Lane: 3
-  HitSound: Normal
 - StartTime: 3369
   Lane: 4
-  HitSound: Normal
 - StartTime: 3369
   Lane: 2
   EndTime: 3769
-  HitSound: Normal
 - StartTime: 3769
   Lane: 3
-  HitSound: Normal
 - StartTime: 3969
   Lane: 4
-  HitSound: Normal
 - StartTime: 4169
   Lane: 1
-  HitSound: Normal
 - StartTime: 4169
   Lane: 4
   EndTime: 4569
-  HitSound: Normal
 - StartTime: 4169
   Lane: 3
-  HitSound: Normal
 - StartTime: 4169
   Lane: 2
-  HitSound: Normal
 - StartTime: 4569
   Lane: 2
-  HitSound: Normal
 - StartTime: 4769
   Lane: 2
-  HitSound: Normal
 - StartTime: 4969
   Lane: 2
-  HitSound: Normal
 - StartTime: 4969
   Lane: 4
   EndTime: 5369
-  HitSound: Normal
 - StartTime: 4969
   Lane: 3
-  HitSound: Normal
 - StartTime: 4969
   Lane: 1
-  HitSound: Normal
 - StartTime: 5369
   Lane: 1
-  HitSound: Normal
 - StartTime: 5569
   Lane: 1
-  HitSound: Normal
 - StartTime: 5769
   Lane: 1
-  HitSound: Normal
 - StartTime: 5769
   Lane: 4
-  HitSound: Normal
 - StartTime: 5769
   Lane: 3
-  HitSound: Normal
 - StartTime: 5769
   Lane: 2
   EndTime: 5969
-  HitSound: Normal
 - StartTime: 10169
   Lane: 4
-  HitSound: Normal
 - StartTime: 10169
   Lane: 3
-  HitSound: Normal
 - StartTime: 10169
   Lane: 2
-  HitSound: Normal
 - StartTime: 10169
   Lane: 1
-  HitSound: Normal
 - StartTime: 10369
   Lane: 3
-  HitSound: Normal
 - StartTime: 10569
   Lane: 1
-  HitSound: Normal
 - StartTime: 10569
   Lane: 4
-  HitSound: Normal
 - StartTime: 10569
   Lane: 2
-  HitSound: Normal
 - StartTime: 10569
   Lane: 3
   EndTime: 10969
-  HitSound: Normal
 - StartTime: 10969
   Lane: 2
-  HitSound: Normal
 - StartTime: 10969
   Lane: 1
-  HitSound: Normal
 - StartTime: 11169
   Lane: 3
-  HitSound: Normal
 - StartTime: 11269
   Lane: 2
-  HitSound: Normal
 - StartTime: 11369
   Lane: 3
   EndTime: 11569
-  HitSound: Normal
 - StartTime: 11369
   Lane: 4
-  HitSound: Normal
 - StartTime: 11369
   Lane: 1
-  HitSound: Normal
 - StartTime: 11569
   Lane: 1
-  HitSound: Normal
 - StartTime: 11969
   Lane: 1
-  HitSound: Normal
 - StartTime: 12069
   Lane: 3
-  HitSound: Normal
 - StartTime: 12169
   Lane: 1
-  HitSound: Normal
 - StartTime: 12169
   Lane: 2
   EndTime: 12569
-  HitSound: Normal
 - StartTime: 12169
   Lane: 4
-  HitSound: Normal
 - StartTime: 12369
   Lane: 4
-  HitSound: Normal
 - StartTime: 12569
   Lane: 1
-  HitSound: Normal
 - StartTime: 12569
   Lane: 4
-  HitSound: Normal
 - StartTime: 12569
   Lane: 3
-  HitSound: Normal
 - StartTime: 12769
   Lane: 1
-  HitSound: Normal
 - StartTime: 12869
   Lane: 3
-  HitSound: Normal
 - StartTime: 12969
   Lane: 4
-  HitSound: Normal
 - StartTime: 12969
   Lane: 2
   EndTime: 13169
-  HitSound: Normal
 - StartTime: 12969
   Lane: 1
-  HitSound: Normal
 - StartTime: 13169
   Lane: 4
-  HitSound: Normal
 - StartTime: 13569
   Lane: 4
-  HitSound: Normal
 - StartTime: 13669
   Lane: 3
-  HitSound: Normal
 - StartTime: 13769
   Lane: 2
-  HitSound: Normal
 - StartTime: 13769
   Lane: 1
-  HitSound: Normal
 - StartTime: 13769
   Lane: 4
   EndTime: 14169
-  HitSound: Normal
 - StartTime: 13969
   Lane: 1
-  HitSound: Normal
 - StartTime: 14169
   Lane: 2
-  HitSound: Normal
 - StartTime: 14169
   Lane: 3
-  HitSound: Normal
 - StartTime: 14169
   Lane: 1
-  HitSound: Normal
 - StartTime: 14369
   Lane: 2
-  HitSound: Normal
 - StartTime: 14469
   Lane: 3
-  HitSound: Normal
 - StartTime: 14569
   Lane: 1
-  HitSound: Normal
 - StartTime: 14569
   Lane: 2
-  HitSound: Normal
 - StartTime: 14569
   Lane: 4
   EndTime: 14769
-  HitSound: Normal
 - StartTime: 14769
   Lane: 1
-  HitSound: Normal
 - StartTime: 15169
   Lane: 1
-  HitSound: Normal
 - StartTime: 15269
   Lane: 3
-  HitSound: Normal
 - StartTime: 15369
   Lane: 2
   EndTime: 15569
-  HitSound: Normal
 - StartTime: 15369
   Lane: 1
-  HitSound: Normal
 - StartTime: 15369
   Lane: 4
-  HitSound: Normal
 - StartTime: 15569
   Lane: 4
-  HitSound: Normal
 - StartTime: 15769
   Lane: 4
-  HitSound: Normal
 - StartTime: 15769
   Lane: 3
-  HitSound: Normal
 - StartTime: 15769
   Lane: 2
-  HitSound: Normal
 - StartTime: 15769
   Lane: 1
-  HitSound: Normal
 - StartTime: 15969
   Lane: 3
-  HitSound: Normal
 - StartTime: 16069
   Lane: 2
-  HitSound: Normal
 - StartTime: 16169
   Lane: 4
   EndTime: 16469
-  HitSound: Normal
 - StartTime: 16169
   Lane: 3
   EndTime: 16469
-  HitSound: Normal
 - StartTime: 16169
   Lane: 1
   EndTime: 16469
-  HitSound: Normal
 - StartTime: 16569
   Lane: 2
   EndTime: 16869
-  HitSound: Normal
 - StartTime: 16569
   Lane: 3
   EndTime: 16869
-  HitSound: Normal
 - StartTime: 16569
   Lane: 4
   EndTime: 16869
-  HitSound: Normal
 - StartTime: 16969
   Lane: 1
-  HitSound: Normal
 - StartTime: 16969
   Lane: 4
-  HitSound: Normal
 - StartTime: 16969
   Lane: 2
-  HitSound: Normal
 - StartTime: 16969
   Lane: 3
   EndTime: 17369
-  HitSound: Normal
 - StartTime: 17369
   Lane: 2
-  HitSound: Normal
 - StartTime: 17369
   Lane: 1
-  HitSound: Normal
 - StartTime: 17569
   Lane: 3
-  HitSound: Normal
 - StartTime: 17669
   Lane: 2
-  HitSound: Normal
 - StartTime: 17769
   Lane: 3
   EndTime: 17969
-  HitSound: Normal
 - StartTime: 17769
   Lane: 4
-  HitSound: Normal
 - StartTime: 17769
   Lane: 1
-  HitSound: Normal
 - StartTime: 17969
   Lane: 1
-  HitSound: Normal
 - StartTime: 18369
   Lane: 1
-  HitSound: Normal
 - StartTime: 18469
   Lane: 3
-  HitSound: Normal
 - StartTime: 18569
   Lane: 1
-  HitSound: Normal
 - StartTime: 18569
   Lane: 2
   EndTime: 18969
-  HitSound: Normal
 - StartTime: 18569
   Lane: 4
-  HitSound: Normal
 - StartTime: 18769
   Lane: 4
-  HitSound: Normal
 - StartTime: 18969
   Lane: 1
-  HitSound: Normal
 - StartTime: 18969
   Lane: 4
-  HitSound: Normal
 - StartTime: 18969
   Lane: 3
-  HitSound: Normal
 - StartTime: 19169
   Lane: 1
-  HitSound: Normal
 - StartTime: 19269
   Lane: 3
-  HitSound: Normal
 - StartTime: 19369
   Lane: 4
-  HitSound: Normal
 - StartTime: 19369
   Lane: 2
   EndTime: 19569
-  HitSound: Normal
 - StartTime: 19369
   Lane: 1
-  HitSound: Normal
 - StartTime: 19569
   Lane: 4
-  HitSound: Normal
 - StartTime: 19969
   Lane: 4
-  HitSound: Normal
 - StartTime: 20069
   Lane: 3
-  HitSound: Normal
 - StartTime: 20169
   Lane: 2
-  HitSound: Normal
 - StartTime: 20169
   Lane: 1
-  HitSound: Normal
 - StartTime: 20169
   Lane: 4
   EndTime: 20569
-  HitSound: Normal
 - StartTime: 20369
   Lane: 1
-  HitSound: Normal
 - StartTime: 20569
   Lane: 2
-  HitSound: Normal
 - StartTime: 20569
   Lane: 3
-  HitSound: Normal
 - StartTime: 20569
   Lane: 1
-  HitSound: Normal
 - StartTime: 20769
   Lane: 2
-  HitSound: Normal
 - StartTime: 20869
   Lane: 3
-  HitSound: Normal
 - StartTime: 20969
   Lane: 1
-  HitSound: Normal
 - StartTime: 20969
   Lane: 2
-  HitSound: Normal
 - StartTime: 20969
   Lane: 4
   EndTime: 21169
-  HitSound: Normal
 - StartTime: 21169
   Lane: 1
-  HitSound: Normal
 - StartTime: 21569
   Lane: 1
-  HitSound: Normal
 - StartTime: 21669
   Lane: 3
-  HitSound: Normal
 - StartTime: 21769
   Lane: 2
   EndTime: 21969
-  HitSound: Normal
 - StartTime: 21769
   Lane: 1
-  HitSound: Normal
 - StartTime: 21769
   Lane: 4
-  HitSound: Normal
 - StartTime: 21969
   Lane: 4
-  HitSound: Normal
 - StartTime: 22169
   Lane: 4
-  HitSound: Normal
 - StartTime: 22169
   Lane: 1
-  HitSound: Normal
 - StartTime: 22202
   Lane: 3
-  HitSound: Normal
 - StartTime: 22235
   Lane: 2
-  HitSound: Normal
 - StartTime: 22302
   Lane: 4
-  HitSound: Normal
 - StartTime: 22319
   Lane: 1
-  HitSound: Normal
 - StartTime: 22369
   Lane: 3
-  HitSound: Normal
 - StartTime: 22419
   Lane: 2
-  HitSound: Normal
 - StartTime: 22469
   Lane: 4
-  HitSound: Normal
 - StartTime: 22519
   Lane: 3
-  HitSound: Normal
 - StartTime: 22569
   Lane: 2
-  HitSound: Normal
 - StartTime: 22569
   Lane: 1
-  HitSound: Normal
 - StartTime: 22635
   Lane: 4
-  HitSound: Normal
 - StartTime: 22702
   Lane: 3
-  HitSound: Normal
 - StartTime: 22769
   Lane: 1
-  HitSound: Normal
 - StartTime: 22769
   Lane: 2
-  HitSound: Normal
 - StartTime: 22869
   Lane: 3
-  HitSound: Normal
 - StartTime: 22969
   Lane: 2
-  HitSound: Normal
 - StartTime: 23069
   Lane: 3
-  HitSound: Normal
 - StartTime: 23069
   Lane: 4
-  HitSound: Normal
 - StartTime: 23169
   Lane: 4
-  HitSound: Normal
 - StartTime: 23169
   Lane: 3
-  HitSound: Normal
 - StartTime: 23269
   Lane: 2
-  HitSound: Normal
 - StartTime: 23269
   Lane: 1
-  HitSound: Normal
 - StartTime: 23369
   Lane: 4
-  HitSound: Normal
 - StartTime: 23369
   Lane: 3
-  HitSound: Normal
 - StartTime: 23369
   Lane: 1
-  HitSound: Normal
 - StartTime: 23569
   Lane: 3
-  HitSound: Normal
 - StartTime: 23769
   Lane: 4
-  HitSound: Normal
 - StartTime: 23769
   Lane: 2
-  HitSound: Normal
 - StartTime: 23769
   Lane: 1
-  HitSound: Normal
 - StartTime: 23769
   Lane: 3
-  HitSound: Normal
 - StartTime: 23969
   Lane: 3
-  HitSound: Normal
 - StartTime: 24069
   Lane: 2
-  HitSound: Normal
 - StartTime: 24169
   Lane: 3
   EndTime: 24369
-  HitSound: Normal
 - StartTime: 24169
   Lane: 4
-  HitSound: Normal
 - StartTime: 24169
   Lane: 1
-  HitSound: Normal
 - StartTime: 24369
   Lane: 1
-  HitSound: Normal
 - StartTime: 24769
   Lane: 1
-  HitSound: Normal
 - StartTime: 24869
   Lane: 3
-  HitSound: Normal
 - StartTime: 24969
   Lane: 1
-  HitSound: Normal
 - StartTime: 24969
   Lane: 2
   EndTime: 25369
-  HitSound: Normal
 - StartTime: 24969
   Lane: 4
-  HitSound: Normal
 - StartTime: 25169
   Lane: 4
-  HitSound: Normal
 - StartTime: 25369
   Lane: 1
-  HitSound: Normal
 - StartTime: 25369
   Lane: 4
-  HitSound: Normal
 - StartTime: 25369
   Lane: 3
-  HitSound: Normal
 - StartTime: 25569
   Lane: 1
-  HitSound: Normal
 - StartTime: 25669
   Lane: 3
-  HitSound: Normal
 - StartTime: 25769
   Lane: 4
-  HitSound: Normal
 - StartTime: 25769
   Lane: 2
   EndTime: 25969
-  HitSound: Normal
 - StartTime: 25769
   Lane: 1
-  HitSound: Normal
 - StartTime: 25969
   Lane: 4
-  HitSound: Normal
 - StartTime: 26369
   Lane: 4
-  HitSound: Normal
 - StartTime: 26469
   Lane: 3
-  HitSound: Normal
 - StartTime: 26569
   Lane: 2
-  HitSound: Normal
 - StartTime: 26569
   Lane: 1
-  HitSound: Normal
 - StartTime: 26569
   Lane: 4
   EndTime: 26969
-  HitSound: Normal
 - StartTime: 26769
   Lane: 1
-  HitSound: Normal
 - StartTime: 26969
   Lane: 2
-  HitSound: Normal
 - StartTime: 26969
   Lane: 3
-  HitSound: Normal
 - StartTime: 26969
   Lane: 1
-  HitSound: Normal
 - StartTime: 27169
   Lane: 2
-  HitSound: Normal
 - StartTime: 27269
   Lane: 3
-  HitSound: Normal
 - StartTime: 27369
   Lane: 1
-  HitSound: Normal
 - StartTime: 27369
   Lane: 2
-  HitSound: Normal
 - StartTime: 27369
   Lane: 4
   EndTime: 27569
-  HitSound: Normal
 - StartTime: 27569
   Lane: 1
-  HitSound: Normal
 - StartTime: 27969
   Lane: 1
-  HitSound: Normal
 - StartTime: 28069
   Lane: 3
-  HitSound: Normal
 - StartTime: 28169
   Lane: 2
   EndTime: 28369
-  HitSound: Normal
 - StartTime: 28169
   Lane: 1
-  HitSound: Normal
 - StartTime: 28169
   Lane: 4
-  HitSound: Normal
 - StartTime: 28369
   Lane: 4
-  HitSound: Normal
 - StartTime: 28569
   Lane: 4
-  HitSound: Normal
 - StartTime: 28569
   Lane: 1
-  HitSound: Normal
 - StartTime: 28569
   Lane: 3
-  HitSound: Normal
 - StartTime: 28569
   Lane: 2
-  HitSound: Normal
 - StartTime: 28769
   Lane: 3
-  HitSound: Normal
 - StartTime: 28869
   Lane: 3
-  HitSound: Normal
 - StartTime: 28969
   Lane: 4
-  HitSound: Normal
 - StartTime: 28969
   Lane: 2
-  HitSound: Normal
 - StartTime: 28969
   Lane: 1
-  HitSound: Normal
 - StartTime: 29069
   Lane: 3
-  HitSound: Normal
 - StartTime: 29169
   Lane: 2
-  HitSound: Normal
 - StartTime: 29169
   Lane: 1
-  HitSound: Normal
 - StartTime: 29369
   Lane: 3
-  HitSound: Normal
 - StartTime: 29369
   Lane: 2
-  HitSound: Normal
 - StartTime: 29369
   Lane: 1
-  HitSound: Normal
 - StartTime: 29369
   Lane: 4
   EndTime: 29569
-  HitSound: Normal
 - StartTime: 29569
   Lane: 2
-  HitSound: Normal
 - StartTime: 29569
   Lane: 1
-  HitSound: Normal
 - StartTime: 29769
   Lane: 3
-  HitSound: Normal
 - StartTime: 29869
   Lane: 4
-  HitSound: Normal
 - StartTime: 29969
   Lane: 3
-  HitSound: Normal
 - StartTime: 29969
   Lane: 2
-  HitSound: Normal
 - StartTime: 29969
   Lane: 1
-  HitSound: Normal
 - StartTime: 30169
   Lane: 2
-  HitSound: Normal
 - StartTime: 30169
   Lane: 1
-  HitSound: Normal
 - StartTime: 30169
   Lane: 4
-  HitSound: Normal
 - StartTime: 30169
   Lane: 3
-  HitSound: Normal
 - StartTime: 30369
   Lane: 1
-  HitSound: Normal
 - StartTime: 30369
   Lane: 4
-  HitSound: Normal
 - StartTime: 30369
   Lane: 3
-  HitSound: Normal
 - StartTime: 30769
   Lane: 1
-  HitSound: Normal
 - StartTime: 30769
   Lane: 4
-  HitSound: Normal
 - StartTime: 30769
   Lane: 3
-  HitSound: Normal
 - StartTime: 31169
   Lane: 1
-  HitSound: Normal
 - StartTime: 31169
   Lane: 4
-  HitSound: Normal
 - StartTime: 31169
   Lane: 3
-  HitSound: Normal
 - StartTime: 31569
   Lane: 1
-  HitSound: Normal
 - StartTime: 31569
   Lane: 4
-  HitSound: Normal
 - StartTime: 31569
   Lane: 3
-  HitSound: Normal
 - StartTime: 31769
   Lane: 2
-  HitSound: Normal
 - StartTime: 31769
   Lane: 1
-  HitSound: Normal
 - StartTime: 31769
   Lane: 3
-  HitSound: Normal
 - StartTime: 31769
   Lane: 4
-  HitSound: Normal
 - StartTime: 31969
   Lane: 1
-  HitSound: Normal
 - StartTime: 31969
   Lane: 4
-  HitSound: Normal
 - StartTime: 31969
   Lane: 3
-  HitSound: Normal
 - StartTime: 32369
   Lane: 1
-  HitSound: Normal
 - StartTime: 32369
   Lane: 4
-  HitSound: Normal
 - StartTime: 32369
   Lane: 3
-  HitSound: Normal
 - StartTime: 32569
   Lane: 1
-  HitSound: Normal
 - StartTime: 32569
   Lane: 2
-  HitSound: Normal
 - StartTime: 32569
   Lane: 4
-  HitSound: Normal
 - StartTime: 32569
   Lane: 3
-  HitSound: Normal
 - StartTime: 32769
   Lane: 1
-  HitSound: Normal
 - StartTime: 32769
   Lane: 4
-  HitSound: Normal
 - StartTime: 32769
   Lane: 3
-  HitSound: Normal
 - StartTime: 33169
   Lane: 1
-  HitSound: Normal
 - StartTime: 33169
   Lane: 4
-  HitSound: Normal
 - StartTime: 33169
   Lane: 3
-  HitSound: Normal
 - StartTime: 33369
   Lane: 1
-  HitSound: Normal
 - StartTime: 33369
   Lane: 2
-  HitSound: Normal
 - StartTime: 33369
   Lane: 4
-  HitSound: Normal
 - StartTime: 33369
   Lane: 3
-  HitSound: Normal
 - StartTime: 33569
   Lane: 1
-  HitSound: Normal
 - StartTime: 33569
   Lane: 4
-  HitSound: Normal
 - StartTime: 33569
   Lane: 3
-  HitSound: Normal
 - StartTime: 33969
   Lane: 4
-  HitSound: Normal
 - StartTime: 33969
   Lane: 3
-  HitSound: Normal
 - StartTime: 33969
   Lane: 2
-  HitSound: Normal
 - StartTime: 34169
   Lane: 4
-  HitSound: Normal
 - StartTime: 34169
   Lane: 3
-  HitSound: Normal
 - StartTime: 34169
   Lane: 1
-  HitSound: Normal
 - StartTime: 34269
   Lane: 2
-  HitSound: Normal
 - StartTime: 34469
   Lane: 2
-  HitSound: Normal
 - StartTime: 34569
   Lane: 3
-  HitSound: Normal
 - StartTime: 34569
   Lane: 4
-  HitSound: Normal
 - StartTime: 34569
   Lane: 1
-  HitSound: Normal
 - StartTime: 34669
   Lane: 2
-  HitSound: Normal
 - StartTime: 34869
   Lane: 2
-  HitSound: Normal
 - StartTime: 34969
   Lane: 3
-  HitSound: Normal
 - StartTime: 34969
   Lane: 4
-  HitSound: Normal
 - StartTime: 34969
   Lane: 1
-  HitSound: Normal
 - StartTime: 35069
   Lane: 2
-  HitSound: Normal
 - StartTime: 35269
   Lane: 2
-  HitSound: Normal
 - StartTime: 35369
   Lane: 1
-  HitSound: Normal
 - StartTime: 35369
   Lane: 3
-  HitSound: Normal
 - StartTime: 35369
   Lane: 4
-  HitSound: Normal
 - StartTime: 35469
   Lane: 2
-  HitSound: Normal
 - StartTime: 35669
   Lane: 2
-  HitSound: Normal
 - StartTime: 35769
   Lane: 4
-  HitSound: Normal
 - StartTime: 35769
   Lane: 3
-  HitSound: Normal
 - StartTime: 35769
   Lane: 1
-  HitSound: Normal
 - StartTime: 35869
   Lane: 2
-  HitSound: Normal
 - StartTime: 35969
   Lane: 3
-  HitSound: Normal
 - StartTime: 36069
   Lane: 2
   EndTime: 36269
-  HitSound: Normal
 - StartTime: 36269
   Lane: 3
-  HitSound: Normal
 - StartTime: 36369
   Lane: 2
-  HitSound: Normal
 - StartTime: 36469
   Lane: 1
-  HitSound: Normal
 - StartTime: 36569
   Lane: 3
-  HitSound: Normal
 - StartTime: 36669
   Lane: 2
-  HitSound: Normal
 - StartTime: 36769
   Lane: 3
-  HitSound: Normal
 - StartTime: 36869
   Lane: 4
-  HitSound: Normal
 - StartTime: 36969
   Lane: 2
-  HitSound: Normal
 - StartTime: 37069
   Lane: 1
-  HitSound: Normal
 - StartTime: 37169
   Lane: 2
-  HitSound: Normal
 - StartTime: 37269
   Lane: 4
-  HitSound: Normal
 - StartTime: 37369
   Lane: 2
-  HitSound: Normal
 - StartTime: 37469
   Lane: 3
-  HitSound: Normal
 - StartTime: 37569
   Lane: 1
-  HitSound: Normal
 - StartTime: 37669
   Lane: 2
-  HitSound: Normal
 - StartTime: 37769
   Lane: 3
-  HitSound: Normal
 - StartTime: 37869
   Lane: 1
-  HitSound: Normal
 - StartTime: 37969
   Lane: 2
-  HitSound: Normal
 - StartTime: 38069
   Lane: 4
-  HitSound: Normal
 - StartTime: 38169
   Lane: 2
-  HitSound: Normal
 - StartTime: 38269
   Lane: 3
-  HitSound: Normal
 - StartTime: 38369
   Lane: 4
-  HitSound: Normal
 - StartTime: 38469
   Lane: 1
-  HitSound: Normal
 - StartTime: 38569
   Lane: 3
-  HitSound: Normal
 - StartTime: 38669
   Lane: 2
-  HitSound: Normal
 - StartTime: 38769
   Lane: 4
-  HitSound: Normal
 - StartTime: 38869
   Lane: 1
   EndTime: 38969
-  HitSound: Normal
 - StartTime: 38969
   Lane: 4
   EndTime: 39069
-  HitSound: Normal
 - StartTime: 39069
   Lane: 3
   EndTime: 39269
-  HitSound: Normal
 - StartTime: 39269
   Lane: 1
-  HitSound: Normal
 - StartTime: 39369
   Lane: 2
-  HitSound: Normal
 - StartTime: 39469
   Lane: 4
-  HitSound: Normal
 - StartTime: 39569
   Lane: 2
-  HitSound: Normal
 - StartTime: 39669
   Lane: 3
-  HitSound: Normal
 - StartTime: 39769
   Lane: 1
-  HitSound: Normal
 - StartTime: 39869
   Lane: 4
-  HitSound: Normal
 - StartTime: 39969
   Lane: 2
-  HitSound: Normal
 - StartTime: 40069
   Lane: 1
-  HitSound: Normal
 - StartTime: 40169
   Lane: 3
-  HitSound: Normal
 - StartTime: 40269
   Lane: 4
-  HitSound: Normal
 - StartTime: 40369
   Lane: 1
-  HitSound: Normal
 - StartTime: 40469
   Lane: 3
-  HitSound: Normal
 - StartTime: 40569
   Lane: 2
-  HitSound: Normal
 - StartTime: 40669
   Lane: 4
-  HitSound: Normal
 - StartTime: 40769
   Lane: 2
-  HitSound: Normal
 - StartTime: 40869
   Lane: 3
-  HitSound: Normal
 - StartTime: 40969
   Lane: 1
-  HitSound: Normal
 - StartTime: 41069
   Lane: 4
-  HitSound: Normal
 - StartTime: 41169
   Lane: 2
-  HitSound: Normal
 - StartTime: 41269
   Lane: 3
-  HitSound: Normal
 - StartTime: 41369
   Lane: 2
-  HitSound: Normal
 - StartTime: 41469
   Lane: 4
-  HitSound: Normal
 - StartTime: 41569
   Lane: 3
-  HitSound: Normal
 - StartTime: 41669
   Lane: 2
-  HitSound: Normal
 - StartTime: 41769
   Lane: 3
-  HitSound: Normal
 - StartTime: 41869
   Lane: 1
-  HitSound: Normal
 - StartTime: 41969
   Lane: 4
-  HitSound: Normal
 - StartTime: 42069
   Lane: 2
-  HitSound: Normal
 - StartTime: 42169
   Lane: 4
-  HitSound: Normal
 - StartTime: 42269
   Lane: 3
-  HitSound: Normal
 - StartTime: 42369
   Lane: 2
-  HitSound: Normal
 - StartTime: 42469
   Lane: 3
-  HitSound: Normal
 - StartTime: 42569
   Lane: 1
-  HitSound: Normal
 - StartTime: 42669
   Lane: 4
-  HitSound: Normal
 - StartTime: 42769
   Lane: 2
-  HitSound: Normal
 - StartTime: 42869
   Lane: 3
-  HitSound: Normal
 - StartTime: 42969
   Lane: 1
-  HitSound: Normal
 - StartTime: 43069
   Lane: 4
-  HitSound: Normal
 - StartTime: 43169
   Lane: 2
-  HitSound: Normal
 - StartTime: 43269
   Lane: 1
-  HitSound: Normal
 - StartTime: 43369
   Lane: 3
-  HitSound: Normal
 - StartTime: 43469
   Lane: 4
-  HitSound: Normal
 - StartTime: 43569
   Lane: 1
-  HitSound: Normal
 - StartTime: 43669
   Lane: 3
-  HitSound: Normal
 - StartTime: 43769
   Lane: 2
-  HitSound: Normal
 - StartTime: 43869
   Lane: 4
-  HitSound: Normal
 - StartTime: 43969
   Lane: 2
-  HitSound: Normal
 - StartTime: 44069
   Lane: 3
-  HitSound: Normal
 - StartTime: 44169
   Lane: 1
-  HitSound: Normal
 - StartTime: 44269
   Lane: 4
-  HitSound: Normal
 - StartTime: 44369
   Lane: 2
-  HitSound: Normal
 - StartTime: 44469
   Lane: 3
-  HitSound: Normal
 - StartTime: 44569
   Lane: 3
-  HitSound: Normal
 - StartTime: 44669
   Lane: 1
-  HitSound: Normal
 - StartTime: 44769
   Lane: 3
-  HitSound: Normal
 - StartTime: 44869
   Lane: 3
-  HitSound: Normal
 - StartTime: 44969
   Lane: 2
-  HitSound: Normal
 - StartTime: 45069
   Lane: 3
-  HitSound: Normal
 - StartTime: 45169
   Lane: 3
-  HitSound: Normal
 - StartTime: 45269
   Lane: 1
-  HitSound: Normal
 - StartTime: 45369
   Lane: 3
-  HitSound: Normal
 - StartTime: 45469
   Lane: 2
-  HitSound: Normal
 - StartTime: 45569
   Lane: 4
-  HitSound: Normal
 - StartTime: 45569
   Lane: 1
   EndTime: 45769
-  HitSound: Normal
 - StartTime: 45669
   Lane: 3
-  HitSound: Normal
 - StartTime: 45769
   Lane: 2
-  HitSound: Normal
 - StartTime: 45819
   Lane: 4
-  HitSound: Normal
 - StartTime: 45869
   Lane: 3
-  HitSound: Normal
 - StartTime: 45969
   Lane: 1
-  HitSound: Normal
 - StartTime: 46069
   Lane: 4
-  HitSound: Normal
 - StartTime: 46169
   Lane: 2
-  HitSound: Normal
 - StartTime: 46169
   Lane: 1
-  HitSound: Normal
 - StartTime: 46269
   Lane: 3
-  HitSound: Normal
 - StartTime: 46302
   Lane: 4
-  HitSound: Normal
 - StartTime: 46369
   Lane: 1
-  HitSound: Normal
 - StartTime: 46419
   Lane: 2
-  HitSound: Normal
 - StartTime: 46469
   Lane: 3
-  HitSound: Normal
 - StartTime: 46569
   Lane: 2
-  HitSound: Normal
 - StartTime: 46569
   Lane: 4
-  HitSound: Normal
 - StartTime: 46669
   Lane: 1
-  HitSound: Normal
 - StartTime: 46769
   Lane: 4
-  HitSound: Normal
 - StartTime: 46769
   Lane: 3
-  HitSound: Normal
 - StartTime: 46869
   Lane: 2
-  HitSound: Normal
 - StartTime: 46969
   Lane: 4
-  HitSound: Normal
 - StartTime: 47069
   Lane: 4
-  HitSound: Normal
 - StartTime: 47169
   Lane: 4
-  HitSound: Normal
 - StartTime: 47269
   Lane: 4
-  HitSound: Normal
 - StartTime: 47369
   Lane: 4
-  HitSound: Normal
 - StartTime: 47369
   Lane: 1
-  HitSound: Normal
 - StartTime: 47419
   Lane: 3
-  HitSound: Normal
 - StartTime: 47469
   Lane: 2
-  HitSound: Normal
 - StartTime: 47569
   Lane: 1
-  HitSound: Normal
 - StartTime: 47669
   Lane: 4
-  HitSound: Normal
 - StartTime: 47769
   Lane: 2
-  HitSound: Normal
 - StartTime: 47769
   Lane: 1
-  HitSound: Normal
 - StartTime: 47869
   Lane: 3
-  HitSound: Normal
 - StartTime: 47902
   Lane: 4
-  HitSound: Normal
 - StartTime: 47969
   Lane: 1
-  HitSound: Normal
 - StartTime: 48019
   Lane: 2
-  HitSound: Normal
 - StartTime: 48069
   Lane: 3
-  HitSound: Normal
 - StartTime: 48169
   Lane: 2
-  HitSound: Normal
 - StartTime: 48169
   Lane: 4
-  HitSound: Normal
 - StartTime: 48269
   Lane: 1
-  HitSound: Normal
 - StartTime: 48369
   Lane: 4
-  HitSound: Normal
 - StartTime: 48369
   Lane: 3
-  HitSound: Normal
 - StartTime: 48469
   Lane: 2
-  HitSound: Normal
 - StartTime: 48569
   Lane: 3
-  HitSound: Normal
 - StartTime: 48569
   Lane: 4
-  HitSound: Normal
 - StartTime: 48669
   Lane: 1
-  HitSound: Normal
 - StartTime: 48769
   Lane: 2
-  HitSound: Normal
 - StartTime: 48769
   Lane: 3
-  HitSound: Normal
 - StartTime: 48869
   Lane: 4
-  HitSound: Normal
 - StartTime: 48969
   Lane: 2
-  HitSound: Normal
 - StartTime: 48969
   Lane: 1
-  HitSound: Normal
 - StartTime: 48969
   Lane: 4
-  HitSound: Normal
 - StartTime: 49069
   Lane: 3
-  HitSound: Normal
 - StartTime: 49169
   Lane: 2
-  HitSound: Normal
 - StartTime: 49269
   Lane: 3
-  HitSound: Normal
 - StartTime: 49369
   Lane: 2
-  HitSound: Normal
 - StartTime: 49469
   Lane: 3
-  HitSound: Normal
 - StartTime: 49569
   Lane: 2
-  HitSound: Normal
 - StartTime: 49669
   Lane: 3
-  HitSound: Normal
 - StartTime: 49769
   Lane: 2
-  HitSound: Normal
 - StartTime: 49769
   Lane: 1
-  HitSound: Normal
 - StartTime: 49769
   Lane: 4
-  HitSound: Normal
 - StartTime: 49869
   Lane: 3
-  HitSound: Normal
 - StartTime: 49969
   Lane: 2
-  HitSound: Normal
 - StartTime: 50069
   Lane: 3
-  HitSound: Normal
 - StartTime: 50169
   Lane: 2
-  HitSound: Normal
 - StartTime: 50269
   Lane: 3
-  HitSound: Normal
 - StartTime: 50369
   Lane: 2
-  HitSound: Normal
 - StartTime: 50469
   Lane: 3
-  HitSound: Normal
 - StartTime: 50569
   Lane: 1
-  HitSound: Normal
 - StartTime: 50569
   Lane: 4
-  HitSound: Normal
 - StartTime: 50569
   Lane: 2
-  HitSound: Normal
 - StartTime: 50669
   Lane: 3
-  HitSound: Normal
 - StartTime: 50769
   Lane: 2
-  HitSound: Normal
 - StartTime: 50869
   Lane: 3
-  HitSound: Normal
 - StartTime: 50969
   Lane: 2
-  HitSound: Normal
 - StartTime: 51069
   Lane: 3
-  HitSound: Normal
 - StartTime: 51169
   Lane: 2
-  HitSound: Normal
 - StartTime: 51269
   Lane: 3
-  HitSound: Normal
 - StartTime: 51369
   Lane: 2
-  HitSound: Normal
 - StartTime: 51369
   Lane: 4
-  HitSound: Normal
 - StartTime: 51369
   Lane: 1
-  HitSound: Normal
 - StartTime: 51469
   Lane: 3
-  HitSound: Normal
 - StartTime: 51569
   Lane: 2
-  HitSound: Normal
 - StartTime: 51669
   Lane: 3
-  HitSound: Normal
 - StartTime: 51769
   Lane: 2
-  HitSound: Normal
 - StartTime: 51869
   Lane: 3
-  HitSound: Normal
 - StartTime: 51969
   Lane: 2
-  HitSound: Normal
 - StartTime: 52069
   Lane: 3
-  HitSound: Normal
 - StartTime: 52169
   Lane: 1
-  HitSound: Normal
 - StartTime: 52169
   Lane: 4
-  HitSound: Normal
 - StartTime: 52169
   Lane: 2
-  HitSound: Normal
 - StartTime: 52269
   Lane: 3
-  HitSound: Normal
 - StartTime: 52369
   Lane: 2
-  HitSound: Normal
 - StartTime: 52469
   Lane: 3
-  HitSound: Normal
 - StartTime: 52569
   Lane: 2
-  HitSound: Normal
 - StartTime: 52669
   Lane: 3
-  HitSound: Normal
 - StartTime: 52769
   Lane: 2
-  HitSound: Normal
 - StartTime: 52869
   Lane: 3
-  HitSound: Normal
 - StartTime: 52969
   Lane: 2
-  HitSound: Normal
 - StartTime: 52969
   Lane: 4
-  HitSound: Normal
 - StartTime: 52969
   Lane: 1
-  HitSound: Normal
 - StartTime: 53069
   Lane: 3
-  HitSound: Normal
 - StartTime: 53169
   Lane: 2
-  HitSound: Normal
 - StartTime: 53269
   Lane: 3
-  HitSound: Normal
 - StartTime: 53369
   Lane: 2
-  HitSound: Normal
 - StartTime: 53469
   Lane: 3
-  HitSound: Normal
 - StartTime: 53569
   Lane: 2
-  HitSound: Normal
 - StartTime: 53669
   Lane: 3
-  HitSound: Normal
 - StartTime: 53769
   Lane: 1
-  HitSound: Normal
 - StartTime: 53769
   Lane: 4
-  HitSound: Normal
 - StartTime: 53769
   Lane: 2
-  HitSound: Normal
 - StartTime: 53869
   Lane: 3
-  HitSound: Normal
 - StartTime: 53969
   Lane: 2
-  HitSound: Normal
 - StartTime: 54069
   Lane: 3
-  HitSound: Normal
 - StartTime: 54169
   Lane: 2
-  HitSound: Normal
 - StartTime: 54269
   Lane: 3
-  HitSound: Normal
 - StartTime: 54369
   Lane: 2
-  HitSound: Normal
 - StartTime: 54469
   Lane: 3
-  HitSound: Normal
 - StartTime: 54569
   Lane: 2
-  HitSound: Normal
 - StartTime: 54569
   Lane: 4
-  HitSound: Normal
 - StartTime: 54569
   Lane: 1
-  HitSound: Normal
 - StartTime: 54669
   Lane: 3
-  HitSound: Normal
 - StartTime: 54769
   Lane: 2
-  HitSound: Normal
 - StartTime: 54869
   Lane: 3
-  HitSound: Normal
 - StartTime: 54969
   Lane: 2
-  HitSound: Normal
 - StartTime: 54969
   Lane: 1
-  HitSound: Normal
 - StartTime: 55069
   Lane: 3
-  HitSound: Normal
 - StartTime: 55169
   Lane: 2
-  HitSound: Normal
 - StartTime: 55169
   Lane: 4
-  HitSound: Normal
 - StartTime: 55169
   Lane: 1
-  HitSound: Normal
 - StartTime: 55269
   Lane: 3
-  HitSound: Normal
 - StartTime: 55369
   Lane: 2
-  HitSound: Normal
 - StartTime: 55469
   Lane: 3
-  HitSound: Normal
 - StartTime: 55569
   Lane: 4
-  HitSound: Normal
 - StartTime: 55569
   Lane: 2
-  HitSound: Normal
 - StartTime: 55569
   Lane: 1
-  HitSound: Normal
 - StartTime: 55669
   Lane: 3
-  HitSound: Normal
 - StartTime: 55769
   Lane: 2
-  HitSound: Normal
 - StartTime: 55869
   Lane: 3
-  HitSound: Normal
 - StartTime: 55969
   Lane: 1
-  HitSound: Normal
 - StartTime: 55969
   Lane: 4
-  HitSound: Normal
 - StartTime: 55969
   Lane: 2
-  HitSound: Normal
 - StartTime: 56069
   Lane: 3
-  HitSound: Normal
 - StartTime: 56169
   Lane: 2
-  HitSound: Normal
 - StartTime: 56269
   Lane: 3
-  HitSound: Normal
 - StartTime: 56369
   Lane: 2
-  HitSound: Normal
 - StartTime: 56369
   Lane: 4
-  HitSound: Normal
 - StartTime: 56369
   Lane: 1
-  HitSound: Normal
 - StartTime: 56419
   Lane: 3
-  HitSound: Normal
 - StartTime: 56469
   Lane: 4
-  HitSound: Normal
 - StartTime: 56519
   Lane: 1
-  HitSound: Normal
 - StartTime: 56569
   Lane: 2
-  HitSound: Normal
 - StartTime: 56669
   Lane: 3
-  HitSound: Normal
 - StartTime: 56769
   Lane: 1
-  HitSound: Normal
 - StartTime: 56769
   Lane: 4
-  HitSound: Normal
 - StartTime: 56769
   Lane: 2
-  HitSound: Normal
 - StartTime: 56869
   Lane: 3
-  HitSound: Normal
 - StartTime: 56969
   Lane: 2
-  HitSound: Normal
 - StartTime: 57069
   Lane: 3
-  HitSound: Normal
 - StartTime: 57169
   Lane: 2
-  HitSound: Normal
 - StartTime: 57169
   Lane: 4
-  HitSound: Normal
 - StartTime: 57169
   Lane: 1
-  HitSound: Normal
 - StartTime: 57269
   Lane: 3
-  HitSound: Normal
 - StartTime: 57369
   Lane: 2
-  HitSound: Normal
 - StartTime: 57469
   Lane: 3
-  HitSound: Normal
 - StartTime: 57569
   Lane: 2
-  HitSound: Normal
 - StartTime: 57569
   Lane: 1
-  HitSound: Normal
 - StartTime: 57569
   Lane: 4
-  HitSound: Normal
 - StartTime: 57669
   Lane: 3
-  HitSound: Normal
 - StartTime: 57769
   Lane: 2
-  HitSound: Normal
 - StartTime: 57869
   Lane: 3
-  HitSound: Normal
 - StartTime: 57969
   Lane: 2
-  HitSound: Normal
 - StartTime: 57969
   Lane: 1
-  HitSound: Normal
 - StartTime: 57969
   Lane: 4
-  HitSound: Normal
 - StartTime: 58019
   Lane: 3
-  HitSound: Normal
 - StartTime: 58069
   Lane: 4
-  HitSound: Normal
 - StartTime: 58119
   Lane: 1
-  HitSound: Normal
 - StartTime: 58169
   Lane: 2
-  HitSound: Normal
 - StartTime: 58269
   Lane: 4
-  HitSound: Normal
 - StartTime: 58269
   Lane: 3
-  HitSound: Normal
 - StartTime: 58369
   Lane: 1
-  HitSound: Normal
 - StartTime: 58469
   Lane: 2
-  HitSound: Normal
 - StartTime: 58469
   Lane: 4
-  HitSound: Normal
 - StartTime: 58469
   Lane: 3
-  HitSound: Normal
 - StartTime: 58569
   Lane: 1
-  HitSound: Normal
 - StartTime: 58669
   Lane: 4
-  HitSound: Normal
 - StartTime: 58669
   Lane: 3
-  HitSound: Normal
 - StartTime: 58769
   Lane: 2
-  HitSound: Normal
 - StartTime: 58869
   Lane: 1
-  HitSound: Normal
 - StartTime: 58869
   Lane: 4
-  HitSound: Normal
 - StartTime: 58869
   Lane: 3
-  HitSound: Normal
 - StartTime: 58969
   Lane: 2
-  HitSound: Normal
 - StartTime: 59069
   Lane: 1
-  HitSound: Normal
 - StartTime: 59069
   Lane: 4
-  HitSound: Normal
 - StartTime: 59169
   Lane: 3
-  HitSound: Normal
 - StartTime: 59269
   Lane: 2
-  HitSound: Normal
 - StartTime: 59269
   Lane: 1
-  HitSound: Normal
 - StartTime: 59269
   Lane: 4
-  HitSound: Normal
 - StartTime: 59319
   Lane: 3
-  HitSound: Normal
 - StartTime: 59369
   Lane: 1
-  HitSound: Normal
 - StartTime: 59419
   Lane: 2
-  HitSound: Normal
 - StartTime: 59469
   Lane: 4
-  HitSound: Normal
 - StartTime: 59519
   Lane: 3
-  HitSound: Normal
 - StartTime: 59569
   Lane: 2
-  HitSound: Normal
 - StartTime: 59619
   Lane: 4
-  HitSound: Normal
 - StartTime: 59669
   Lane: 3
-  HitSound: Normal
 - StartTime: 59719
   Lane: 1
-  HitSound: Normal
 - StartTime: 59769
   Lane: 4
-  HitSound: Normal
 - StartTime: 59769
   Lane: 2
-  HitSound: Normal
 - StartTime: 59969
   Lane: 3
-  HitSound: Normal
 - StartTime: 60169
   Lane: 1
-  HitSound: Normal
 - StartTime: 60369
   Lane: 3
-  HitSound: Normal
 - StartTime: 60519
   Lane: 3
-  HitSound: Normal
 - StartTime: 60569
   Lane: 4
-  HitSound: Normal
 - StartTime: 60669
   Lane: 4
-  HitSound: Normal
 - StartTime: 60769
   Lane: 2
-  HitSound: Normal
 - StartTime: 60869
   Lane: 3
-  HitSound: Normal
 - StartTime: 61069
   Lane: 1
   EndTime: 61369
-  HitSound: Normal
 - StartTime: 61069
   Lane: 2
-  HitSound: Normal
 - StartTime: 61269
   Lane: 3
-  HitSound: Normal
 - StartTime: 61269
   Lane: 4
-  HitSound: Normal
 - StartTime: 61369
   Lane: 4
-  HitSound: Normal
 - StartTime: 61369
   Lane: 2
-  HitSound: Normal
 - StartTime: 61369
   Lane: 3
-  HitSound: Normal
 - StartTime: 61469
   Lane: 1
-  HitSound: Normal
 - StartTime: 61519
   Lane: 2
-  HitSound: Normal
 - StartTime: 61569
   Lane: 3
-  HitSound: Normal
 - StartTime: 61619
   Lane: 4
-  HitSound: Normal
 - StartTime: 61669
   Lane: 2
-  HitSound: Normal
 - StartTime: 61719
   Lane: 3
-  HitSound: Normal
 - StartTime: 61769
   Lane: 1
   EndTime: 61969
-  HitSound: Normal
 - StartTime: 61819
   Lane: 2
   EndTime: 61969
-  HitSound: Normal
 - StartTime: 61869
   Lane: 3
   EndTime: 61969
-  HitSound: Normal
 - StartTime: 62569
   Lane: 4
   EndTime: 62769
-  HitSound: Normal
 - StartTime: 62619
   Lane: 3
   EndTime: 62769
-  HitSound: Normal
 - StartTime: 62669
   Lane: 2
   EndTime: 62769
-  HitSound: Normal
 - StartTime: 63369
   Lane: 1
   EndTime: 63569
-  HitSound: Normal
 - StartTime: 63419
   Lane: 2
   EndTime: 63569
-  HitSound: Normal
 - StartTime: 63469
   Lane: 3
   EndTime: 63569
-  HitSound: Normal
 - StartTime: 64169
   Lane: 4
   EndTime: 64369
-  HitSound: Normal
 - StartTime: 64219
   Lane: 3
   EndTime: 64369
-  HitSound: Normal
 - StartTime: 64269
   Lane: 2
   EndTime: 64369
-  HitSound: Normal
 - StartTime: 64969
   Lane: 1
   EndTime: 65169
-  HitSound: Normal
 - StartTime: 65019
   Lane: 2
   EndTime: 65169
-  HitSound: Normal
 - StartTime: 65069
   Lane: 3
   EndTime: 65169
-  HitSound: Normal
 - StartTime: 65769
   Lane: 4
   EndTime: 65969
-  HitSound: Normal
 - StartTime: 65819
   Lane: 3
   EndTime: 65969
-  HitSound: Normal
 - StartTime: 65869
   Lane: 2
   EndTime: 65969
-  HitSound: Normal
 - StartTime: 66569
   Lane: 1
   EndTime: 66769
-  HitSound: Normal
 - StartTime: 66619
   Lane: 2
   EndTime: 66769
-  HitSound: Normal
 - StartTime: 66669
   Lane: 3
   EndTime: 66769
-  HitSound: Normal
 - StartTime: 67369
   Lane: 4
   EndTime: 67569
-  HitSound: Normal
 - StartTime: 67419
   Lane: 3
   EndTime: 67569
-  HitSound: Normal
 - StartTime: 67469
   Lane: 2
   EndTime: 67569
-  HitSound: Normal
 - StartTime: 67769
   Lane: 3
-  HitSound: Normal
 - StartTime: 67769
   Lane: 2
-  HitSound: Normal
 - StartTime: 67769
   Lane: 1
-  HitSound: Normal
 - StartTime: 67769
   Lane: 4
-  HitSound: Normal
 - StartTime: 67969
   Lane: 4
-  HitSound: Normal
 - StartTime: 67969
   Lane: 2
-  HitSound: Normal
 - StartTime: 68019
   Lane: 3
-  HitSound: Normal
 - StartTime: 68069
   Lane: 1
-  HitSound: Normal
 - StartTime: 68119
   Lane: 2
-  HitSound: Normal
 - StartTime: 68369
   Lane: 4
-  HitSound: Normal
 - StartTime: 68369
   Lane: 2
-  HitSound: Normal
 - StartTime: 68419
   Lane: 3
-  HitSound: Normal
 - StartTime: 68469
   Lane: 1
-  HitSound: Normal
 - StartTime: 68519
   Lane: 2
-  HitSound: Normal
 - StartTime: 68769
   Lane: 2
-  HitSound: Normal
 - StartTime: 68769
   Lane: 4
-  HitSound: Normal
 - StartTime: 68819
   Lane: 3
-  HitSound: Normal
 - StartTime: 68869
   Lane: 1
-  HitSound: Normal
 - StartTime: 68919
   Lane: 2
-  HitSound: Normal
 - StartTime: 69169
   Lane: 4
-  HitSound: Normal
 - StartTime: 69169
   Lane: 2
-  HitSound: Normal
 - StartTime: 69219
   Lane: 3
-  HitSound: Normal
 - StartTime: 69269
   Lane: 1
-  HitSound: Normal
 - StartTime: 69319
   Lane: 2
-  HitSound: Normal
 - StartTime: 69569
   Lane: 2
-  HitSound: Normal
 - StartTime: 69569
   Lane: 4
-  HitSound: Normal
 - StartTime: 69619
   Lane: 3
-  HitSound: Normal
 - StartTime: 69669
   Lane: 1
-  HitSound: Normal
 - StartTime: 69719
   Lane: 2
-  HitSound: Normal
 - StartTime: 69969
   Lane: 2
-  HitSound: Normal
 - StartTime: 69969
   Lane: 4
-  HitSound: Normal
 - StartTime: 70019
   Lane: 3
-  HitSound: Normal
 - StartTime: 70069
   Lane: 1
-  HitSound: Normal
 - StartTime: 70119
   Lane: 2
-  HitSound: Normal
 - StartTime: 70369
   Lane: 4
-  HitSound: Normal
 - StartTime: 70369
   Lane: 2
-  HitSound: Normal
 - StartTime: 70419
   Lane: 3
-  HitSound: Normal
 - StartTime: 70469
   Lane: 1
-  HitSound: Normal
 - StartTime: 70519
   Lane: 2
-  HitSound: Normal
 - StartTime: 71169
   Lane: 4
-  HitSound: Normal
 - StartTime: 71169
   Lane: 2
-  HitSound: Normal
 - StartTime: 71219
   Lane: 3
-  HitSound: Normal
 - StartTime: 71269
   Lane: 1
-  HitSound: Normal
 - StartTime: 71319
   Lane: 2
-  HitSound: Normal
 - StartTime: 71569
   Lane: 2
-  HitSound: Normal
 - StartTime: 71569
   Lane: 4
-  HitSound: Normal
 - StartTime: 71619
   Lane: 3
-  HitSound: Normal
 - StartTime: 71669
   Lane: 1
-  HitSound: Normal
 - StartTime: 71719
   Lane: 2
-  HitSound: Normal
 - StartTime: 71969
   Lane: 4
-  HitSound: Normal
 - StartTime: 71969
   Lane: 2
-  HitSound: Normal
 - StartTime: 72019
   Lane: 3
-  HitSound: Normal
 - StartTime: 72069
   Lane: 1
-  HitSound: Normal
 - StartTime: 72119
   Lane: 2
-  HitSound: Normal
 - StartTime: 72369
   Lane: 2
-  HitSound: Normal
 - StartTime: 72369
   Lane: 4
-  HitSound: Normal
 - StartTime: 72419
   Lane: 3
-  HitSound: Normal
 - StartTime: 72469
   Lane: 1
-  HitSound: Normal
 - StartTime: 72519
   Lane: 2
-  HitSound: Normal
 - StartTime: 72769
   Lane: 4
-  HitSound: Normal
 - StartTime: 72769
   Lane: 2
-  HitSound: Normal
 - StartTime: 72819
   Lane: 3
-  HitSound: Normal
 - StartTime: 72869
   Lane: 1
-  HitSound: Normal
 - StartTime: 72919
   Lane: 2
-  HitSound: Normal
 - StartTime: 73169
   Lane: 2
-  HitSound: Normal
 - StartTime: 73169
   Lane: 4
-  HitSound: Normal
 - StartTime: 73219
   Lane: 3
-  HitSound: Normal
 - StartTime: 73269
   Lane: 1
-  HitSound: Normal
 - StartTime: 73319
   Lane: 2
-  HitSound: Normal
 - StartTime: 73369
   Lane: 4
-  HitSound: Normal
 - StartTime: 73369
   Lane: 3
-  HitSound: Normal
 - StartTime: 73435
   Lane: 2
-  HitSound: Normal
 - StartTime: 73502
   Lane: 3
-  HitSound: Normal
 - StartTime: 73569
   Lane: 4
-  HitSound: Normal
 - StartTime: 73569
   Lane: 1
-  HitSound: Normal
 - StartTime: 73635
   Lane: 2
-  HitSound: Normal
 - StartTime: 73702
   Lane: 3
-  HitSound: Normal
 - StartTime: 73769
   Lane: 1
-  HitSound: Normal
 - StartTime: 73769
   Lane: 2
   EndTime: 73969
-  HitSound: Normal
 - StartTime: 73969
   Lane: 4
-  HitSound: Normal
 - StartTime: 73969
   Lane: 3
-  HitSound: Normal
 - StartTime: 74019
   Lane: 1
-  HitSound: Normal
 - StartTime: 74069
   Lane: 2
-  HitSound: Normal
 - StartTime: 74119
   Lane: 4
-  HitSound: Normal
 - StartTime: 74169
   Lane: 3
-  HitSound: Normal
 - StartTime: 74202
   Lane: 1
-  HitSound: Normal
 - StartTime: 74235
   Lane: 2
-  HitSound: Normal
 - StartTime: 74269
   Lane: 4
-  HitSound: Normal
 - StartTime: 74319
   Lane: 3
-  HitSound: Normal
 - StartTime: 74369
   Lane: 1
-  HitSound: Normal
 - StartTime: 74435
   Lane: 2
-  HitSound: Normal
 - StartTime: 74502
   Lane: 3
-  HitSound: Normal
 - StartTime: 74569
   Lane: 4
-  HitSound: Normal
 - StartTime: 74569
   Lane: 1
   EndTime: 74769
-  HitSound: Normal
 - StartTime: 74619
   Lane: 2
   EndTime: 74769
-  HitSound: Normal
 - StartTime: 74669
   Lane: 3
   EndTime: 74769
-  HitSound: Normal
 - StartTime: 75369
   Lane: 4
   EndTime: 75569
-  HitSound: Normal
 - StartTime: 75419
   Lane: 3
   EndTime: 75569
-  HitSound: Normal
 - StartTime: 75469
   Lane: 2
   EndTime: 75569
-  HitSound: Normal
 - StartTime: 76169
   Lane: 1
   EndTime: 76369
-  HitSound: Normal
 - StartTime: 76219
   Lane: 2
   EndTime: 76369
-  HitSound: Normal
 - StartTime: 76269
   Lane: 3
   EndTime: 76369
-  HitSound: Normal
 - StartTime: 76969
   Lane: 4
   EndTime: 77169
-  HitSound: Normal
 - StartTime: 77019
   Lane: 3
   EndTime: 77169
-  HitSound: Normal
 - StartTime: 77069
   Lane: 2
   EndTime: 77169
-  HitSound: Normal
 - StartTime: 77769
   Lane: 1
   EndTime: 77969
-  HitSound: Normal
 - StartTime: 77819
   Lane: 2
   EndTime: 77969
-  HitSound: Normal
 - StartTime: 77869
   Lane: 3
   EndTime: 77969
-  HitSound: Normal
 - StartTime: 78569
   Lane: 4
   EndTime: 78769
-  HitSound: Normal
 - StartTime: 78619
   Lane: 3
   EndTime: 78769
-  HitSound: Normal
 - StartTime: 78669
   Lane: 2
   EndTime: 78769
-  HitSound: Normal
 - StartTime: 79369
   Lane: 1
   EndTime: 79569
-  HitSound: Normal
 - StartTime: 79419
   Lane: 2
   EndTime: 79569
-  HitSound: Normal
 - StartTime: 79469
   Lane: 3
   EndTime: 79569
-  HitSound: Normal
 - StartTime: 80569
   Lane: 3
-  HitSound: Normal
 - StartTime: 80569
   Lane: 2
-  HitSound: Normal
 - StartTime: 80569
   Lane: 1
-  HitSound: Normal
 - StartTime: 80569
   Lane: 4
-  HitSound: Normal
 - StartTime: 80669
   Lane: 4
-  HitSound: Normal
 - StartTime: 80669
   Lane: 3
-  HitSound: Normal
 - StartTime: 80669
   Lane: 2
-  HitSound: Normal
 - StartTime: 80669
   Lane: 1
-  HitSound: Normal
 - StartTime: 80869
   Lane: 4
-  HitSound: Normal
 - StartTime: 80869
   Lane: 3
-  HitSound: Normal
 - StartTime: 80869
   Lane: 1
-  HitSound: Normal
 - StartTime: 80869
   Lane: 2
-  HitSound: Normal
 - StartTime: 81069
   Lane: 4
-  HitSound: Normal
 - StartTime: 81069
   Lane: 2
-  HitSound: Normal
 - StartTime: 81069
   Lane: 3
-  HitSound: Normal
 - StartTime: 81069
   Lane: 1
-  HitSound: Normal
 - StartTime: 81269
   Lane: 4
-  HitSound: Normal
 - StartTime: 81269
   Lane: 2
-  HitSound: Normal
 - StartTime: 81269
   Lane: 1
-  HitSound: Normal
 - StartTime: 81269
   Lane: 3
-  HitSound: Normal
 - StartTime: 81369
   Lane: 4
-  HitSound: Normal
 - StartTime: 81369
   Lane: 3
-  HitSound: Normal
 - StartTime: 81369
   Lane: 2
-  HitSound: Normal
 - StartTime: 81369
   Lane: 1
-  HitSound: Normal
 - StartTime: 81469
   Lane: 3
-  HitSound: Normal
 - StartTime: 81469
   Lane: 1
-  HitSound: Normal
 - StartTime: 81469
   Lane: 4
-  HitSound: Normal
 - StartTime: 81469
   Lane: 2
-  HitSound: Normal
 - StartTime: 81669
   Lane: 1
-  HitSound: Normal
 - StartTime: 81669
   Lane: 3
-  HitSound: Normal
 - StartTime: 81669
   Lane: 4
-  HitSound: Normal
 - StartTime: 81669
   Lane: 2
-  HitSound: Normal
 - StartTime: 81869
   Lane: 4
-  HitSound: Normal
 - StartTime: 81869
   Lane: 2
-  HitSound: Normal
 - StartTime: 81869
   Lane: 3
-  HitSound: Normal
 - StartTime: 81869
   Lane: 1
-  HitSound: Normal
 - StartTime: 82069
   Lane: 4
-  HitSound: Normal
 - StartTime: 82069
   Lane: 2
-  HitSound: Normal
 - StartTime: 82069
   Lane: 1
-  HitSound: Normal
 - StartTime: 82069
   Lane: 3
-  HitSound: Normal
 - StartTime: 82269
   Lane: 3
-  HitSound: Normal
 - StartTime: 82269
   Lane: 1
-  HitSound: Normal
 - StartTime: 82269
   Lane: 4
-  HitSound: Normal
 - StartTime: 82269
   Lane: 2
-  HitSound: Normal
 - StartTime: 82469
   Lane: 1
-  HitSound: Normal
 - StartTime: 82469
   Lane: 3
-  HitSound: Normal
 - StartTime: 82469
   Lane: 4
-  HitSound: Normal
 - StartTime: 82469
   Lane: 2
-  HitSound: Normal
 - StartTime: 82669
   Lane: 4
-  HitSound: Normal
 - StartTime: 82669
   Lane: 2
-  HitSound: Normal
 - StartTime: 82669
   Lane: 3
-  HitSound: Normal
 - StartTime: 82669
   Lane: 1
-  HitSound: Normal
 - StartTime: 82869
   Lane: 4
-  HitSound: Normal
 - StartTime: 82869
   Lane: 2
-  HitSound: Normal
 - StartTime: 82869
   Lane: 1
-  HitSound: Normal
 - StartTime: 82869
   Lane: 3
-  HitSound: Normal
 - StartTime: 82969
   Lane: 4
-  HitSound: Normal
 - StartTime: 82969
   Lane: 3
-  HitSound: Normal
 - StartTime: 82969
   Lane: 2
-  HitSound: Normal
 - StartTime: 82969
   Lane: 1
-  HitSound: Normal
 - StartTime: 83069
   Lane: 4
-  HitSound: Normal
 - StartTime: 83069
   Lane: 3
-  HitSound: Normal
 - StartTime: 83069
   Lane: 2
-  HitSound: Normal
 - StartTime: 83069
   Lane: 1
-  HitSound: Normal
 - StartTime: 83269
   Lane: 3
-  HitSound: Normal
 - StartTime: 83269
   Lane: 1
-  HitSound: Normal
 - StartTime: 83269
   Lane: 4
-  HitSound: Normal
 - StartTime: 83269
   Lane: 2
-  HitSound: Normal
 - StartTime: 83469
   Lane: 1
-  HitSound: Normal
 - StartTime: 83469
   Lane: 3
-  HitSound: Normal
 - StartTime: 83469
   Lane: 4
-  HitSound: Normal
 - StartTime: 83469
   Lane: 2
-  HitSound: Normal
 - StartTime: 83669
   Lane: 4
-  HitSound: Normal
 - StartTime: 83669
   Lane: 2
-  HitSound: Normal
 - StartTime: 83669
   Lane: 3
-  HitSound: Normal
 - StartTime: 83669
   Lane: 1
-  HitSound: Normal
 - StartTime: 83869
   Lane: 4
-  HitSound: Normal
 - StartTime: 83869
   Lane: 2
-  HitSound: Normal
 - StartTime: 83869
   Lane: 1
-  HitSound: Normal
 - StartTime: 83869
   Lane: 3
-  HitSound: Normal
 - StartTime: 84069
   Lane: 3
-  HitSound: Normal
 - StartTime: 84069
   Lane: 1
-  HitSound: Normal
 - StartTime: 84069
   Lane: 4
-  HitSound: Normal
 - StartTime: 84069
   Lane: 2
-  HitSound: Normal
 - StartTime: 84169
   Lane: 4
-  HitSound: Normal
 - StartTime: 84169
   Lane: 3
-  HitSound: Normal
 - StartTime: 84169
   Lane: 2
-  HitSound: Normal
 - StartTime: 84169
   Lane: 1
-  HitSound: Normal
 - StartTime: 84269
   Lane: 1
-  HitSound: Normal
 - StartTime: 84269
   Lane: 3
-  HitSound: Normal
 - StartTime: 84269
   Lane: 4
-  HitSound: Normal
 - StartTime: 84269
   Lane: 2
-  HitSound: Normal
 - StartTime: 84469
   Lane: 4
-  HitSound: Normal
 - StartTime: 84469
   Lane: 2
-  HitSound: Normal
 - StartTime: 84469
   Lane: 3
-  HitSound: Normal
 - StartTime: 84469
   Lane: 1
-  HitSound: Normal
 - StartTime: 84669
   Lane: 4
-  HitSound: Normal
 - StartTime: 84669
   Lane: 2
-  HitSound: Normal
 - StartTime: 84669
   Lane: 1
-  HitSound: Normal
 - StartTime: 84669
   Lane: 3
-  HitSound: Normal
 - StartTime: 84869
   Lane: 3
-  HitSound: Normal
 - StartTime: 84869
   Lane: 1
-  HitSound: Normal
 - StartTime: 84869
   Lane: 4
-  HitSound: Normal
 - StartTime: 84869
   Lane: 2
-  HitSound: Normal
 - StartTime: 84969
   Lane: 4
-  HitSound: Normal
 - StartTime: 84969
   Lane: 3
-  HitSound: Normal
 - StartTime: 84969
   Lane: 2
-  HitSound: Normal
 - StartTime: 84969
   Lane: 1
-  HitSound: Normal
 - StartTime: 85069
   Lane: 1
-  HitSound: Normal
 - StartTime: 85069
   Lane: 3
-  HitSound: Normal
 - StartTime: 85069
   Lane: 4
-  HitSound: Normal
 - StartTime: 85069
   Lane: 2
-  HitSound: Normal
 - StartTime: 85269
   Lane: 4
-  HitSound: Normal
 - StartTime: 85269
   Lane: 2
-  HitSound: Normal
 - StartTime: 85269
   Lane: 3
-  HitSound: Normal
 - StartTime: 85269
   Lane: 1
-  HitSound: Normal
 - StartTime: 85369
   Lane: 4
-  HitSound: Normal
 - StartTime: 85369
   Lane: 3
-  HitSound: Normal
 - StartTime: 85369
   Lane: 2
-  HitSound: Normal
 - StartTime: 85369
   Lane: 1
-  HitSound: Normal
 - StartTime: 85469
   Lane: 4
-  HitSound: Normal
 - StartTime: 85469
   Lane: 2
-  HitSound: Normal
 - StartTime: 85469
   Lane: 1
-  HitSound: Normal
 - StartTime: 85469
   Lane: 3
-  HitSound: Normal
 - StartTime: 85669
   Lane: 3
-  HitSound: Normal
 - StartTime: 85669
   Lane: 1
-  HitSound: Normal
 - StartTime: 85669
   Lane: 4
-  HitSound: Normal
 - StartTime: 85669
   Lane: 2
-  HitSound: Normal
 - StartTime: 85769
   Lane: 4
-  HitSound: Normal
 - StartTime: 85769
   Lane: 3
-  HitSound: Normal
 - StartTime: 85769
   Lane: 2
-  HitSound: Normal
 - StartTime: 85769
   Lane: 1
-  HitSound: Normal
 - StartTime: 85869
   Lane: 1
-  HitSound: Normal
 - StartTime: 85869
   Lane: 3
-  HitSound: Normal
 - StartTime: 85869
   Lane: 4
-  HitSound: Normal
 - StartTime: 85869
   Lane: 2
-  HitSound: Normal
 - StartTime: 86069
   Lane: 1
-  HitSound: Normal
 - StartTime: 86069
   Lane: 2
-  HitSound: Normal
 - StartTime: 86069
   Lane: 4
-  HitSound: Normal
 - StartTime: 86069
   Lane: 3
-  HitSound: Normal
 - StartTime: 86169
   Lane: 4
-  HitSound: Normal
 - StartTime: 86169
   Lane: 3
-  HitSound: Normal
 - StartTime: 86169
   Lane: 2
-  HitSound: Normal
 - StartTime: 86169
   Lane: 1
-  HitSound: Normal
 - StartTime: 86269
   Lane: 3
-  HitSound: Normal
 - StartTime: 86369
   Lane: 3
-  HitSound: Normal
 - StartTime: 86469
   Lane: 2
-  HitSound: Normal
 - StartTime: 86569
   Lane: 4
-  HitSound: Normal
 - StartTime: 86569
   Lane: 3
-  HitSound: Normal
 - StartTime: 86769
   Lane: 2
-  HitSound: Normal
 - StartTime: 86769
   Lane: 1
-  HitSound: Normal
 - StartTime: 86969
   Lane: 4
-  HitSound: Normal
 - StartTime: 86969
   Lane: 3
-  HitSound: Normal
 - StartTime: 87169
   Lane: 2
-  HitSound: Normal
 - StartTime: 87169
   Lane: 1
-  HitSound: Normal
 - StartTime: 87369
   Lane: 4
-  HitSound: Normal
 - StartTime: 87369
   Lane: 3
-  HitSound: Normal
 - StartTime: 87569
   Lane: 2
-  HitSound: Normal
 - StartTime: 87569
   Lane: 1
-  HitSound: Normal
 - StartTime: 87769
   Lane: 4
-  HitSound: Normal
 - StartTime: 87769
   Lane: 3
-  HitSound: Normal
 - StartTime: 87869
   Lane: 4
-  HitSound: Normal
 - StartTime: 87869
   Lane: 3
-  HitSound: Normal
 - StartTime: 87969
   Lane: 4
-  HitSound: Normal
 - StartTime: 87969
   Lane: 3
-  HitSound: Normal
 - StartTime: 88069
   Lane: 4
-  HitSound: Normal
 - StartTime: 88069
   Lane: 3
-  HitSound: Normal
 - StartTime: 88169
   Lane: 3
-  HitSound: Normal
 - StartTime: 88169
   Lane: 4
-  HitSound: Normal
 - StartTime: 88369
   Lane: 3
-  HitSound: Normal
 - StartTime: 88369
   Lane: 1
-  HitSound: Normal
 - StartTime: 88469
   Lane: 4
-  HitSound: Normal
 - StartTime: 88469
   Lane: 2
-  HitSound: Normal
 - StartTime: 88669
   Lane: 4
-  HitSound: Normal
 - StartTime: 88669
   Lane: 2
-  HitSound: Normal
 - StartTime: 88769
   Lane: 1
-  HitSound: Normal
 - StartTime: 88769
   Lane: 3
-  HitSound: Normal
 - StartTime: 88969
   Lane: 4
-  HitSound: Normal
 - StartTime: 88969
   Lane: 3
-  HitSound: Normal
 - StartTime: 88969
   Lane: 1
-  HitSound: Normal
 - StartTime: 88969
   Lane: 2
-  HitSound: Normal
 - StartTime: 89169
   Lane: 3
-  HitSound: Normal
 - StartTime: 89169
   Lane: 1
-  HitSound: Normal
 - StartTime: 89269
   Lane: 2
-  HitSound: Normal
 - StartTime: 89269
   Lane: 4
-  HitSound: Normal
 - StartTime: 89469
   Lane: 2
-  HitSound: Normal
 - StartTime: 89469
   Lane: 4
-  HitSound: Normal
 - StartTime: 89569
   Lane: 1
-  HitSound: Normal
 - StartTime: 89569
   Lane: 3
-  HitSound: Normal
 - StartTime: 89769
   Lane: 4
-  HitSound: Normal
 - StartTime: 89769
   Lane: 1
-  HitSound: Normal
 - StartTime: 89769
   Lane: 3
-  HitSound: Normal
 - StartTime: 89769
   Lane: 2
-  HitSound: Normal
 - StartTime: 90169
   Lane: 4
-  HitSound: Normal
 - StartTime: 90169
   Lane: 1
-  HitSound: Normal
 - StartTime: 90235
   Lane: 3
-  HitSound: Normal
 - StartTime: 90302
   Lane: 2
-  HitSound: Normal
 - StartTime: 90369
   Lane: 4
-  HitSound: Normal
 - StartTime: 90419
   Lane: 3
-  HitSound: Normal
 - StartTime: 90469
   Lane: 1
-  HitSound: Normal
 - StartTime: 90519
   Lane: 2
-  HitSound: Normal
 - StartTime: 90569
   Lane: 4
-  HitSound: Normal
 - StartTime: 90569
   Lane: 3
-  HitSound: Normal
 - StartTime: 90769
   Lane: 1
-  HitSound: Normal
 - StartTime: 90869
   Lane: 1
-  HitSound: Normal
 - StartTime: 90969
   Lane: 4
-  HitSound: Normal
 - StartTime: 90969
   Lane: 3
-  HitSound: Normal
 - StartTime: 90969
   Lane: 2
-  HitSound: Normal
 - StartTime: 91069
   Lane: 1
   EndTime: 91169
-  HitSound: Normal
 - StartTime: 91069
   Lane: 2
   EndTime: 91169
-  HitSound: Normal
 - StartTime: 91069
   Lane: 3
   EndTime: 91169
-  HitSound: Normal
 - StartTime: 91269
   Lane: 4
   EndTime: 91369
-  HitSound: Normal
 - StartTime: 91269
   Lane: 3
   EndTime: 91369
-  HitSound: Normal
 - StartTime: 91269
   Lane: 2
   EndTime: 91369
-  HitSound: Normal
 - StartTime: 91469
   Lane: 3
   EndTime: 91569
-  HitSound: Normal
 - StartTime: 91469
   Lane: 2
   EndTime: 91569
-  HitSound: Normal
 - StartTime: 91469
   Lane: 1
   EndTime: 91569
-  HitSound: Normal
 - StartTime: 91669
   Lane: 2
   EndTime: 91769
-  HitSound: Normal
 - StartTime: 91669
   Lane: 4
   EndTime: 91769
-  HitSound: Normal
 - StartTime: 91669
   Lane: 3
   EndTime: 91769
-  HitSound: Normal
 - StartTime: 91869
   Lane: 3
   EndTime: 91969
-  HitSound: Normal
 - StartTime: 91869
   Lane: 2
   EndTime: 91969
-  HitSound: Normal
 - StartTime: 91869
   Lane: 1
   EndTime: 91969
-  HitSound: Normal
 - StartTime: 92069
   Lane: 2
   EndTime: 92169
-  HitSound: Normal
 - StartTime: 92069
   Lane: 3
   EndTime: 92169
-  HitSound: Normal
 - StartTime: 92069
   Lane: 4
   EndTime: 92169
-  HitSound: Normal
 - StartTime: 92569
   Lane: 4
-  HitSound: Normal
 - StartTime: 92569
   Lane: 3
-  HitSound: Normal
 - StartTime: 92635
   Lane: 2
-  HitSound: Normal
 - StartTime: 92635
   Lane: 1
-  HitSound: Normal
 - StartTime: 92702
   Lane: 4
-  HitSound: Normal
 - StartTime: 92702
   Lane: 3
-  HitSound: Normal
 - StartTime: 92769
   Lane: 2
-  HitSound: Normal
 - StartTime: 92769
   Lane: 1
-  HitSound: Normal
 - StartTime: 92869
   Lane: 4
-  HitSound: Normal
 - StartTime: 92869
   Lane: 3
-  HitSound: Normal
 - StartTime: 92969
   Lane: 2
-  HitSound: Normal
 - StartTime: 92969
   Lane: 1
-  HitSound: Normal
 - StartTime: 93069
   Lane: 3
-  HitSound: Normal
 - StartTime: 93169
   Lane: 2
   EndTime: 93369
-  HitSound: Normal
 - StartTime: 93369
   Lane: 1
-  HitSound: Normal
 - StartTime: 93369
   Lane: 4
-  HitSound: Normal
 - StartTime: 93419
   Lane: 3
-  HitSound: Normal
 - StartTime: 93469
   Lane: 2
-  HitSound: Normal
 - StartTime: 93519
   Lane: 4
-  HitSound: Normal
 - StartTime: 93569
   Lane: 3
-  HitSound: Normal
 - StartTime: 93619
   Lane: 1
-  HitSound: Normal
 - StartTime: 93669
   Lane: 2
-  HitSound: Normal
 - StartTime: 93719
   Lane: 3
-  HitSound: Normal
 - StartTime: 93769
   Lane: 4
-  HitSound: Normal
 - StartTime: 93769
   Lane: 1
-  HitSound: Normal
 - StartTime: 93835
   Lane: 2
-  HitSound: Normal
 - StartTime: 93902
   Lane: 3
-  HitSound: Normal
 - StartTime: 93969
   Lane: 2
-  HitSound: Normal
 - StartTime: 93969
   Lane: 1
-  HitSound: Normal
 - StartTime: 94069
   Lane: 3
-  HitSound: Normal
 - StartTime: 94069
   Lane: 4
-  HitSound: Normal
 - StartTime: 94269
   Lane: 4
-  HitSound: Normal
 - StartTime: 94269
   Lane: 3
-  HitSound: Normal
 - StartTime: 94369
   Lane: 1
-  HitSound: Normal
 - StartTime: 94369
   Lane: 2
-  HitSound: Normal
 - StartTime: 94569
   Lane: 4
-  HitSound: Normal
 - StartTime: 94569
   Lane: 3
-  HitSound: Normal
 - StartTime: 94569
   Lane: 2
-  HitSound: Normal
 - StartTime: 94569
   Lane: 1
-  HitSound: Normal
 - StartTime: 94769
   Lane: 2
-  HitSound: Normal
 - StartTime: 94769
   Lane: 1
-  HitSound: Normal
 - StartTime: 94869
   Lane: 4
-  HitSound: Normal
 - StartTime: 94869
   Lane: 3
-  HitSound: Normal
 - StartTime: 95069
   Lane: 4
-  HitSound: Normal
 - StartTime: 95069
   Lane: 3
-  HitSound: Normal
 - StartTime: 95169
   Lane: 2
-  HitSound: Normal
 - StartTime: 95169
   Lane: 1
-  HitSound: Normal
 - StartTime: 95369
   Lane: 4
-  HitSound: Normal
 - StartTime: 95369
   Lane: 3
-  HitSound: Normal
 - StartTime: 95369
   Lane: 2
-  HitSound: Normal
 - StartTime: 95369
   Lane: 1
-  HitSound: Normal
 - StartTime: 95569
   Lane: 2
-  HitSound: Normal
 - StartTime: 95569
   Lane: 1
-  HitSound: Normal
 - StartTime: 95669
   Lane: 3
-  HitSound: Normal
 - StartTime: 95669
   Lane: 4
-  HitSound: Normal
 - StartTime: 95869
   Lane: 4
-  HitSound: Normal
 - StartTime: 95869
   Lane: 3
-  HitSound: Normal
 - StartTime: 95969
   Lane: 2
-  HitSound: Normal
 - StartTime: 95969
   Lane: 1
-  HitSound: Normal
 - StartTime: 96169
   Lane: 4
-  HitSound: Normal
 - StartTime: 96169
   Lane: 3
-  HitSound: Normal
 - StartTime: 96169
   Lane: 1
-  HitSound: Normal
 - StartTime: 96219
   Lane: 2
-  HitSound: Normal
 - StartTime: 96269
   Lane: 4
-  HitSound: Normal
 - StartTime: 96319
   Lane: 3
-  HitSound: Normal
 - StartTime: 96369
   Lane: 1
-  HitSound: Normal
 - StartTime: 96419
   Lane: 2
-  HitSound: Normal
 - StartTime: 96469
   Lane: 4
-  HitSound: Normal
 - StartTime: 96519
   Lane: 3
-  HitSound: Normal
 - StartTime: 96569
   Lane: 1
-  HitSound: Normal
 - StartTime: 96569
   Lane: 2
-  HitSound: Normal
 - StartTime: 96619
   Lane: 4
-  HitSound: Normal
 - StartTime: 96669
   Lane: 3
-  HitSound: Normal
 - StartTime: 96719
   Lane: 2
-  HitSound: Normal
 - StartTime: 96769
   Lane: 1
-  HitSound: Normal
 - StartTime: 96769
   Lane: 4
-  HitSound: Normal
 - StartTime: 96819
   Lane: 3
-  HitSound: Normal
 - StartTime: 96869
   Lane: 2
-  HitSound: Normal
 - StartTime: 96919
   Lane: 1
-  HitSound: Normal
 - StartTime: 96969
   Lane: 4
-  HitSound: Normal
 - StartTime: 96969
   Lane: 3
   EndTime: 97169
-  HitSound: Normal
 - StartTime: 97169
   Lane: 2
-  HitSound: Normal
 - StartTime: 97269
   Lane: 2
-  HitSound: Normal
 - StartTime: 97369
   Lane: 4
-  HitSound: Normal
 - StartTime: 97369
   Lane: 3
-  HitSound: Normal
 - StartTime: 97369
   Lane: 1
-  HitSound: Normal
 - StartTime: 97469
   Lane: 1
   EndTime: 97569
-  HitSound: Normal
 - StartTime: 97469
   Lane: 2
   EndTime: 97569
-  HitSound: Normal
 - StartTime: 97469
   Lane: 3
   EndTime: 97569
-  HitSound: Normal
 - StartTime: 97669
   Lane: 4
   EndTime: 97769
-  HitSound: Normal
 - StartTime: 97669
   Lane: 3
   EndTime: 97769
-  HitSound: Normal
 - StartTime: 97669
   Lane: 2
   EndTime: 97769
-  HitSound: Normal
 - StartTime: 97869
   Lane: 2
   EndTime: 97969
-  HitSound: Normal
 - StartTime: 97869
   Lane: 1
   EndTime: 97969
-  HitSound: Normal
 - StartTime: 97869
   Lane: 3
   EndTime: 97969
-  HitSound: Normal
 - StartTime: 98069
   Lane: 4
   EndTime: 98169
-  HitSound: Normal
 - StartTime: 98069
   Lane: 3
   EndTime: 98169
-  HitSound: Normal
 - StartTime: 98069
   Lane: 2
   EndTime: 98169
-  HitSound: Normal
 - StartTime: 98269
   Lane: 1
   EndTime: 98369
-  HitSound: Normal
 - StartTime: 98269
   Lane: 2
   EndTime: 98369
-  HitSound: Normal
 - StartTime: 98269
   Lane: 3
   EndTime: 98369
-  HitSound: Normal
 - StartTime: 98469
   Lane: 4
   EndTime: 98569
-  HitSound: Normal
 - StartTime: 98469
   Lane: 3
   EndTime: 98569
-  HitSound: Normal
 - StartTime: 98469
   Lane: 2
   EndTime: 98569
-  HitSound: Normal
 - StartTime: 98969
   Lane: 4
-  HitSound: Normal
 - StartTime: 98969
   Lane: 2
-  HitSound: Normal
 - StartTime: 98969
   Lane: 1
-  HitSound: Normal
 - StartTime: 99035
   Lane: 3
-  HitSound: Normal
 - StartTime: 99102
   Lane: 2
-  HitSound: Normal
 - StartTime: 99102
   Lane: 1
-  HitSound: Normal
 - StartTime: 99169
   Lane: 4
-  HitSound: Normal
 - StartTime: 99169
   Lane: 3
-  HitSound: Normal
 - StartTime: 99269
   Lane: 4
-  HitSound: Normal
 - StartTime: 99269
   Lane: 1
-  HitSound: Normal
 - StartTime: 99269
   Lane: 2
   EndTime: 99569
-  HitSound: Normal
 - StartTime: 99569
   Lane: 4
-  HitSound: Normal
 - StartTime: 99569
   Lane: 3
-  HitSound: Normal
 - StartTime: 99569
   Lane: 1
-  HitSound: Normal
 - StartTime: 99619
   Lane: 2
-  HitSound: Normal
 - StartTime: 99669
   Lane: 4
-  HitSound: Normal
 - StartTime: 99719
   Lane: 3
-  HitSound: Normal
 - StartTime: 99769
   Lane: 1
-  HitSound: Normal
 - StartTime: 99819
   Lane: 2
-  HitSound: Normal
 - StartTime: 99869
   Lane: 4
-  HitSound: Normal
 - StartTime: 99919
   Lane: 3
-  HitSound: Normal
 - StartTime: 99969
   Lane: 1
-  HitSound: Normal
 - StartTime: 100035
   Lane: 2
-  HitSound: Normal
 - StartTime: 100102
   Lane: 3
-  HitSound: Normal
 - StartTime: 100169
   Lane: 4
-  HitSound: Normal
 - StartTime: 100169
   Lane: 2
-  HitSound: Normal
 - StartTime: 100169
   Lane: 1
-  HitSound: Normal
 - StartTime: 100369
   Lane: 1
-  HitSound: Normal
 - StartTime: 100369
   Lane: 4
-  HitSound: Normal
 - StartTime: 100469
   Lane: 3
-  HitSound: Normal
 - StartTime: 100469
   Lane: 2
-  HitSound: Normal
 - StartTime: 100669
   Lane: 3
-  HitSound: Normal
 - StartTime: 100669
   Lane: 2
-  HitSound: Normal
 - StartTime: 100769
   Lane: 1
-  HitSound: Normal
 - StartTime: 100769
   Lane: 4
-  HitSound: Normal
 - StartTime: 100969
   Lane: 4
-  HitSound: Normal
 - StartTime: 100969
   Lane: 3
-  HitSound: Normal
 - StartTime: 100969
   Lane: 2
-  HitSound: Normal
 - StartTime: 100969
   Lane: 1
-  HitSound: Normal
 - StartTime: 101169
   Lane: 1
-  HitSound: Normal
 - StartTime: 101169
   Lane: 4
-  HitSound: Normal
 - StartTime: 101269
   Lane: 3
-  HitSound: Normal
 - StartTime: 101269
   Lane: 2
-  HitSound: Normal
 - StartTime: 101469
   Lane: 3
-  HitSound: Normal
 - StartTime: 101469
   Lane: 2
-  HitSound: Normal
 - StartTime: 101569
   Lane: 4
-  HitSound: Normal
 - StartTime: 101569
   Lane: 1
-  HitSound: Normal
 - StartTime: 101769
   Lane: 1
-  HitSound: Normal
 - StartTime: 101769
   Lane: 3
-  HitSound: Normal
 - StartTime: 101769
   Lane: 2
-  HitSound: Normal
 - StartTime: 101769
   Lane: 4
-  HitSound: Normal
 - StartTime: 101969
   Lane: 4
-  HitSound: Normal
 - StartTime: 101969
   Lane: 1
-  HitSound: Normal
 - StartTime: 102069
   Lane: 2
-  HitSound: Normal
 - StartTime: 102069
   Lane: 3
-  HitSound: Normal
 - StartTime: 102269
   Lane: 2
-  HitSound: Normal
 - StartTime: 102269
   Lane: 3
-  HitSound: Normal
 - StartTime: 102369
   Lane: 1
-  HitSound: Normal
 - StartTime: 102369
   Lane: 4
-  HitSound: Normal
 - StartTime: 102569
   Lane: 2
-  HitSound: Normal
 - StartTime: 102569
   Lane: 4
-  HitSound: Normal
 - StartTime: 102569
   Lane: 1
-  HitSound: Normal
 - StartTime: 102569
   Lane: 3
-  HitSound: Normal
 - StartTime: 102969
   Lane: 4
-  HitSound: Normal
 - StartTime: 102969
   Lane: 2
-  HitSound: Normal
 - StartTime: 103019
   Lane: 3
-  HitSound: Normal
 - StartTime: 103069
   Lane: 1
-  HitSound: Normal
 - StartTime: 103119
   Lane: 2
-  HitSound: Normal
 - StartTime: 103169
   Lane: 4
-  HitSound: Normal
 - StartTime: 103219
   Lane: 3
-  HitSound: Normal
 - StartTime: 103269
   Lane: 2
-  HitSound: Normal
 - StartTime: 103319
   Lane: 1
-  HitSound: Normal
 - StartTime: 103369
   Lane: 3
-  HitSound: Normal
 - StartTime: 103369
   Lane: 4
-  HitSound: Normal
 - StartTime: 103419
   Lane: 2
-  HitSound: Normal
 - StartTime: 103469
   Lane: 1
-  HitSound: Normal
 - StartTime: 103519
   Lane: 4
-  HitSound: Normal
 - StartTime: 103569
   Lane: 3
-  HitSound: Normal
 - StartTime: 103669
   Lane: 3
-  HitSound: Normal
 - StartTime: 103769
   Lane: 2
-  HitSound: Normal
 - StartTime: 103769
   Lane: 1
-  HitSound: Normal
 - StartTime: 103769
   Lane: 4
-  HitSound: Normal
 - StartTime: 103869
   Lane: 3
   EndTime: 103969
-  HitSound: Normal
 - StartTime: 103869
   Lane: 2
   EndTime: 103969
-  HitSound: Normal
 - StartTime: 103869
   Lane: 1
   EndTime: 103969
-  HitSound: Normal
 - StartTime: 104069
   Lane: 4
   EndTime: 104169
-  HitSound: Normal
 - StartTime: 104069
   Lane: 3
   EndTime: 104169
-  HitSound: Normal
 - StartTime: 104069
   Lane: 2
   EndTime: 104169
-  HitSound: Normal
 - StartTime: 104269
   Lane: 3
   EndTime: 104369
-  HitSound: Normal
 - StartTime: 104269
   Lane: 1
   EndTime: 104369
-  HitSound: Normal
 - StartTime: 104269
   Lane: 2
   EndTime: 104369
-  HitSound: Normal
 - StartTime: 104469
   Lane: 2
   EndTime: 104569
-  HitSound: Normal
 - StartTime: 104469
   Lane: 3
   EndTime: 104569
-  HitSound: Normal
 - StartTime: 104469
   Lane: 4
   EndTime: 104569
-  HitSound: Normal
 - StartTime: 104669
   Lane: 2
   EndTime: 104769
-  HitSound: Normal
 - StartTime: 104669
   Lane: 1
   EndTime: 104769
-  HitSound: Normal
 - StartTime: 104669
   Lane: 3
   EndTime: 104769
-  HitSound: Normal
 - StartTime: 104869
   Lane: 4
   EndTime: 104969
-  HitSound: Normal
 - StartTime: 104869
   Lane: 3
   EndTime: 104969
-  HitSound: Normal
 - StartTime: 104869
   Lane: 2
   EndTime: 104969
-  HitSound: Normal
 - StartTime: 105369
   Lane: 2
-  HitSound: Normal
 - StartTime: 105369
   Lane: 1
-  HitSound: Normal
 - StartTime: 105369
   Lane: 4
-  HitSound: Normal
 - StartTime: 105435
   Lane: 3
-  HitSound: Normal
 - StartTime: 105502
   Lane: 2
-  HitSound: Normal
 - StartTime: 105502
   Lane: 1
-  HitSound: Normal
 - StartTime: 105569
   Lane: 4
-  HitSound: Normal
 - StartTime: 105569
   Lane: 3
-  HitSound: Normal
 - StartTime: 105669
   Lane: 2
-  HitSound: Normal
 - StartTime: 105669
   Lane: 1
-  HitSound: Normal
 - StartTime: 105769
   Lane: 4
-  HitSound: Normal
 - StartTime: 105769
   Lane: 3
-  HitSound: Normal
 - StartTime: 105869
   Lane: 2
-  HitSound: Normal
 - StartTime: 105969
   Lane: 3
   EndTime: 106169
-  HitSound: Normal
 - StartTime: 105969
   Lane: 1
-  HitSound: Normal
 - StartTime: 106169
   Lane: 2
-  HitSound: Normal
 - StartTime: 106169
   Lane: 1
-  HitSound: Normal
 - StartTime: 106219
   Lane: 4
-  HitSound: Normal
 - StartTime: 106269
   Lane: 3
-  HitSound: Normal
 - StartTime: 106319
   Lane: 2
-  HitSound: Normal
 - StartTime: 106369
   Lane: 1
-  HitSound: Normal
 - StartTime: 106369
   Lane: 4
-  HitSound: Normal
 - StartTime: 106419
   Lane: 3
-  HitSound: Normal
 - StartTime: 106469
   Lane: 2
-  HitSound: Normal
 - StartTime: 106519
   Lane: 1
-  HitSound: Normal
 - StartTime: 106569
   Lane: 4
-  HitSound: Normal
 - StartTime: 106569
   Lane: 3
-  HitSound: Normal
 - StartTime: 106635
   Lane: 2
-  HitSound: Normal
 - StartTime: 106702
   Lane: 4
-  HitSound: Normal
 - StartTime: 106769
   Lane: 3
-  HitSound: Normal
 - StartTime: 106769
   Lane: 2
-  HitSound: Normal
 - StartTime: 106869
   Lane: 1
-  HitSound: Normal
 - StartTime: 106869
   Lane: 4
-  HitSound: Normal
 - StartTime: 107069
   Lane: 4
-  HitSound: Normal
 - StartTime: 107069
   Lane: 1
-  HitSound: Normal
 - StartTime: 107169
   Lane: 3
-  HitSound: Normal
 - StartTime: 107169
   Lane: 2
-  HitSound: Normal
 - StartTime: 107369
   Lane: 4
-  HitSound: Normal
 - StartTime: 107369
   Lane: 3
-  HitSound: Normal
 - StartTime: 107369
   Lane: 2
-  HitSound: Normal
 - StartTime: 107369
   Lane: 1
-  HitSound: Normal
 - StartTime: 107569
   Lane: 3
-  HitSound: Normal
 - StartTime: 107569
   Lane: 2
-  HitSound: Normal
 - StartTime: 107669
   Lane: 1
-  HitSound: Normal
 - StartTime: 107669
   Lane: 4
-  HitSound: Normal
 - StartTime: 107869
   Lane: 4
-  HitSound: Normal
 - StartTime: 107869
   Lane: 1
-  HitSound: Normal
 - StartTime: 107969
   Lane: 2
-  HitSound: Normal
 - StartTime: 107969
   Lane: 3
-  HitSound: Normal
 - StartTime: 108169
   Lane: 4
-  HitSound: Normal
 - StartTime: 108169
   Lane: 3
-  HitSound: Normal
 - StartTime: 108169
   Lane: 2
-  HitSound: Normal
 - StartTime: 108169
   Lane: 1
-  HitSound: Normal
 - StartTime: 108369
   Lane: 3
-  HitSound: Normal
 - StartTime: 108369
   Lane: 2
-  HitSound: Normal
 - StartTime: 108469
   Lane: 4
-  HitSound: Normal
 - StartTime: 108469
   Lane: 1
-  HitSound: Normal
 - StartTime: 108669
   Lane: 4
-  HitSound: Normal
 - StartTime: 108669
   Lane: 1
-  HitSound: Normal
 - StartTime: 108769
   Lane: 2
-  HitSound: Normal
 - StartTime: 108769
   Lane: 3
-  HitSound: Normal
 - StartTime: 108969
   Lane: 1
-  HitSound: Normal
 - StartTime: 108969
   Lane: 3
-  HitSound: Normal
 - StartTime: 108969
   Lane: 4
-  HitSound: Normal
 - StartTime: 108969
   Lane: 2
-  HitSound: Normal
 - StartTime: 109169
   Lane: 2
-  HitSound: Normal
 - StartTime: 109169
   Lane: 3
-  HitSound: Normal
 - StartTime: 109269
   Lane: 1
-  HitSound: Normal
 - StartTime: 109269
   Lane: 4
-  HitSound: Normal
 - StartTime: 109469
   Lane: 4
-  HitSound: Normal
 - StartTime: 109469
   Lane: 1
-  HitSound: Normal
 - StartTime: 109569
   Lane: 2
-  HitSound: Normal
 - StartTime: 109569
   Lane: 3
-  HitSound: Normal
 - StartTime: 109769
   Lane: 1
-  HitSound: Normal
 - StartTime: 109769
   Lane: 3
-  HitSound: Normal
 - StartTime: 109769
   Lane: 4
-  HitSound: Normal
 - StartTime: 109769
   Lane: 2
-  HitSound: Normal
 - StartTime: 109969
   Lane: 2
-  HitSound: Normal
 - StartTime: 109969
   Lane: 3
-  HitSound: Normal
 - StartTime: 110069
   Lane: 4
-  HitSound: Normal
 - StartTime: 110069
   Lane: 1
-  HitSound: Normal
 - StartTime: 110269
   Lane: 1
-  HitSound: Normal
 - StartTime: 110269
   Lane: 4
-  HitSound: Normal
 - StartTime: 110369
   Lane: 3
-  HitSound: Normal
 - StartTime: 110369
   Lane: 2
-  HitSound: Normal
 - StartTime: 110569
   Lane: 4
-  HitSound: Normal
 - StartTime: 110569
   Lane: 2
-  HitSound: Normal
 - StartTime: 110569
   Lane: 1
-  HitSound: Normal
 - StartTime: 110569
   Lane: 3
-  HitSound: Normal
 - StartTime: 110769
   Lane: 3
-  HitSound: Normal
 - StartTime: 110769
   Lane: 2
-  HitSound: Normal
 - StartTime: 110869
   Lane: 4
-  HitSound: Normal
 - StartTime: 110869
   Lane: 1
-  HitSound: Normal
 - StartTime: 110969
   Lane: 3
-  HitSound: Normal
 - StartTime: 110969
   Lane: 2
-  HitSound: Normal
 - StartTime: 111069
   Lane: 3
-  HitSound: Normal
 - StartTime: 111069
   Lane: 2
-  HitSound: Normal
 - StartTime: 111269
   Lane: 2
-  HitSound: Normal
 - StartTime: 111269
   Lane: 1
-  HitSound: Normal
 - StartTime: 111269
   Lane: 3
-  HitSound: Normal
 - StartTime: 111269
   Lane: 4
-  HitSound: Normal
 - StartTime: 111369
   Lane: 3
-  HitSound: Normal
 - StartTime: 111369
   Lane: 2
-  HitSound: Normal
 - StartTime: 111369
   Lane: 1
-  HitSound: Normal
 - StartTime: 111369
   Lane: 4
-  HitSound: Normal
 - StartTime: 111469
   Lane: 2
-  HitSound: Normal
 - StartTime: 111469
   Lane: 1
-  HitSound: Normal
 - StartTime: 111469
   Lane: 3
-  HitSound: Normal
 - StartTime: 111469
   Lane: 4
-  HitSound: Normal
 - StartTime: 111669
   Lane: 4
-  HitSound: Normal
 - StartTime: 111669
   Lane: 3
-  HitSound: Normal
 - StartTime: 111669
   Lane: 2
-  HitSound: Normal
 - StartTime: 111669
   Lane: 1
-  HitSound: Normal
 - StartTime: 111769
   Lane: 4
-  HitSound: Normal
 - StartTime: 111769
   Lane: 3
-  HitSound: Normal
 - StartTime: 111769
   Lane: 2
-  HitSound: Normal
 - StartTime: 111769
   Lane: 1
-  HitSound: Normal
 - StartTime: 112169
   Lane: 1
   EndTime: 112569
-  HitSound: Normal
 - StartTime: 112569
   Lane: 4
-  HitSound: Normal
 - StartTime: 112569
   Lane: 3
-  HitSound: Normal
 - StartTime: 112569
   Lane: 2
-  HitSound: Normal
 - StartTime: 113069
   Lane: 2
   EndTime: 113469
-  HitSound: Normal
 - StartTime: 113869
   Lane: 2
   EndTime: 114269
-  HitSound: Normal
 - StartTime: 114669
   Lane: 1
   EndTime: 115069
-  HitSound: Normal
 - StartTime: 115469
   Lane: 1
   EndTime: 115869
-  HitSound: Normal
 - StartTime: 116269
   Lane: 4
   EndTime: 116669
-  HitSound: Normal
 - StartTime: 117069
   Lane: 4
   EndTime: 117469
-  HitSound: Normal
 - StartTime: 117869
   Lane: 3
   EndTime: 118269
-  HitSound: Normal
 - StartTime: 118669
   Lane: 3
   EndTime: 119069
-  HitSound: Normal
 - StartTime: 119469
   Lane: 2
   EndTime: 119869
-  HitSound: Normal
 - StartTime: 120269
   Lane: 2
   EndTime: 120669
-  HitSound: Normal
 - StartTime: 121069
   Lane: 1
   EndTime: 121469
-  HitSound: Normal
 - StartTime: 121269
   Lane: 3
-  HitSound: Normal
 - StartTime: 121369
   Lane: 3
-  HitSound: Normal
 - StartTime: 121569
   Lane: 3
-  HitSound: Normal
 - StartTime: 121669
   Lane: 3
-  HitSound: Normal
 - StartTime: 121869
   Lane: 1
   EndTime: 122269
-  HitSound: Normal
 - StartTime: 121869
   Lane: 3
-  HitSound: Normal
 - StartTime: 121969
   Lane: 3
-  HitSound: Normal
 - StartTime: 122169
   Lane: 3
-  HitSound: Normal
 - StartTime: 122369
   Lane: 2
-  HitSound: Normal
 - StartTime: 122569
   Lane: 1
-  HitSound: Normal
 - StartTime: 122619
   Lane: 3
-  HitSound: Normal
 - StartTime: 122669
   Lane: 4
   EndTime: 123069
-  HitSound: Normal
 - StartTime: 122769
   Lane: 2
-  HitSound: Normal
 - StartTime: 122969
   Lane: 3
-  HitSound: Normal
 - StartTime: 123069
   Lane: 1
-  HitSound: Normal
 - StartTime: 123169
   Lane: 2
-  HitSound: Normal
 - StartTime: 123369
   Lane: 3
-  HitSound: Normal
 - StartTime: 123469
   Lane: 4
   EndTime: 123869
-  HitSound: Normal
 - StartTime: 123569
   Lane: 2
-  HitSound: Normal
 - StartTime: 123869
   Lane: 3
-  HitSound: Normal
 - StartTime: 123969
   Lane: 3
-  HitSound: Normal
 - StartTime: 124069
   Lane: 3
-  HitSound: Normal
 - StartTime: 124169
   Lane: 1
-  HitSound: Normal
 - StartTime: 124219
   Lane: 2
-  HitSound: Normal
 - StartTime: 124269
   Lane: 3
   EndTime: 124669
-  HitSound: Normal
 - StartTime: 124419
   Lane: 2
-  HitSound: Normal
 - StartTime: 124569
   Lane: 4
-  HitSound: Normal
 - StartTime: 124669
   Lane: 1
-  HitSound: Normal
 - StartTime: 124769
   Lane: 2
-  HitSound: Normal
 - StartTime: 124969
   Lane: 4
-  HitSound: Normal
 - StartTime: 125069
   Lane: 3
   EndTime: 125469
-  HitSound: Normal
 - StartTime: 125269
   Lane: 2
-  HitSound: Normal
 - StartTime: 125369
   Lane: 1
-  HitSound: Normal
 - StartTime: 125469
   Lane: 2
   EndTime: 125669
-  HitSound: Normal
 - StartTime: 125669
   Lane: 3
   EndTime: 125869
-  HitSound: Normal
 - StartTime: 125869
   Lane: 2
-  HitSound: Normal
 - StartTime: 125969
   Lane: 3
-  HitSound: Normal
 - StartTime: 126069
   Lane: 2
-  HitSound: Normal
 - StartTime: 126169
   Lane: 4
-  HitSound: Normal
 - StartTime: 126269
   Lane: 1
-  HitSound: Normal
 - StartTime: 126369
   Lane: 3
-  HitSound: Normal
 - StartTime: 126469
   Lane: 4
-  HitSound: Normal
 - StartTime: 126569
   Lane: 2
-  HitSound: Normal
 - StartTime: 126669
   Lane: 1
-  HitSound: Normal
 - StartTime: 126769
   Lane: 2
-  HitSound: Normal
 - StartTime: 126869
   Lane: 3
-  HitSound: Normal
 - StartTime: 126969
   Lane: 1
-  HitSound: Normal
 - StartTime: 127069
   Lane: 4
-  HitSound: Normal
 - StartTime: 127169
   Lane: 2
-  HitSound: Normal
 - StartTime: 127269
   Lane: 3
-  HitSound: Normal
 - StartTime: 127369
   Lane: 1
-  HitSound: Normal
 - StartTime: 127469
   Lane: 2
-  HitSound: Normal
 - StartTime: 127569
   Lane: 3
-  HitSound: Normal
 - StartTime: 127669
   Lane: 1
-  HitSound: Normal
 - StartTime: 127769
   Lane: 4
-  HitSound: Normal
 - StartTime: 127869
   Lane: 3
-  HitSound: Normal
 - StartTime: 127969
   Lane: 1
-  HitSound: Normal
 - StartTime: 128069
   Lane: 4
-  HitSound: Normal
 - StartTime: 128169
   Lane: 2
-  HitSound: Normal
 - StartTime: 128269
   Lane: 3
-  HitSound: Normal
 - StartTime: 128369
   Lane: 4
-  HitSound: Normal
 - StartTime: 128469
   Lane: 2
-  HitSound: Normal
 - StartTime: 128569
   Lane: 1
-  HitSound: Normal
 - StartTime: 128669
   Lane: 3
   EndTime: 128869
-  HitSound: Normal
 - StartTime: 128869
   Lane: 2
-  HitSound: Normal
 - StartTime: 128969
   Lane: 1
-  HitSound: Normal
 - StartTime: 129069
   Lane: 3
-  HitSound: Normal
 - StartTime: 129169
   Lane: 2
-  HitSound: Normal
 - StartTime: 129269
   Lane: 4
-  HitSound: Normal
 - StartTime: 129369
   Lane: 1
-  HitSound: Normal
 - StartTime: 129469
   Lane: 3
-  HitSound: Normal
 - StartTime: 129569
   Lane: 2
-  HitSound: Normal
 - StartTime: 129669
   Lane: 4
-  HitSound: Normal
 - StartTime: 129769
   Lane: 3
-  HitSound: Normal
 - StartTime: 129869
   Lane: 1
-  HitSound: Normal
 - StartTime: 129969
   Lane: 3
-  HitSound: Normal
 - StartTime: 130069
   Lane: 2
-  HitSound: Normal
 - StartTime: 130169
   Lane: 1
-  HitSound: Normal
 - StartTime: 130269
   Lane: 4
-  HitSound: Normal
 - StartTime: 130369
   Lane: 2
-  HitSound: Normal
 - StartTime: 130469
   Lane: 3
-  HitSound: Normal
 - StartTime: 130569
   Lane: 1
-  HitSound: Normal
 - StartTime: 130669
   Lane: 2
-  HitSound: Normal
 - StartTime: 130769
   Lane: 3
-  HitSound: Normal
 - StartTime: 130869
   Lane: 1
-  HitSound: Normal
 - StartTime: 130969
   Lane: 3
-  HitSound: Normal
 - StartTime: 131069
   Lane: 4
-  HitSound: Normal
 - StartTime: 131169
   Lane: 2
-  HitSound: Normal
 - StartTime: 131269
   Lane: 3
-  HitSound: Normal
 - StartTime: 131369
   Lane: 1
-  HitSound: Normal
 - StartTime: 131469
   Lane: 2
-  HitSound: Normal
 - StartTime: 131569
   Lane: 4
-  HitSound: Normal
 - StartTime: 131669
   Lane: 3
-  HitSound: Normal
 - StartTime: 131769
   Lane: 1
-  HitSound: Normal
 - StartTime: 131869
   Lane: 3
-  HitSound: Normal
 - StartTime: 131969
   Lane: 1
-  HitSound: Normal
 - StartTime: 132069
   Lane: 2
-  HitSound: Normal
 - StartTime: 132169
   Lane: 4
-  HitSound: Normal
 - StartTime: 132269
   Lane: 1
-  HitSound: Normal
 - StartTime: 132369
   Lane: 3
-  HitSound: Normal
 - StartTime: 132469
   Lane: 2
-  HitSound: Normal
 - StartTime: 132569
   Lane: 4
-  HitSound: Normal
 - StartTime: 132669
   Lane: 3
-  HitSound: Normal
 - StartTime: 132769
   Lane: 1
-  HitSound: Normal
 - StartTime: 132869
   Lane: 4
-  HitSound: Normal
 - StartTime: 132969
   Lane: 2
-  HitSound: Normal
 - StartTime: 133069
   Lane: 3
-  HitSound: Normal
 - StartTime: 133169
   Lane: 1
-  HitSound: Normal
 - StartTime: 133269
   Lane: 2
-  HitSound: Normal
 - StartTime: 133369
   Lane: 1
-  HitSound: Normal
 - StartTime: 133469
   Lane: 4
-  HitSound: Normal
 - StartTime: 133569
   Lane: 2
-  HitSound: Normal
 - StartTime: 133669
   Lane: 3
-  HitSound: Normal
 - StartTime: 133769
   Lane: 1
-  HitSound: Normal
 - StartTime: 133869
   Lane: 4
-  HitSound: Normal
 - StartTime: 133969
   Lane: 2
-  HitSound: Normal
 - StartTime: 134069
   Lane: 3
-  HitSound: Normal
 - StartTime: 134169
   Lane: 3
-  HitSound: Normal
 - StartTime: 134269
   Lane: 1
-  HitSound: Normal
 - StartTime: 134369
   Lane: 3
-  HitSound: Normal
 - StartTime: 134469
   Lane: 3
-  HitSound: Normal
 - StartTime: 134569
   Lane: 2
-  HitSound: Normal
 - StartTime: 134669
   Lane: 3
-  HitSound: Normal
 - StartTime: 134769
   Lane: 3
-  HitSound: Normal
 - StartTime: 134869
   Lane: 1
-  HitSound: Normal
 - StartTime: 134969
   Lane: 3
-  HitSound: Normal
 - StartTime: 135069
   Lane: 2
-  HitSound: Normal
 - StartTime: 135169
   Lane: 4
-  HitSound: Normal
 - StartTime: 135169
   Lane: 1
   EndTime: 135369
-  HitSound: Normal
 - StartTime: 135269
   Lane: 3
-  HitSound: Normal
 - StartTime: 135369
   Lane: 2
-  HitSound: Normal
 - StartTime: 135419
   Lane: 4
-  HitSound: Normal
 - StartTime: 135469
   Lane: 3
-  HitSound: Normal
 - StartTime: 135569
   Lane: 1
-  HitSound: Normal
 - StartTime: 135669
   Lane: 4
-  HitSound: Normal
 - StartTime: 135769
   Lane: 2
-  HitSound: Normal
 - StartTime: 135769
   Lane: 1
-  HitSound: Normal
 - StartTime: 135869
   Lane: 3
-  HitSound: Normal
 - StartTime: 135902
   Lane: 4
-  HitSound: Normal
 - StartTime: 135969
   Lane: 1
-  HitSound: Normal
 - StartTime: 136019
   Lane: 2
-  HitSound: Normal
 - StartTime: 136069
   Lane: 3
-  HitSound: Normal
 - StartTime: 136169
   Lane: 2
-  HitSound: Normal
 - StartTime: 136169
   Lane: 4
-  HitSound: Normal
 - StartTime: 136269
   Lane: 1
-  HitSound: Normal
 - StartTime: 136369
   Lane: 4
-  HitSound: Normal
 - StartTime: 136369
   Lane: 3
-  HitSound: Normal
 - StartTime: 136469
   Lane: 2
-  HitSound: Normal
 - StartTime: 136569
   Lane: 4
-  HitSound: Normal
 - StartTime: 136669
   Lane: 4
-  HitSound: Normal
 - StartTime: 136769
   Lane: 4
-  HitSound: Normal
 - StartTime: 136869
   Lane: 4
-  HitSound: Normal
 - StartTime: 136969
   Lane: 4
-  HitSound: Normal
 - StartTime: 136969
   Lane: 1
-  HitSound: Normal
 - StartTime: 137019
   Lane: 3
-  HitSound: Normal
 - StartTime: 137069
   Lane: 2
-  HitSound: Normal
 - StartTime: 137169
   Lane: 1
-  HitSound: Normal
 - StartTime: 137169
   Lane: 4
-  HitSound: Normal
 - StartTime: 137235
   Lane: 3
-  HitSound: Normal
 - StartTime: 137302
   Lane: 4
-  HitSound: Normal
 - StartTime: 137369
   Lane: 2
-  HitSound: Normal
 - StartTime: 137369
   Lane: 1
-  HitSound: Normal
 - StartTime: 137469
   Lane: 3
-  HitSound: Normal
 - StartTime: 137502
   Lane: 4
-  HitSound: Normal
 - StartTime: 137569
   Lane: 1
-  HitSound: Normal
 - StartTime: 137619
   Lane: 2
-  HitSound: Normal
 - StartTime: 137669
   Lane: 3
-  HitSound: Normal
 - StartTime: 137769
   Lane: 2
-  HitSound: Normal
 - StartTime: 137769
   Lane: 4
-  HitSound: Normal
 - StartTime: 137869
   Lane: 1
-  HitSound: Normal
 - StartTime: 137969
   Lane: 4
-  HitSound: Normal
 - StartTime: 137969
   Lane: 3
-  HitSound: Normal
 - StartTime: 138069
   Lane: 2
-  HitSound: Normal
 - StartTime: 138169
   Lane: 3
-  HitSound: Normal
 - StartTime: 138169
   Lane: 4
-  HitSound: Normal
 - StartTime: 138169
   Lane: 1
-  HitSound: Normal
 - StartTime: 138369
   Lane: 3
-  HitSound: Normal
 - StartTime: 138569
   Lane: 3
-  HitSound: Normal
 - StartTime: 138769
   Lane: 3
-  HitSound: Normal
 - StartTime: 138969
   Lane: 4
-  HitSound: Normal
 - StartTime: 138969
   Lane: 3
-  HitSound: Normal
 - StartTime: 138969
   Lane: 2
-  HitSound: Normal
 - StartTime: 138969
   Lane: 1
-  HitSound: Normal
 - StartTime: 140569
   Lane: 4
-  HitSound: Normal
 - StartTime: 140569
   Lane: 1
-  HitSound: Normal
 - StartTime: 140569
   Lane: 3
-  HitSound: Normal
 - StartTime: 140569
   Lane: 2
-  HitSound: Normal
 - StartTime: 142169
   Lane: 3
-  HitSound: Normal
 - StartTime: 142169
   Lane: 2
-  HitSound: Normal
 - StartTime: 142169
   Lane: 4
-  HitSound: Normal
 - StartTime: 142169
   Lane: 1
-  HitSound: Normal
 - StartTime: 143769
   Lane: 4
-  HitSound: Normal
 - StartTime: 143769
   Lane: 1
-  HitSound: Normal
 - StartTime: 143769
   Lane: 3
-  HitSound: Normal
 - StartTime: 143769
   Lane: 2
-  HitSound: Normal
 - StartTime: 144569
   Lane: 3
-  HitSound: Normal
 - StartTime: 144569
   Lane: 2
-  HitSound: Normal
 - StartTime: 144569
   Lane: 4
-  HitSound: Normal
 - StartTime: 144569
   Lane: 1
-  HitSound: Normal
 - StartTime: 144969
   Lane: 3
   EndTime: 145169
-  HitSound: Normal
 - StartTime: 145169
   Lane: 2
   EndTime: 145269
-  HitSound: Normal
 - StartTime: 145369
   Lane: 4
-  HitSound: Normal
 - StartTime: 145369
   Lane: 3
-  HitSound: Normal
 - StartTime: 145369
   Lane: 2
-  HitSound: Normal
 - StartTime: 145369
   Lane: 1
-  HitSound: Normal
 - StartTime: 146969
   Lane: 4
-  HitSound: Normal
 - StartTime: 146969
   Lane: 1
-  HitSound: Normal
 - StartTime: 146969
   Lane: 3
-  HitSound: Normal
 - StartTime: 146969
   Lane: 2
-  HitSound: Normal
 - StartTime: 148569
   Lane: 3
-  HitSound: Normal
 - StartTime: 148569
   Lane: 2
-  HitSound: Normal
 - StartTime: 148569
   Lane: 4
-  HitSound: Normal
 - StartTime: 148569
   Lane: 1
-  HitSound: Normal
 - StartTime: 150169
   Lane: 4
-  HitSound: Normal
 - StartTime: 150169
   Lane: 1
-  HitSound: Normal
 - StartTime: 150169
   Lane: 3
-  HitSound: Normal
 - StartTime: 150169
   Lane: 2
-  HitSound: Normal
 - StartTime: 151369
   Lane: 3
-  HitSound: Normal
 - StartTime: 151369
   Lane: 2
-  HitSound: Normal
 - StartTime: 151369
   Lane: 4
-  HitSound: Normal
 - StartTime: 151369
   Lane: 1
-  HitSound: Normal
 - StartTime: 152169
   Lane: 4
-  HitSound: Normal
 - StartTime: 152169
   Lane: 1
-  HitSound: Normal
 - StartTime: 152169
   Lane: 3
-  HitSound: Normal
 - StartTime: 152169
   Lane: 2
-  HitSound: Normal
 - StartTime: 152969
   Lane: 3
-  HitSound: Normal
 - StartTime: 152969
   Lane: 2
-  HitSound: Normal
 - StartTime: 152969
   Lane: 4
-  HitSound: Normal
 - StartTime: 152969
   Lane: 1
-  HitSound: Normal
 - StartTime: 153769
   Lane: 4
-  HitSound: Normal
 - StartTime: 153769
   Lane: 1
-  HitSound: Normal
 - StartTime: 153769
   Lane: 3
-  HitSound: Normal
 - StartTime: 153769
   Lane: 2
-  HitSound: Normal
 - StartTime: 154569
   Lane: 3
-  HitSound: Normal
 - StartTime: 154569
   Lane: 2
-  HitSound: Normal
 - StartTime: 154569
   Lane: 4
-  HitSound: Normal
 - StartTime: 154569
   Lane: 1
-  HitSound: Normal
 - StartTime: 155369
   Lane: 4
-  HitSound: Normal
 - StartTime: 155369
   Lane: 1
-  HitSound: Normal
 - StartTime: 155369
   Lane: 3
-  HitSound: Normal
 - StartTime: 155369
   Lane: 2
-  HitSound: Normal
 - StartTime: 156169
   Lane: 3
-  HitSound: Normal
 - StartTime: 156169
   Lane: 2
-  HitSound: Normal
 - StartTime: 156169
   Lane: 4
-  HitSound: Normal
 - StartTime: 156169
   Lane: 1
-  HitSound: Normal
 - StartTime: 156969
   Lane: 4
-  HitSound: Normal
 - StartTime: 156969
   Lane: 1
-  HitSound: Normal
 - StartTime: 156969
   Lane: 3
-  HitSound: Normal
 - StartTime: 156969
   Lane: 2
-  HitSound: Normal
 - StartTime: 157369
   Lane: 4
-  HitSound: Normal
 - StartTime: 157369
   Lane: 3
-  HitSound: Normal
 - StartTime: 157369
   Lane: 2
-  HitSound: Normal
 - StartTime: 157369
   Lane: 1
-  HitSound: Normal
 - StartTime: 157502
   Lane: 4
-  HitSound: Normal
 - StartTime: 157502
   Lane: 3
-  HitSound: Normal
 - StartTime: 157502
   Lane: 2
-  HitSound: Normal
 - StartTime: 157502
   Lane: 1
-  HitSound: Normal
 - StartTime: 157769
   Lane: 4
-  HitSound: Normal
 - StartTime: 157769
   Lane: 3
-  HitSound: Normal
 - StartTime: 157769
   Lane: 1
-  HitSound: Normal
 - StartTime: 157769
   Lane: 2
-  HitSound: Normal
 - StartTime: 158035
   Lane: 4
-  HitSound: Normal
 - StartTime: 158035
   Lane: 3
-  HitSound: Normal
 - StartTime: 158035
   Lane: 2
-  HitSound: Normal
 - StartTime: 158035
   Lane: 1
-  HitSound: Normal
 - StartTime: 158302
   Lane: 4
-  HitSound: Normal
 - StartTime: 158302
   Lane: 3
-  HitSound: Normal
 - StartTime: 158302
   Lane: 2
-  HitSound: Normal
 - StartTime: 158302
   Lane: 1
-  HitSound: Normal
 - StartTime: 158435
   Lane: 4
-  HitSound: Normal
 - StartTime: 158435
   Lane: 3
-  HitSound: Normal
 - StartTime: 158435
   Lane: 2
-  HitSound: Normal
 - StartTime: 158435
   Lane: 1
-  HitSound: Normal
 - StartTime: 158569
   Lane: 4
-  HitSound: Normal
 - StartTime: 158569
   Lane: 3
-  HitSound: Normal
 - StartTime: 158569
   Lane: 2
-  HitSound: Normal
 - StartTime: 158569
   Lane: 1
-  HitSound: Normal
 - StartTime: 158835
   Lane: 4
-  HitSound: Normal
 - StartTime: 158835
   Lane: 3
-  HitSound: Normal
 - StartTime: 158835
   Lane: 2
-  HitSound: Normal
 - StartTime: 158835
   Lane: 1
-  HitSound: Normal
 - StartTime: 159102
   Lane: 4
-  HitSound: Normal
 - StartTime: 159102
   Lane: 3
-  HitSound: Normal
 - StartTime: 159102
   Lane: 2
-  HitSound: Normal
 - StartTime: 159102
   Lane: 1
-  HitSound: Normal
 - StartTime: 159369
   Lane: 4
-  HitSound: Normal
 - StartTime: 159369
   Lane: 2
-  HitSound: Normal
 - StartTime: 159369
   Lane: 1
-  HitSound: Normal
 - StartTime: 159369
   Lane: 3
-  HitSound: Normal
 - StartTime: 159635
   Lane: 4
-  HitSound: Normal
 - StartTime: 159635
   Lane: 3
-  HitSound: Normal
 - StartTime: 159635
   Lane: 2
-  HitSound: Normal
 - StartTime: 159635
   Lane: 1
-  HitSound: Normal
 - StartTime: 159902
   Lane: 4
-  HitSound: Normal
 - StartTime: 159902
   Lane: 3
-  HitSound: Normal
 - StartTime: 159902
   Lane: 2
-  HitSound: Normal
 - StartTime: 159902
   Lane: 1
-  HitSound: Normal
 - StartTime: 160035
   Lane: 4
-  HitSound: Normal
 - StartTime: 160035
   Lane: 3
-  HitSound: Normal
 - StartTime: 160035
   Lane: 2
-  HitSound: Normal
 - StartTime: 160035
   Lane: 1
-  HitSound: Normal
 - StartTime: 160169
   Lane: 4
-  HitSound: Normal
 - StartTime: 160169
   Lane: 3
-  HitSound: Normal
 - StartTime: 160169
   Lane: 2
-  HitSound: Normal
 - StartTime: 160169
   Lane: 1
-  HitSound: Normal
 - StartTime: 160435
   Lane: 2
-  HitSound: Normal
 - StartTime: 160435
   Lane: 1
-  HitSound: Normal
 - StartTime: 160569
   Lane: 2
-  HitSound: Normal
 - StartTime: 160569
   Lane: 1
-  HitSound: Normal
 - StartTime: 160702
   Lane: 2
-  HitSound: Normal
 - StartTime: 160702
   Lane: 1
-  HitSound: Normal
 - StartTime: 160702
   Lane: 4
-  HitSound: Normal
 - StartTime: 160702
   Lane: 3
-  HitSound: Normal
 - StartTime: 160835
   Lane: 4
-  HitSound: Normal
 - StartTime: 160835
   Lane: 3
-  HitSound: Normal
 - StartTime: 160969
   Lane: 4
-  HitSound: Normal
 - StartTime: 160969
   Lane: 2
-  HitSound: Normal
 - StartTime: 160969
   Lane: 1
-  HitSound: Normal
 - StartTime: 160969
   Lane: 3
-  HitSound: Normal
 - StartTime: 161102
   Lane: 2
-  HitSound: Normal
 - StartTime: 161102
   Lane: 1
-  HitSound: Normal
 - StartTime: 161235
   Lane: 4
-  HitSound: Normal
 - StartTime: 161235
   Lane: 3
-  HitSound: Normal
 - StartTime: 161235
   Lane: 1
-  HitSound: Normal
 - StartTime: 161235
   Lane: 2
-  HitSound: Normal
 - StartTime: 161369
   Lane: 3
-  HitSound: Normal
 - StartTime: 161369
   Lane: 4
-  HitSound: Normal
 - StartTime: 161502
   Lane: 3
-  HitSound: Normal
 - StartTime: 161502
   Lane: 2
-  HitSound: Normal
 - StartTime: 161502
   Lane: 1
-  HitSound: Normal
 - StartTime: 161502
   Lane: 4
-  HitSound: Normal
 - StartTime: 161635
   Lane: 1
-  HitSound: Normal
 - StartTime: 161635
   Lane: 2
-  HitSound: Normal
 - StartTime: 161769
   Lane: 1
-  HitSound: Normal
 - StartTime: 161769
   Lane: 2
-  HitSound: Normal
 - StartTime: 161769
   Lane: 4
-  HitSound: Normal
 - StartTime: 161769
   Lane: 3
-  HitSound: Normal
 - StartTime: 161902
   Lane: 4
-  HitSound: Normal
 - StartTime: 161902
   Lane: 3
-  HitSound: Normal
 - StartTime: 162035
   Lane: 1
-  HitSound: Normal
 - StartTime: 162035
   Lane: 4
-  HitSound: Normal
 - StartTime: 162035
   Lane: 3
-  HitSound: Normal
 - StartTime: 162035
   Lane: 2
-  HitSound: Normal
 - StartTime: 162169
   Lane: 4
-  HitSound: Normal
 - StartTime: 162169
   Lane: 3
-  HitSound: Normal
 - StartTime: 162169
   Lane: 1
-  HitSound: Normal
 - StartTime: 162169
   Lane: 2
-  HitSound: Normal
 - StartTime: 162435
   Lane: 3
-  HitSound: Normal
 - StartTime: 162569
   Lane: 4
-  HitSound: Normal
 - StartTime: 162769
   Lane: 1
-  HitSound: Normal
 - StartTime: 162835
   Lane: 2
-  HitSound: Normal
 - StartTime: 162869
   Lane: 4
-  HitSound: Normal
 - StartTime: 162919
   Lane: 3
-  HitSound: Normal
 - StartTime: 162969
   Lane: 2
-  HitSound: Normal
 - StartTime: 163102
   Lane: 3
-  HitSound: Normal
 - StartTime: 163235
   Lane: 2
-  HitSound: Normal
 - StartTime: 163369
   Lane: 4
-  HitSound: Normal
 - StartTime: 163369
   Lane: 1
-  HitSound: Normal
 - StartTime: 163635
   Lane: 3
-  HitSound: Normal
 - StartTime: 163769
   Lane: 4
-  HitSound: Normal
 - StartTime: 163769
   Lane: 1
-  HitSound: Normal
 - StartTime: 163769
   Lane: 3
-  HitSound: Normal
 - StartTime: 163902
   Lane: 2
-  HitSound: Normal
 - StartTime: 164035
   Lane: 2
-  HitSound: Normal
 - StartTime: 164169
   Lane: 4
-  HitSound: Normal
 - StartTime: 164169
   Lane: 1
-  HitSound: Normal
 - StartTime: 164235
   Lane: 3
-  HitSound: Normal
 - StartTime: 164302
   Lane: 2
-  HitSound: Normal
 - StartTime: 164435
   Lane: 2
-  HitSound: Normal
 - StartTime: 164569
   Lane: 1
   EndTime: 164819
-  HitSound: Normal
 - StartTime: 164569
   Lane: 4
-  HitSound: Normal
 - StartTime: 164619
   Lane: 2
   EndTime: 164819
-  HitSound: Normal
 - StartTime: 164669
   Lane: 3
   EndTime: 164819
-  HitSound: Normal
 - StartTime: 165102
   Lane: 4
   EndTime: 165352
-  HitSound: Normal
 - StartTime: 165102
   Lane: 1
-  HitSound: Normal
 - StartTime: 165152
   Lane: 3
   EndTime: 165352
-  HitSound: Normal
 - StartTime: 165202
   Lane: 2
   EndTime: 165352
-  HitSound: Normal
 - StartTime: 165635
   Lane: 4
-  HitSound: Normal
 - StartTime: 165635
   Lane: 1
   EndTime: 165885
-  HitSound: Normal
 - StartTime: 165685
   Lane: 2
   EndTime: 165885
-  HitSound: Normal
 - StartTime: 165735
   Lane: 3
   EndTime: 165885
-  HitSound: Normal
 - StartTime: 166169
   Lane: 4
   EndTime: 166419
-  HitSound: Normal
 - StartTime: 166169
   Lane: 1
-  HitSound: Normal
 - StartTime: 166219
   Lane: 3
   EndTime: 166419
-  HitSound: Normal
 - StartTime: 166269
   Lane: 2
   EndTime: 166419
-  HitSound: Normal
 - StartTime: 166702
   Lane: 4
-  HitSound: Normal
 - StartTime: 166702
   Lane: 1
   EndTime: 166952
-  HitSound: Normal
 - StartTime: 166752
   Lane: 2
   EndTime: 166952
-  HitSound: Normal
 - StartTime: 166802
   Lane: 3
   EndTime: 166952
-  HitSound: Normal
 - StartTime: 167235
   Lane: 4
   EndTime: 167485
-  HitSound: Normal
 - StartTime: 167235
   Lane: 1
-  HitSound: Normal
 - StartTime: 167285
   Lane: 3
   EndTime: 167485
-  HitSound: Normal
 - StartTime: 167335
   Lane: 2
   EndTime: 167485
-  HitSound: Normal
 - StartTime: 167769
   Lane: 4
-  HitSound: Normal
 - StartTime: 167769
   Lane: 1
   EndTime: 168019
-  HitSound: Normal
 - StartTime: 167819
   Lane: 2
   EndTime: 168019
-  HitSound: Normal
 - StartTime: 167869
   Lane: 3
   EndTime: 168019
-  HitSound: Normal
 - StartTime: 168302
   Lane: 4
   EndTime: 168552
-  HitSound: Normal
 - StartTime: 168302
   Lane: 1
-  HitSound: Normal
 - StartTime: 168352
   Lane: 3
   EndTime: 168552
-  HitSound: Normal
 - StartTime: 168402
   Lane: 2
   EndTime: 168552
-  HitSound: Normal
 - StartTime: 168835
   Lane: 4
-  HitSound: Normal
 - StartTime: 168835
   Lane: 1
   EndTime: 169085
-  HitSound: Normal
 - StartTime: 168885
   Lane: 2
   EndTime: 169085
-  HitSound: Normal
 - StartTime: 168935
   Lane: 3
   EndTime: 169085
-  HitSound: Normal
 - StartTime: 169369
   Lane: 4
   EndTime: 169619
-  HitSound: Normal
 - StartTime: 169369
   Lane: 1
-  HitSound: Normal
 - StartTime: 169419
   Lane: 3
   EndTime: 169619
-  HitSound: Normal
 - StartTime: 169469
   Lane: 2
   EndTime: 169619
-  HitSound: Normal
 - StartTime: 169769
   Lane: 4
-  HitSound: Normal
 - StartTime: 169769
   Lane: 1
-  HitSound: Normal
 - StartTime: 169819
   Lane: 2
-  HitSound: Normal
 - StartTime: 169869
   Lane: 3
-  HitSound: Normal
 - StartTime: 170169
   Lane: 3
-  HitSound: Normal
 - StartTime: 170169
   Lane: 1
-  HitSound: Normal
 - StartTime: 170169
   Lane: 4
-  HitSound: Normal
 - StartTime: 170219
   Lane: 2
-  HitSound: Normal
 - StartTime: 170269
   Lane: 4
-  HitSound: Normal
 - StartTime: 170319
   Lane: 3
-  HitSound: Normal
 - StartTime: 170369
   Lane: 1
-  HitSound: Normal
 - StartTime: 170419
   Lane: 2
-  HitSound: Normal
 - StartTime: 170469
   Lane: 4
-  HitSound: Normal
 - StartTime: 170519
   Lane: 3
-  HitSound: Normal
 - StartTime: 170569
   Lane: 2
-  HitSound: Normal
 - StartTime: 170569
   Lane: 1
-  HitSound: Normal
 - StartTime: 170619
   Lane: 4
-  HitSound: Normal
 - StartTime: 170669
   Lane: 1
-  HitSound: Normal
 - StartTime: 170719
   Lane: 3
-  HitSound: Normal
 - StartTime: 170769
   Lane: 4
-  HitSound: Normal
 - StartTime: 170819
   Lane: 2
-  HitSound: Normal
 - StartTime: 170835
   Lane: 1
-  HitSound: Normal
 - StartTime: 170869
   Lane: 3
-  HitSound: Normal
 - StartTime: 170969
   Lane: 4
-  HitSound: Normal
 - StartTime: 170969
   Lane: 2
-  HitSound: Normal
 - StartTime: 170969
   Lane: 1
-  HitSound: Normal
 - StartTime: 171102
   Lane: 4
-  HitSound: Normal
 - StartTime: 171235
   Lane: 4
-  HitSound: Normal
 - StartTime: 171369
   Lane: 4
-  HitSound: Normal
 - StartTime: 171635
   Lane: 2
   EndTime: 172035
-  HitSound: Normal
 - StartTime: 172035
   Lane: 4
-  HitSound: Normal
 - StartTime: 172035
   Lane: 3
-  HitSound: Normal
 - StartTime: 172169
   Lane: 4
-  HitSound: Normal
 - StartTime: 172169
   Lane: 2
-  HitSound: Normal
 - StartTime: 172169
   Lane: 1
-  HitSound: Normal
 - StartTime: 172219
   Lane: 3
-  HitSound: Normal
 - StartTime: 172269
   Lane: 1
-  HitSound: Normal
 - StartTime: 172319
   Lane: 4
-  HitSound: Normal
 - StartTime: 172369
   Lane: 2
-  HitSound: Normal
 - StartTime: 172419
   Lane: 1
-  HitSound: Normal
 - StartTime: 172469
   Lane: 4
-  HitSound: Normal
 - StartTime: 172519
   Lane: 3
-  HitSound: Normal
 - StartTime: 172569
   Lane: 1
-  HitSound: Normal
 - StartTime: 172569
   Lane: 2
-  HitSound: Normal
 - StartTime: 172635
   Lane: 4
-  HitSound: Normal
 - StartTime: 172702
   Lane: 2
-  HitSound: Normal
 - StartTime: 172702
   Lane: 1
-  HitSound: Normal
 - StartTime: 172769
   Lane: 3
-  HitSound: Normal
 - StartTime: 172835
   Lane: 2
-  HitSound: Normal
 - StartTime: 172835
   Lane: 1
-  HitSound: Normal
 - StartTime: 172902
   Lane: 4
-  HitSound: Normal
 - StartTime: 172969
   Lane: 2
-  HitSound: Normal
 - StartTime: 172969
   Lane: 1
-  HitSound: Normal
 - StartTime: 173035
   Lane: 3
-  HitSound: Normal
 - StartTime: 173102
   Lane: 2
-  HitSound: Normal
 - StartTime: 173102
   Lane: 1
-  HitSound: Normal
 - StartTime: 173169
   Lane: 4
-  HitSound: Normal
 - StartTime: 173235
   Lane: 2
-  HitSound: Normal
 - StartTime: 173235
   Lane: 1
-  HitSound: Normal
 - StartTime: 173302
   Lane: 3
-  HitSound: Normal
 - StartTime: 173635
   Lane: 2
-  HitSound: Normal
 - StartTime: 173635
   Lane: 1
-  HitSound: Normal
 - StartTime: 173702
   Lane: 4
-  HitSound: Normal
 - StartTime: 173769
   Lane: 3
-  HitSound: Normal
 - StartTime: 173769
   Lane: 1
-  HitSound: Normal
 - StartTime: 173819
   Lane: 2
-  HitSound: Normal
 - StartTime: 173869
   Lane: 4
-  HitSound: Normal
 - StartTime: 173869
   Lane: 3
-  HitSound: Normal
 - StartTime: 173919
   Lane: 1
-  HitSound: Normal
 - StartTime: 173969
   Lane: 2
-  HitSound: Normal
 - StartTime: 174035
   Lane: 4
-  HitSound: Normal
 - StartTime: 174035
   Lane: 3
-  HitSound: Normal
 - StartTime: 174169
   Lane: 4
-  HitSound: Normal
 - StartTime: 174169
   Lane: 1
-  HitSound: Normal
 - StartTime: 174169
   Lane: 2
   EndTime: 174369
-  HitSound: Normal
 - StartTime: 174569
   Lane: 3
-  HitSound: Normal
 - StartTime: 174569
   Lane: 1
-  HitSound: Normal
 - StartTime: 174569
   Lane: 4
   EndTime: 174702
-  HitSound: Normal
 - StartTime: 174835
   Lane: 4
-  HitSound: Normal
 - StartTime: 174835
   Lane: 2
   EndTime: 175102
-  HitSound: Normal
 - StartTime: 175102
   Lane: 4
   EndTime: 175302
-  HitSound: Normal
 - StartTime: 175169
   Lane: 3
   EndTime: 175302
-  HitSound: Normal
 - StartTime: 175235
   Lane: 2
   EndTime: 175369
-  HitSound: Normal
 - StartTime: 175235
   Lane: 1
   EndTime: 175369
-  HitSound: Normal
 - StartTime: 175369
   Lane: 4
-  HitSound: Normal
 - StartTime: 175369
   Lane: 3
-  HitSound: Normal
 - StartTime: 175435
   Lane: 2
-  HitSound: Normal
 - StartTime: 175502
   Lane: 4
-  HitSound: Normal
 - StartTime: 175569
   Lane: 2
-  HitSound: Normal
 - StartTime: 175635
   Lane: 3
-  HitSound: Normal
 - StartTime: 175635
   Lane: 4
-  HitSound: Normal
 - StartTime: 175702
   Lane: 1
-  HitSound: Normal
 - StartTime: 175769
   Lane: 2
-  HitSound: Normal
 - StartTime: 175769
   Lane: 3
-  HitSound: Normal
 - StartTime: 175769
   Lane: 4
-  HitSound: Normal
 - StartTime: 175869
   Lane: 2
-  HitSound: Normal
 - StartTime: 175969
   Lane: 3
-  HitSound: Normal
 - StartTime: 176069
   Lane: 2
-  HitSound: Normal
 - StartTime: 176169
   Lane: 4
   EndTime: 176569
-  HitSound: Normal
 - StartTime: 176169
   Lane: 3
-  HitSound: Normal
 - StartTime: 176369
   Lane: 1
-  HitSound: Normal
 - StartTime: 176435
   Lane: 2
-  HitSound: Normal
 - StartTime: 176502
   Lane: 3
-  HitSound: Normal
 - StartTime: 176519
   Lane: 1
-  HitSound: Normal
 - StartTime: 176569
   Lane: 2
-  HitSound: Normal
 - StartTime: 176619
   Lane: 3
-  HitSound: Normal
 - StartTime: 176669
   Lane: 4
-  HitSound: Normal
 - StartTime: 176719
   Lane: 1
-  HitSound: Normal
 - StartTime: 176769
   Lane: 2
-  HitSound: Normal
 - StartTime: 176819
   Lane: 4
-  HitSound: Normal
 - StartTime: 176869
   Lane: 3
-  HitSound: Normal
 - StartTime: 176919
   Lane: 2
-  HitSound: Normal
 - StartTime: 176969
   Lane: 1
-  HitSound: Normal
 - StartTime: 176969
   Lane: 4
-  HitSound: Normal
 - StartTime: 176969
   Lane: 3
-  HitSound: Normal
 - StartTime: 177102
   Lane: 2
-  HitSound: Normal
 - StartTime: 177235
   Lane: 2
-  HitSound: Normal
 - StartTime: 177369
   Lane: 1
-  HitSound: Normal
 - StartTime: 177369
   Lane: 4
   EndTime: 177619
-  HitSound: Normal
 - StartTime: 177419
   Lane: 3
   EndTime: 177619
-  HitSound: Normal
 - StartTime: 177469
   Lane: 2
   EndTime: 177619
-  HitSound: Normal
 - StartTime: 177902
   Lane: 4
-  HitSound: Normal
 - StartTime: 177902
   Lane: 1
   EndTime: 178152
-  HitSound: Normal
 - StartTime: 177952
   Lane: 2
   EndTime: 178152
-  HitSound: Normal
 - StartTime: 178002
   Lane: 3
   EndTime: 178152
-  HitSound: Normal
 - StartTime: 178435
   Lane: 1
-  HitSound: Normal
 - StartTime: 178435
   Lane: 4
   EndTime: 178686
-  HitSound: Normal
 - StartTime: 178486
   Lane: 3
   EndTime: 178686
-  HitSound: Normal
 - StartTime: 178535
   Lane: 2
   EndTime: 178686
-  HitSound: Normal
 - StartTime: 178969
   Lane: 1
   EndTime: 179219
-  HitSound: Normal
 - StartTime: 178969
   Lane: 4
-  HitSound: Normal
 - StartTime: 179019
   Lane: 2
   EndTime: 179219
-  HitSound: Normal
 - StartTime: 179069
   Lane: 3
   EndTime: 179219
-  HitSound: Normal
 - StartTime: 179502
   Lane: 1
-  HitSound: Normal
 - StartTime: 179502
   Lane: 4
   EndTime: 179752
-  HitSound: Normal
 - StartTime: 179552
   Lane: 3
   EndTime: 179752
-  HitSound: Normal
 - StartTime: 179602
   Lane: 2
   EndTime: 179752
-  HitSound: Normal
 - StartTime: 180035
   Lane: 1
   EndTime: 180286
-  HitSound: Normal
 - StartTime: 180035
   Lane: 4
-  HitSound: Normal
 - StartTime: 180086
   Lane: 2
   EndTime: 180286
-  HitSound: Normal
 - StartTime: 180135
   Lane: 3
   EndTime: 180286
-  HitSound: Normal
 - StartTime: 180569
   Lane: 1
-  HitSound: Normal
 - StartTime: 180569
   Lane: 4
   EndTime: 180819
-  HitSound: Normal
 - StartTime: 180619
   Lane: 3
   EndTime: 180819
-  HitSound: Normal
 - StartTime: 180669
   Lane: 2
   EndTime: 180819
-  HitSound: Normal
 - StartTime: 181102
   Lane: 1
   EndTime: 181352
-  HitSound: Normal
 - StartTime: 181102
   Lane: 4
-  HitSound: Normal
 - StartTime: 181152
   Lane: 2
   EndTime: 181352
-  HitSound: Normal
 - StartTime: 181202
   Lane: 3
   EndTime: 181352
-  HitSound: Normal
 - StartTime: 181635
   Lane: 1
-  HitSound: Normal
 - StartTime: 181635
   Lane: 4
   EndTime: 181886
-  HitSound: Normal
 - StartTime: 181686
   Lane: 3
   EndTime: 181886
-  HitSound: Normal
 - StartTime: 181735
   Lane: 2
   EndTime: 181886
-  HitSound: Normal
 - StartTime: 182169
   Lane: 4
-  HitSound: Normal
 - StartTime: 182169
   Lane: 1
-  HitSound: Normal
 - StartTime: 182169
   Lane: 2
-  HitSound: Normal
 - StartTime: 182169
   Lane: 3
-  HitSound: Normal
 - StartTime: 182969
   Lane: 4
-  HitSound: Normal
 - StartTime: 182969
   Lane: 3
-  HitSound: Normal
 - StartTime: 182969
   Lane: 2
-  HitSound: Normal
 - StartTime: 182969
   Lane: 1
-  HitSound: Normal
 - StartTime: 183102
   Lane: 2
-  HitSound: Normal
 - StartTime: 183102
   Lane: 1
-  HitSound: Normal
 - StartTime: 183169
   Lane: 4
-  HitSound: Normal
 - StartTime: 183169
   Lane: 3
-  HitSound: Normal
 - StartTime: 183235
   Lane: 1
-  HitSound: Normal
 - StartTime: 183302
   Lane: 4
-  HitSound: Normal
 - StartTime: 183302
   Lane: 3
-  HitSound: Normal
 - StartTime: 183369
   Lane: 2
-  HitSound: Normal
 - StartTime: 183402
   Lane: 1
-  HitSound: Normal
 - StartTime: 183435
   Lane: 4
-  HitSound: Normal
 - StartTime: 183435
   Lane: 3
-  HitSound: Normal
 - StartTime: 183502
   Lane: 2
-  HitSound: Normal
 - StartTime: 183569
   Lane: 4
-  HitSound: Normal
 - StartTime: 183569
   Lane: 3
-  HitSound: Normal
 - StartTime: 183569
   Lane: 1
-  HitSound: Normal
 - StartTime: 183635
   Lane: 4
-  HitSound: Normal
 - StartTime: 183635
   Lane: 3
-  HitSound: Normal
 - StartTime: 183702
   Lane: 2
-  HitSound: Normal
 - StartTime: 183702
   Lane: 1
-  HitSound: Normal
 - StartTime: 183769
   Lane: 4
-  HitSound: Normal
 - StartTime: 183769
   Lane: 3
-  HitSound: Normal
 - StartTime: 183835
   Lane: 2
-  HitSound: Normal
 - StartTime: 183902
   Lane: 4
-  HitSound: Normal
 - StartTime: 183969
   Lane: 2
-  HitSound: Normal
 - StartTime: 183969
   Lane: 1
-  HitSound: Normal
 - StartTime: 184035
   Lane: 4
-  HitSound: Normal
 - StartTime: 184102
   Lane: 2
-  HitSound: Normal
 - StartTime: 184102
   Lane: 1
-  HitSound: Normal
 - StartTime: 184169
   Lane: 3
-  HitSound: Normal
 - StartTime: 184235
   Lane: 2
-  HitSound: Normal
 - StartTime: 184235
   Lane: 1
-  HitSound: Normal
 - StartTime: 184302
   Lane: 4
-  HitSound: Normal
 - StartTime: 184369
   Lane: 2
-  HitSound: Normal
 - StartTime: 184369
   Lane: 1
-  HitSound: Normal
 - StartTime: 184435
   Lane: 2
-  HitSound: Normal
 - StartTime: 184435
   Lane: 1
-  HitSound: Normal
 - StartTime: 184502
   Lane: 4
   EndTime: 184769
-  HitSound: Normal
 - StartTime: 184502
   Lane: 3
   EndTime: 184769
-  HitSound: Normal
 - StartTime: 184769
   Lane: 2
-  HitSound: Normal
 - StartTime: 184769
   Lane: 1
-  HitSound: Normal
 - StartTime: 184835
   Lane: 3
-  HitSound: Normal
 - StartTime: 184902
   Lane: 2
-  HitSound: Normal
 - StartTime: 184902
   Lane: 1
-  HitSound: Normal
 - StartTime: 184969
   Lane: 4
-  HitSound: Normal
 - StartTime: 185035
   Lane: 2
-  HitSound: Normal
 - StartTime: 185035
   Lane: 1
-  HitSound: Normal
 - StartTime: 185102
   Lane: 3
-  HitSound: Normal
 - StartTime: 185169
   Lane: 2
-  HitSound: Normal
 - StartTime: 185169
   Lane: 1
-  HitSound: Normal
 - StartTime: 185235
   Lane: 2
-  HitSound: Normal
 - StartTime: 185235
   Lane: 1
-  HitSound: Normal
 - StartTime: 185302
   Lane: 4
-  HitSound: Normal
 - StartTime: 185302
   Lane: 3
-  HitSound: Normal
 - StartTime: 185369
   Lane: 2
-  HitSound: Normal
 - StartTime: 185369
   Lane: 1
-  HitSound: Normal
 - StartTime: 185369
   Lane: 4
-  HitSound: Normal
 - StartTime: 185435
   Lane: 3
-  HitSound: Normal
 - StartTime: 185502
   Lane: 1
-  HitSound: Normal
 - StartTime: 185569
   Lane: 4
-  HitSound: Normal
 - StartTime: 185569
   Lane: 3
-  HitSound: Normal
 - StartTime: 185635
   Lane: 2
-  HitSound: Normal
 - StartTime: 185702
   Lane: 4
-  HitSound: Normal
 - StartTime: 185702
   Lane: 3
-  HitSound: Normal
 - StartTime: 185769
   Lane: 1
-  HitSound: Normal
 - StartTime: 185835
   Lane: 4
-  HitSound: Normal
 - StartTime: 185835
   Lane: 3
-  HitSound: Normal
 - StartTime: 185902
   Lane: 2
-  HitSound: Normal
 - StartTime: 185969
   Lane: 4
-  HitSound: Normal
 - StartTime: 185969
   Lane: 3
-  HitSound: Normal
 - StartTime: 186035
   Lane: 4
-  HitSound: Normal
 - StartTime: 186035
   Lane: 3
-  HitSound: Normal
 - StartTime: 186102
   Lane: 2
   EndTime: 186369
-  HitSound: Normal
 - StartTime: 186102
   Lane: 1
   EndTime: 186369
-  HitSound: Normal
 - StartTime: 186369
   Lane: 4
-  HitSound: Normal
 - StartTime: 186369
   Lane: 3
-  HitSound: Normal
 - StartTime: 186435
   Lane: 2
-  HitSound: Normal
 - StartTime: 186435
   Lane: 1
-  HitSound: Normal
 - StartTime: 186502
   Lane: 3
-  HitSound: Normal
 - StartTime: 186502
   Lane: 4
-  HitSound: Normal
 - StartTime: 186569
   Lane: 2
-  HitSound: Normal
 - StartTime: 186569
   Lane: 1
-  HitSound: Normal
 - StartTime: 186569
   Lane: 4
-  HitSound: Normal
 - StartTime: 186635
   Lane: 2
-  HitSound: Normal
 - StartTime: 186635
   Lane: 1
-  HitSound: Normal
 - StartTime: 186769
   Lane: 4
-  HitSound: Normal
 - StartTime: 186769
   Lane: 3
-  HitSound: Normal
 - StartTime: 186835
   Lane: 2
-  HitSound: Normal
 - StartTime: 186835
   Lane: 1
-  HitSound: Normal
 - StartTime: 186902
   Lane: 4
-  HitSound: Normal
 - StartTime: 186902
   Lane: 3
-  HitSound: Normal
 - StartTime: 186969
   Lane: 3
-  HitSound: Normal
 - StartTime: 186969
   Lane: 2
   EndTime: 187169
-  HitSound: Normal
 - StartTime: 186969
   Lane: 1
   EndTime: 187169
-  HitSound: Normal
 - StartTime: 187169
   Lane: 4
-  HitSound: Normal
 - StartTime: 187169
   Lane: 3
-  HitSound: Normal
 - StartTime: 187235
   Lane: 2
-  HitSound: Normal
 - StartTime: 187235
   Lane: 1
-  HitSound: Normal
 - StartTime: 187302
   Lane: 4
-  HitSound: Normal
 - StartTime: 187302
   Lane: 3
-  HitSound: Normal
 - StartTime: 187369
   Lane: 4
-  HitSound: Normal
 - StartTime: 187369
   Lane: 2
-  HitSound: Normal
 - StartTime: 187369
   Lane: 1
-  HitSound: Normal
 - StartTime: 187435
   Lane: 2
-  HitSound: Normal
 - StartTime: 187435
   Lane: 1
-  HitSound: Normal
 - StartTime: 187569
   Lane: 3
-  HitSound: Normal
 - StartTime: 187569
   Lane: 4
-  HitSound: Normal
 - StartTime: 187635
   Lane: 1
-  HitSound: Normal
 - StartTime: 187635
   Lane: 2
-  HitSound: Normal
 - StartTime: 187702
   Lane: 3
-  HitSound: Normal
 - StartTime: 187702
   Lane: 4
-  HitSound: Normal
 - StartTime: 187769
   Lane: 1
-  HitSound: Normal
 - StartTime: 187769
   Lane: 2
-  HitSound: Normal
 - StartTime: 187769
   Lane: 4
-  HitSound: Normal
 - StartTime: 187969
   Lane: 1
-  HitSound: Normal
 - StartTime: 187969
   Lane: 2
-  HitSound: Normal
 - StartTime: 188035
   Lane: 3
-  HitSound: Normal
 - StartTime: 188035
   Lane: 4
-  HitSound: Normal
 - StartTime: 188102
   Lane: 1
-  HitSound: Normal
 - StartTime: 188102
   Lane: 2
-  HitSound: Normal
 - StartTime: 188169
   Lane: 3
-  HitSound: Normal
 - StartTime: 188169
   Lane: 4
-  HitSound: Normal
 - StartTime: 188169
   Lane: 1
-  HitSound: Normal
 - StartTime: 188369
   Lane: 3
-  HitSound: Normal
 - StartTime: 188369
   Lane: 4
-  HitSound: Normal
 - StartTime: 188435
   Lane: 2
-  HitSound: Normal
 - StartTime: 188435
   Lane: 1
-  HitSound: Normal
 - StartTime: 188502
   Lane: 3
-  HitSound: Normal
 - StartTime: 188502
   Lane: 4
-  HitSound: Normal
 - StartTime: 188569
   Lane: 1
-  HitSound: Normal
 - StartTime: 188569
   Lane: 2
-  HitSound: Normal
 - StartTime: 188569
   Lane: 4
-  HitSound: Normal
 - StartTime: 188702
   Lane: 3
-  HitSound: Normal
 - StartTime: 188702
   Lane: 2
-  HitSound: Normal
 - StartTime: 188835
   Lane: 3
-  HitSound: Normal
 - StartTime: 188835
   Lane: 4
-  HitSound: Normal
 - StartTime: 188969
   Lane: 1
-  HitSound: Normal
 - StartTime: 188969
   Lane: 4
   EndTime: 189369
-  HitSound: Normal
 - StartTime: 189369
   Lane: 3
-  HitSound: Normal
 - StartTime: 189369
   Lane: 2
-  HitSound: Normal
 - StartTime: 189369
   Lane: 1
-  HitSound: Normal
 - StartTime: 189635
   Lane: 3
-  HitSound: Normal
 - StartTime: 189769
   Lane: 1
-  HitSound: Normal
 - StartTime: 189769
   Lane: 4
-  HitSound: Normal
 - StartTime: 189769
   Lane: 2
-  HitSound: Normal
 - StartTime: 189769
   Lane: 3
   EndTime: 190169
-  HitSound: Normal
 - StartTime: 190035
   Lane: 2
-  HitSound: Normal
 - StartTime: 190169
   Lane: 1
-  HitSound: Normal
 - StartTime: 190169
   Lane: 2
-  HitSound: Normal
 - StartTime: 190435
   Lane: 3
-  HitSound: Normal
 - StartTime: 190569
   Lane: 3
   EndTime: 190835
-  HitSound: Normal
 - StartTime: 190569
   Lane: 4
-  HitSound: Normal
 - StartTime: 190569
   Lane: 1
-  HitSound: Normal
 - StartTime: 190835
   Lane: 1
-  HitSound: Normal
 - StartTime: 191235
   Lane: 3
-  HitSound: Normal
 - StartTime: 191369
   Lane: 1
-  HitSound: Normal
 - StartTime: 191369
   Lane: 2
   EndTime: 191769
-  HitSound: Normal
 - StartTime: 191369
   Lane: 4
-  HitSound: Normal
 - StartTime: 191635
   Lane: 4
-  HitSound: Normal
 - StartTime: 191769
   Lane: 1
-  HitSound: Normal
 - StartTime: 191769
   Lane: 4
-  HitSound: Normal
 - StartTime: 191769
   Lane: 3
-  HitSound: Normal
 - StartTime: 192035
   Lane: 3
-  HitSound: Normal
 - StartTime: 192169
   Lane: 4
-  HitSound: Normal
 - StartTime: 192169
   Lane: 2
   EndTime: 192435
-  HitSound: Normal
 - StartTime: 192169
   Lane: 1
-  HitSound: Normal
 - StartTime: 192435
   Lane: 4
-  HitSound: Normal
 - StartTime: 192835
   Lane: 4
-  HitSound: Normal
 - StartTime: 192969
   Lane: 2
-  HitSound: Normal
 - StartTime: 192969
   Lane: 1
-  HitSound: Normal
 - StartTime: 192969
   Lane: 4
   EndTime: 193369
-  HitSound: Normal
 - StartTime: 193235
   Lane: 1
-  HitSound: Normal
 - StartTime: 193369
   Lane: 2
-  HitSound: Normal
 - StartTime: 193369
   Lane: 3
-  HitSound: Normal
 - StartTime: 193369
   Lane: 1
-  HitSound: Normal
 - StartTime: 193635
   Lane: 4
-  HitSound: Normal
 - StartTime: 193769
   Lane: 1
-  HitSound: Normal
 - StartTime: 193769
   Lane: 2
-  HitSound: Normal
 - StartTime: 193769
   Lane: 4
   EndTime: 194035
-  HitSound: Normal
 - StartTime: 194035
   Lane: 1
-  HitSound: Normal
 - StartTime: 194435
   Lane: 1
-  HitSound: Normal
 - StartTime: 194569
   Lane: 2
   EndTime: 194835
-  HitSound: Normal
 - StartTime: 194569
   Lane: 1
-  HitSound: Normal
 - StartTime: 194569
   Lane: 4
-  HitSound: Normal
 - StartTime: 194835
   Lane: 4
-  HitSound: Normal
 - StartTime: 194969
   Lane: 4
-  HitSound: Normal
 - StartTime: 194969
   Lane: 3
-  HitSound: Normal
 - StartTime: 194969
   Lane: 2
-  HitSound: Normal
 - StartTime: 194969
   Lane: 1
-  HitSound: Normal
 - StartTime: 195235
   Lane: 2
-  HitSound: Normal
 - StartTime: 195369
   Lane: 4
   EndTime: 195669
-  HitSound: Normal
 - StartTime: 195369
   Lane: 3
   EndTime: 195669
-  HitSound: Normal
 - StartTime: 195369
   Lane: 1
   EndTime: 195669
-  HitSound: Normal
 - StartTime: 195769
   Lane: 2
   EndTime: 196069
-  HitSound: Normal
 - StartTime: 195769
   Lane: 3
   EndTime: 196069
-  HitSound: Normal
 - StartTime: 195769
   Lane: 4
   EndTime: 196069
-  HitSound: Normal
 - StartTime: 196169
   Lane: 1
-  HitSound: Normal
 - StartTime: 196169
   Lane: 4
-  HitSound: Normal
 - StartTime: 196169
   Lane: 2
-  HitSound: Normal
 - StartTime: 196169
   Lane: 3
   EndTime: 196569
-  HitSound: Normal
 - StartTime: 196569
   Lane: 2
-  HitSound: Normal
 - StartTime: 196569
   Lane: 1
-  HitSound: Normal
 - StartTime: 196835
   Lane: 3
-  HitSound: Normal
 - StartTime: 196969
   Lane: 3
   EndTime: 197235
-  HitSound: Normal
 - StartTime: 196969
   Lane: 4
-  HitSound: Normal
 - StartTime: 196969
   Lane: 1
-  HitSound: Normal
 - StartTime: 197235
   Lane: 1
-  HitSound: Normal
 - StartTime: 197635
   Lane: 1
-  HitSound: Normal
 - StartTime: 197769
   Lane: 3
-  HitSound: Normal
 - StartTime: 197769
   Lane: 1
-  HitSound: Normal
 - StartTime: 197769
   Lane: 2
   EndTime: 198169
-  HitSound: Normal
 - StartTime: 197769
   Lane: 4
-  HitSound: Normal
 - StartTime: 197969
   Lane: 4
-  HitSound: Normal
 - StartTime: 198169
   Lane: 1
-  HitSound: Normal
 - StartTime: 198169
   Lane: 4
-  HitSound: Normal
 - StartTime: 198169
   Lane: 3
-  HitSound: Normal
 - StartTime: 198435
   Lane: 4
-  HitSound: Normal
 - StartTime: 198569
   Lane: 4
-  HitSound: Normal
 - StartTime: 198569
   Lane: 2
   EndTime: 198835
-  HitSound: Normal
 - StartTime: 198569
   Lane: 1
-  HitSound: Normal
 - StartTime: 198835
   Lane: 3
-  HitSound: Normal
 - StartTime: 199235
   Lane: 4
-  HitSound: Normal
 - StartTime: 199369
   Lane: 2
-  HitSound: Normal
 - StartTime: 199369
   Lane: 1
-  HitSound: Normal
 - StartTime: 199369
   Lane: 4
   EndTime: 199769
-  HitSound: Normal
 - StartTime: 199635
   Lane: 2
-  HitSound: Normal
 - StartTime: 199769
   Lane: 2
-  HitSound: Normal
 - StartTime: 199769
   Lane: 3
-  HitSound: Normal
 - StartTime: 199769
   Lane: 1
-  HitSound: Normal
 - StartTime: 200035
   Lane: 4
-  HitSound: Normal
 - StartTime: 200169
   Lane: 1
-  HitSound: Normal
 - StartTime: 200169
   Lane: 2
-  HitSound: Normal
 - StartTime: 200169
   Lane: 4
   EndTime: 200435
-  HitSound: Normal
 - StartTime: 200435
   Lane: 1
-  HitSound: Normal
 - StartTime: 200835
   Lane: 1
-  HitSound: Normal
 - StartTime: 200969
   Lane: 2
   EndTime: 201235
-  HitSound: Normal
 - StartTime: 200969
   Lane: 1
-  HitSound: Normal
 - StartTime: 200969
   Lane: 4
-  HitSound: Normal
 - StartTime: 201235
   Lane: 4
-  HitSound: Normal
 - StartTime: 201369
   Lane: 4
-  HitSound: Normal
 - StartTime: 201369
   Lane: 1
-  HitSound: Normal
 - StartTime: 201402
   Lane: 3
-  HitSound: Normal
 - StartTime: 201435
   Lane: 2
-  HitSound: Normal
 - StartTime: 201502
   Lane: 4
-  HitSound: Normal
 - StartTime: 201519
   Lane: 1
-  HitSound: Normal
 - StartTime: 201569
   Lane: 3
-  HitSound: Normal
 - StartTime: 201619
   Lane: 2
-  HitSound: Normal
 - StartTime: 201669
   Lane: 4
-  HitSound: Normal
 - StartTime: 201719
   Lane: 3
-  HitSound: Normal
 - StartTime: 201769
   Lane: 2
-  HitSound: Normal
 - StartTime: 201769
   Lane: 1
-  HitSound: Normal
 - StartTime: 201869
   Lane: 4
-  HitSound: Normal
 - StartTime: 201969
   Lane: 3
-  HitSound: Normal
 - StartTime: 202035
   Lane: 1
-  HitSound: Normal
 - StartTime: 202035
   Lane: 2
-  HitSound: Normal
 - StartTime: 202119
   Lane: 4
-  HitSound: Normal
 - StartTime: 202194
   Lane: 3
-  HitSound: Normal
 - StartTime: 202269
   Lane: 2
-  HitSound: Normal
 - StartTime: 202269
   Lane: 1
-  HitSound: Normal
 - StartTime: 202344
   Lane: 4
-  HitSound: Normal
 - StartTime: 202419
   Lane: 2
-  HitSound: Normal
 - StartTime: 202419
   Lane: 1
-  HitSound: Normal
 - StartTime: 202494
   Lane: 3
-  HitSound: Normal
 - StartTime: 202569
   Lane: 4
-  HitSound: Normal
 - StartTime: 202569
   Lane: 1
-  HitSound: Normal
 - StartTime: 202569
   Lane: 2
-  HitSound: Normal
 - StartTime: 202835
   Lane: 3
-  HitSound: Normal
 - StartTime: 202969
   Lane: 4
-  HitSound: Normal
 - StartTime: 202969
   Lane: 2
-  HitSound: Normal
 - StartTime: 202969
   Lane: 1
-  HitSound: Normal
 - StartTime: 202969
   Lane: 3
-  HitSound: Normal
 - StartTime: 203235
   Lane: 3
-  HitSound: Normal
 - StartTime: 203369
   Lane: 3
   EndTime: 203635
-  HitSound: Normal
 - StartTime: 203369
   Lane: 4
-  HitSound: Normal
 - StartTime: 203369
   Lane: 1
-  HitSound: Normal
 - StartTime: 203635
   Lane: 1
-  HitSound: Normal
 - StartTime: 204035
   Lane: 1
-  HitSound: Normal
 - StartTime: 204169
   Lane: 1
-  HitSound: Normal
 - StartTime: 204169
   Lane: 2
   EndTime: 204569
-  HitSound: Normal
 - StartTime: 204169
   Lane: 4
-  HitSound: Normal
 - StartTime: 204435
   Lane: 4
-  HitSound: Normal
 - StartTime: 204569
   Lane: 1
-  HitSound: Normal
 - StartTime: 204569
   Lane: 4
-  HitSound: Normal
 - StartTime: 204569
   Lane: 3
-  HitSound: Normal
 - StartTime: 204835
   Lane: 4
-  HitSound: Normal
 - StartTime: 204969
   Lane: 4
-  HitSound: Normal
 - StartTime: 204969
   Lane: 2
   EndTime: 205235
-  HitSound: Normal
 - StartTime: 204969
   Lane: 1
-  HitSound: Normal
 - StartTime: 205235
   Lane: 3
-  HitSound: Normal
 - StartTime: 205635
   Lane: 4
-  HitSound: Normal
 - StartTime: 205769
   Lane: 2
-  HitSound: Normal
 - StartTime: 205769
   Lane: 1
-  HitSound: Normal
 - StartTime: 205769
   Lane: 4
   EndTime: 206169
-  HitSound: Normal
 - StartTime: 206035
   Lane: 1
-  HitSound: Normal
 - StartTime: 206169
   Lane: 2
-  HitSound: Normal
 - StartTime: 206169
   Lane: 3
-  HitSound: Normal
 - StartTime: 206169
   Lane: 1
-  HitSound: Normal
 - StartTime: 206435
   Lane: 4
-  HitSound: Normal
 - StartTime: 206569
   Lane: 1
-  HitSound: Normal
 - StartTime: 206569
   Lane: 2
-  HitSound: Normal
 - StartTime: 206569
   Lane: 4
   EndTime: 206835
-  HitSound: Normal
 - StartTime: 206835
   Lane: 1
-  HitSound: Normal
 - StartTime: 207235
   Lane: 4
-  HitSound: Normal
 - StartTime: 207369
   Lane: 2
   EndTime: 207635
-  HitSound: Normal
 - StartTime: 207369
   Lane: 1
-  HitSound: Normal
 - StartTime: 207369
   Lane: 4
-  HitSound: Normal
 - StartTime: 207635
   Lane: 3
-  HitSound: Normal
 - StartTime: 207769
   Lane: 4
-  HitSound: Normal
 - StartTime: 207769
   Lane: 1
-  HitSound: Normal
 - StartTime: 207769
   Lane: 3
-  HitSound: Normal
 - StartTime: 207769
   Lane: 2
-  HitSound: Normal
 - StartTime: 208035
   Lane: 3
-  HitSound: Normal
 - StartTime: 208169
   Lane: 4
-  HitSound: Normal
 - StartTime: 208169
   Lane: 2
-  HitSound: Normal
 - StartTime: 208169
   Lane: 1
-  HitSound: Normal
 - StartTime: 208435
   Lane: 1
-  HitSound: Normal
 - StartTime: 208435
   Lane: 2
-  HitSound: Normal
 - StartTime: 208569
   Lane: 3
-  HitSound: Normal
 - StartTime: 208569
   Lane: 2
-  HitSound: Normal
 - StartTime: 208569
   Lane: 1
-  HitSound: Normal
 - StartTime: 208702
   Lane: 1
-  HitSound: Normal
 - StartTime: 208702
   Lane: 4
-  HitSound: Normal
 - StartTime: 208702
   Lane: 3
-  HitSound: Normal
 - StartTime: 208969
   Lane: 4
-  HitSound: Normal
 - StartTime: 208969
   Lane: 2
-  HitSound: Normal
 - StartTime: 208969
   Lane: 1
-  HitSound: Normal
 - StartTime: 209235
   Lane: 4
-  HitSound: Normal
 - StartTime: 209235
   Lane: 3
-  HitSound: Normal
 - StartTime: 209235
   Lane: 1
-  HitSound: Normal
 - StartTime: 209502
   Lane: 3
-  HitSound: Normal
 - StartTime: 209502
   Lane: 2
-  HitSound: Normal
 - StartTime: 209502
   Lane: 1
-  HitSound: Normal
 - StartTime: 209769
   Lane: 4
-  HitSound: Normal
 - StartTime: 209769
   Lane: 2
-  HitSound: Normal
 - StartTime: 209769
   Lane: 1
-  HitSound: Normal
 - StartTime: 210035
   Lane: 4
-  HitSound: Normal
 - StartTime: 210035
   Lane: 3
-  HitSound: Normal
 - StartTime: 210035
   Lane: 2
-  HitSound: Normal
 - StartTime: 210302
   Lane: 4
-  HitSound: Normal
 - StartTime: 210302
   Lane: 3
-  HitSound: Normal
 - StartTime: 210302
   Lane: 1
-  HitSound: Normal
 - StartTime: 210569
   Lane: 1
-  HitSound: Normal
 - StartTime: 210569
   Lane: 3
-  HitSound: Normal
 - StartTime: 210569
   Lane: 2
-  HitSound: Normal
 - StartTime: 210835
   Lane: 4
-  HitSound: Normal
 - StartTime: 210835
   Lane: 3
-  HitSound: Normal
 - StartTime: 210835
   Lane: 1
-  HitSound: Normal
 - StartTime: 211102
   Lane: 3
-  HitSound: Normal
 - StartTime: 211102
   Lane: 2
-  HitSound: Normal
 - StartTime: 211102
   Lane: 4
-  HitSound: Normal
 - StartTime: 211369
   Lane: 4
-  HitSound: Normal
 - StartTime: 211369
   Lane: 2
-  HitSound: Normal
 - StartTime: 211369
   Lane: 1
-  HitSound: Normal
 - StartTime: 211635
   Lane: 3
-  HitSound: Normal
 - StartTime: 211635
   Lane: 2
-  HitSound: Normal
 - StartTime: 211635
   Lane: 1
-  HitSound: Normal
 - StartTime: 211902
   Lane: 4
-  HitSound: Normal
 - StartTime: 211902
   Lane: 3
-  HitSound: Normal
 - StartTime: 211902
   Lane: 2
-  HitSound: Normal
 - StartTime: 211902
   Lane: 1
-  HitSound: Normal
 - StartTime: 212169
   Lane: 4
-  HitSound: Normal
 - StartTime: 212169
   Lane: 3
-  HitSound: Normal
 - StartTime: 212169
   Lane: 2
-  HitSound: Normal
 - StartTime: 212169
   Lane: 1
-  HitSound: Normal
 - StartTime: 212435
   Lane: 1
-  HitSound: Normal
 - StartTime: 212435
   Lane: 3
-  HitSound: Normal
 - StartTime: 212435
   Lane: 2
-  HitSound: Normal
 - StartTime: 212435
   Lane: 4
-  HitSound: Normal
 - StartTime: 212702
   Lane: 4
-  HitSound: Normal
 - StartTime: 212702
   Lane: 3
-  HitSound: Normal
 - StartTime: 212702
   Lane: 2
-  HitSound: Normal
 - StartTime: 212702
   Lane: 1
-  HitSound: Normal
 - StartTime: 212969
   Lane: 4
-  HitSound: Normal
 - StartTime: 212969
   Lane: 3
-  HitSound: Normal
 - StartTime: 212969
   Lane: 2
-  HitSound: Normal
 - StartTime: 212969
   Lane: 1
-  HitSound: Normal
 - StartTime: 213235
   Lane: 4
-  HitSound: Normal
 - StartTime: 213235
   Lane: 3
-  HitSound: Normal
 - StartTime: 213235
   Lane: 2
-  HitSound: Normal
 - StartTime: 213235
   Lane: 1
-  HitSound: Normal
 - StartTime: 213369
   Lane: 1
-  HitSound: Normal
 - StartTime: 213369
   Lane: 4
-  HitSound: Normal
 - StartTime: 213369
   Lane: 3
-  HitSound: Normal
 - StartTime: 213369
   Lane: 2
   EndTime: 213635
-  HitSound: Normal
 - StartTime: 213635
   Lane: 3
-  HitSound: Normal
 - StartTime: 213769
   Lane: 4
-  HitSound: Normal
 - StartTime: 213769
   Lane: 1
-  HitSound: Normal
 - StartTime: 214035
   Lane: 2
   EndTime: 214302
-  HitSound: Normal
 - StartTime: 214169
   Lane: 4
-  HitSound: Normal
 - StartTime: 214302
   Lane: 3
-  HitSound: Normal
 - StartTime: 214435
   Lane: 2
-  HitSound: Normal
 - StartTime: 214435
   Lane: 1
-  HitSound: Normal
 - StartTime: 214702
   Lane: 3
   EndTime: 214969
-  HitSound: Normal
 - StartTime: 214969
   Lane: 4
-  HitSound: Normal
 - StartTime: 214969
   Lane: 2
-  HitSound: Normal
 - StartTime: 214969
   Lane: 1
   EndTime: 222959
-  HitSound: Normal

--- a/Quaver.API/Enums/TimeSignature.cs
+++ b/Quaver.API/Enums/TimeSignature.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Quaver.API.Enums
+{
+    /// <summary>
+    ///     Signature of a timing point
+    /// </summary>
+    [Serializable]
+    public enum TimeSignature
+    {
+        Quadruple = 4,
+        Triple = 3,
+    }
+}

--- a/Quaver.API/Maps/Parsers/OsuBeatmap.cs
+++ b/Quaver.API/Maps/Parsers/OsuBeatmap.cs
@@ -441,12 +441,20 @@ namespace Quaver.API.Maps.Parsers
             // Get Timing Info
             foreach (var tp in TimingPoints)
                 if (tp.Inherited == 1)
-                    qua.TimingPoints.Add(new TimingPointInfo { StartTime = tp.Offset, Bpm = 60000 / tp.MillisecondsPerBeat });
+                    qua.TimingPoints.Add(new TimingPointInfo
+                    {
+                        StartTime = tp.Offset,
+                        Bpm = 60000 / tp.MillisecondsPerBeat
+                    });
 
             // Get SliderVelocity Info
             foreach (var tp in TimingPoints)
                 if (tp.Inherited == 0)
-                    qua.SliderVelocities.Add(new SliderVelocityInfo { StartTime = tp.Offset, Multiplier = (-100 / tp.MillisecondsPerBeat).Clamp(0.1f, 10) });
+                    qua.SliderVelocities.Add(new SliderVelocityInfo
+                    {
+                        StartTime = tp.Offset,
+                        Multiplier = (-100 / tp.MillisecondsPerBeat).Clamp(0.1f, 10)
+                    });
 
             // Get HitObject Info
             foreach (var hitObject in HitObjects)

--- a/Quaver.API/Maps/Parsers/OsuBeatmap.cs
+++ b/Quaver.API/Maps/Parsers/OsuBeatmap.cs
@@ -329,10 +329,15 @@ namespace Quaver.API.Maps.Parsers
                             {
                                 var values = line.Split(',');
 
+                                // Parse as double because there are some maps which have this value too large to fit in
+                                // a float, for example https://osu.ppy.sh/beatmapsets/681731#mania/1441497. Parsing as
+                                // double and then casting to float results in the correct outcome though.
+                                var msecPerBeat = double.Parse(values[1], CultureInfo.InvariantCulture);
+
                                 var timingPoint = new OsuTimingPoint
                                 {
                                     Offset = float.Parse(values[0], CultureInfo.InvariantCulture),
-                                    MillisecondsPerBeat = float.Parse(values[1], CultureInfo.InvariantCulture),
+                                    MillisecondsPerBeat = (float) msecPerBeat,
                                     Signature = values[2][0] == '0' ? TimeSignature.Quadruple : (TimeSignature) int.Parse(values[2], CultureInfo.InvariantCulture),
                                     SampleType = int.Parse(values[3], CultureInfo.InvariantCulture),
                                     SampleSet = int.Parse(values[4], CultureInfo.InvariantCulture),

--- a/Quaver.API/Maps/Parsers/OsuBeatmap.cs
+++ b/Quaver.API/Maps/Parsers/OsuBeatmap.cs
@@ -446,7 +446,7 @@ namespace Quaver.API.Maps.Parsers
             // Get SliderVelocity Info
             foreach (var tp in TimingPoints)
                 if (tp.Inherited == 0)
-                    qua.SliderVelocities.Add(new SliderVelocityInfo { StartTime = tp.Offset, Multiplier = (float)Math.Round(0.10 / ((tp.MillisecondsPerBeat / -100) / 10), 2) });
+                    qua.SliderVelocities.Add(new SliderVelocityInfo { StartTime = tp.Offset, Multiplier = (-100 / tp.MillisecondsPerBeat).Clamp(0.1f, 10) });
 
             // Get HitObject Info
             foreach (var hitObject in HitObjects)

--- a/Quaver.API/Maps/Parsers/OsuBeatmap.cs
+++ b/Quaver.API/Maps/Parsers/OsuBeatmap.cs
@@ -333,7 +333,7 @@ namespace Quaver.API.Maps.Parsers
                                 {
                                     Offset = float.Parse(values[0], CultureInfo.InvariantCulture),
                                     MillisecondsPerBeat = float.Parse(values[1], CultureInfo.InvariantCulture),
-                                    Meter = int.Parse(values[2], CultureInfo.InvariantCulture),
+                                    Signature = values[2][0] == '0' ? TimeSignature.Quadruple : (TimeSignature) int.Parse(values[2], CultureInfo.InvariantCulture),
                                     SampleType = int.Parse(values[3], CultureInfo.InvariantCulture),
                                     SampleSet = int.Parse(values[4], CultureInfo.InvariantCulture),
                                     Volume = int.Parse(values[5], CultureInfo.InvariantCulture),
@@ -444,7 +444,8 @@ namespace Quaver.API.Maps.Parsers
                     qua.TimingPoints.Add(new TimingPointInfo
                     {
                         StartTime = tp.Offset,
-                        Bpm = 60000 / tp.MillisecondsPerBeat
+                        Bpm = 60000 / tp.MillisecondsPerBeat,
+                        Signature = tp.Signature
                     });
 
             // Get SliderVelocity Info
@@ -516,7 +517,7 @@ namespace Quaver.API.Maps.Parsers
     {
         public float Offset { get; set; }
         public float MillisecondsPerBeat { get; set; }
-        public int Meter { get; set; }
+        public TimeSignature Signature { get; set; }
         public int SampleType { get; set; }
         public int SampleSet { get; set; }
         public int Volume { get; set; }

--- a/Quaver.API/Maps/Qua.cs
+++ b/Quaver.API/Maps/Qua.cs
@@ -258,6 +258,11 @@ namespace Quaver.API.Maps
             for (var i = TimingPoints.Count - 1; i >= 0; i--)
             {
                 var point = TimingPoints[i];
+
+                // Make sure that timing points past the last object don't break anything.
+                if (point.StartTime > lastTime)
+                    continue;
+
                 var duration = (int) (lastTime - (i == 0 ? 0 : point.StartTime));
                 lastTime = point.StartTime;
 

--- a/Quaver.API/Maps/Qua.cs
+++ b/Quaver.API/Maps/Qua.cs
@@ -243,7 +243,7 @@ namespace Quaver.API.Maps
         }
 
         /// <summary>
-        /// Finds the most common BPM in a Qua object.
+        ///     Finds the most common BPM in a Qua object.
         /// </summary>
         /// <returns></returns>
         public double GetCommonBpm()

--- a/Quaver.API/Maps/Qua.cs
+++ b/Quaver.API/Maps/Qua.cs
@@ -246,7 +246,7 @@ namespace Quaver.API.Maps
         ///     Finds the most common BPM in a Qua object.
         /// </summary>
         /// <returns></returns>
-        public double GetCommonBpm()
+        public float GetCommonBpm()
         {
             if (TimingPoints.Count == 0)
                 return 0;

--- a/Quaver.API/Maps/Structures/TimingPointInfo.cs
+++ b/Quaver.API/Maps/Structures/TimingPointInfo.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using Quaver.API.Enums;
 using YamlDotNet.Serialization;
 
 namespace Quaver.API.Maps.Structures
@@ -26,6 +27,11 @@ namespace Quaver.API.Maps.Structures
         ///     The BPM during this timing point
         /// </summary>
         public float Bpm { get; set; }
+
+        /// <summary>
+        ///     The signature during this timing point
+        /// </summary>
+        public TimeSignature Signature { get; set; }
 
         /// <summary>
         ///     The amount of milliseconds per beat this one takes up.


### PR DESCRIPTION
https://github.com/Quaver/Quaver/issues/534

Alright so I'm not fixing the test until we figure this out: since I added the time signature to the timing points, it's now emitted into YAML and is required to be present there, since it's either 4 or 3 and not 0. It's definitely desirable to omit the default value of 4 (and also the default value of 1 for hitsounds)—to reduce the number of useless lines and to preserve compatibility with old .qua files. What's the best way to do this? Convert the default of 4 to 0 before serialization and convert 0 to 4 right after parsing?