### PR TITLE
ScoreProcessor: add missing InitializeMods()

### DIFF
--- a/Quaver.API/Maps/Processors/Scoring/ScoreProcessor.cs
+++ b/Quaver.API/Maps/Processors/Scoring/ScoreProcessor.cs
@@ -159,6 +159,8 @@ namespace Quaver.API.Maps.Processors.Scoring
             CurrentJudgements[Judgement.Good] = replay.CountGood;
             CurrentJudgements[Judgement.Okay] = replay.CountOkay;
             CurrentJudgements[Judgement.Miss] = replay.CountMiss;
+
+            InitializeMods();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes the hit difference graph (it's relying on `JudgementWindow` values and they were incorrect for replays with rates).