### PR TITLE
Qua SV de-/normalization, "BPM does not affect SV" and SV factor computation

### DIFF
--- a/Quaver.API.Tests/Quaver.API.Tests.csproj
+++ b/Quaver.API.Tests/Quaver.API.Tests.csproj
@@ -86,5 +86,89 @@
     <None Update="Quaver\Resources\keysounds-invalid-sample-index.qua">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Quaver\Resources\regression-1.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\regression-1-normalized.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\regression-2.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\regression-2-normalized.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\regression-3.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\regression-3-normalized.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\regression-4.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\regression-4-normalized.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\regression-5.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\regression-5-normalized.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\regression-6.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\regression-6-normalized.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\regression-7.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\regression-7-normalized.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\regression-8.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\regression-8-normalized.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\sample.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\sample-normalized.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\sv-at-first-timing-point.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\sv-at-first-timing-point-normalized.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\sv-before-first-timing-point.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\sv-before-first-timing-point-normalized.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\symphony.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\symphony-normalized.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\timing-points-override-svs.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\timing-points-override-svs-normalized.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\cheat.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\cheat-normalized.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Quaver.API.Tests/Quaver/Resources/cheat-normalized.qua
+++ b/Quaver.API.Tests/Quaver/Resources/cheat-normalized.qua
@@ -1,0 +1,7087 @@
+---
+Mode: Keys4
+Title: Shiawase ni Nareru Kakushi Command ga Arurashii
+Artist: Utata-P feat. Yuzuki Yukari
+Creator: Kamikaze
+DifficultyName: Cheat Code
+AudioFile: audiooooo.mp3
+BPMDoesNotAffectScrollVelocity: true
+InitialScrollVelocity: 1.0
+TimingPoints:
+  - StartTime: 680.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 7440.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 7441.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 7863.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 7864.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 8285.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 8286.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 8708.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 8709.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 9130.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 9131.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 9553.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 9554.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 9975.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 9976.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 10398.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 10399.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 10820.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 10821.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 11243.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 11244.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 11665.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 11666.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 12088.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 12089.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 12510.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 12511.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 12933.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 12934.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 13356.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 13357.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 13778.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 13779.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 14201.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 14202.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 14623.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 14624.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 15046.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 15047.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 15468.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 15469.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 15891.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 15892.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 16313.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 16314.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 16736.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 16737.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 17158.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 17159.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 17581.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 17582.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 18003.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 18004.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 18426.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 18427.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 18849.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 18850.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 19271.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 19272.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 19694.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 19695.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 20116.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 20117.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 20539.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 20540.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 20961.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 20962.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 21384.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 21385.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 21806.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 21807.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 22229.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 22230.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 22651.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 22652.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 23074.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 23075.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 23496.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 23497.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 23919.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 23920.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 24341.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 24342.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 24764.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 24765.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 25187.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 25188.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 25609.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 25610.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 26032.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 27722.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 29412.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 29413.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 29834.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 29835.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 30257.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 30258.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 30679.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 30680.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 31102.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 31103.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 31524.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 31525.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 31947.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 31948.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 32370.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 32371.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 32792.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 32793.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 33215.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 33216.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 33637.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 33638.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 34060.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 34061.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 34482.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 34483.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 34905.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 34906.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 35327.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 35328.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 35750.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 35751.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 36172.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 36173.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 36595.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 36596.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 37017.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 37018.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 37440.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 37441.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 37862.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 37863.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 38285.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 38286.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 38708.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 38709.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 39130.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 39131.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 39553.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 39554.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 39975.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 39976.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 40398.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 40399.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 40820.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 40821.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 41243.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 42933.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 42934.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 43355.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 43356.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 43778.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 43779.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 44201.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 44202.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 44623.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 44624.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 45046.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 45047.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 45468.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 45469.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 45891.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 45892.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 46313.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 46314.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 46736.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 46737.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 47158.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 47159.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 47581.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 47582.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 48003.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 48004.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 48426.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 48427.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 48848.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 48849.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 49271.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 49272.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 49693.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 49694.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 50116.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 50117.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 50539.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 50540.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 50961.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 50962.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 51384.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 51385.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 51806.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 51807.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 52229.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 52230.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 52651.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 52652.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 53074.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 53075.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 53496.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 53497.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 53919.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 53920.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 54341.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 54342.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 54764.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 56454.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 69130.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 69975.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 81806.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 83496.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 83497.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 83918.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 83919.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 84341.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 84342.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 84763.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 84764.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 85186.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 85187.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 85608.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 85609.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 86031.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 86032.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 86454.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 86455.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 86876.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 86877.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 87299.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 87300.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 87721.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 87722.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 88144.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 88145.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 88566.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 88567.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 88989.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 88990.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 89411.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 89412.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 89834.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 89835.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 90256.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 90257.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 90679.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 90680.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 91101.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 91102.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 91524.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 91525.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 91946.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 91947.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 92369.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 92370.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 92792.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 92793.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 93214.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 93215.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 93637.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 93638.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 94059.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 94060.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 94482.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 94483.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 94904.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 94905.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 95327.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 97017.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 97018.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 97439.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 97440.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 97862.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 97863.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 98284.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 98285.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 98707.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 98708.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 99130.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 99131.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 99552.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 99553.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 99975.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 99976.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 100397.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 100398.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 100820.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 100821.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 101242.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 101243.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 101665.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 101666.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 102087.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 102088.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 102510.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 102511.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 102932.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 102933.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 103355.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 103356.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 103777.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 103778.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 104200.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 104201.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 104623.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 104624.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 105045.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 105046.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 105468.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 105469.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 105890.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 105891.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 106313.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 106314.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 106735.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 106736.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 107158.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 107159.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 107580.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 107581.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 108003.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 108004.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 108425.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 108426.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 108848.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 110538.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 112228.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 124904.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 125749.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 141805.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 141858.0
+    Bpm: 106.49999237060547
+    Signature: 4
+  - StartTime: 141910.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 141963.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 142016.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 142227.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 142438.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 142544.0
+    Bpm: 106.49999237060547
+    Signature: 4
+  - StartTime: 142650.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 145185.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 145238.0
+    Bpm: 106.49999237060547
+    Signature: 4
+  - StartTime: 145290.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 145343.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 145396.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 145607.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 145818.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 145924.0
+    Bpm: 106.49999237060547
+    Signature: 4
+  - StartTime: 146030.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 151101.0
+    Bpm: 106.49999237060547
+    Signature: 4
+  - StartTime: 151171.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 151241.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 151312.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 151945.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 153635.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 153899.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 153952.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 154058.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 154322.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 154375.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 154481.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 154745.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 154798.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 154904.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 155168.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 155221.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 155327.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 155591.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 155644.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 155750.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 156014.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 156067.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 156173.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 156437.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 156490.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 156596.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 156860.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 156913.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 157019.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 157283.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 157336.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 157442.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 157706.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 157759.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 157865.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 158129.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 158182.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 158288.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 158552.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 158605.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 158711.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 158975.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 159028.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 159134.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 159398.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 159451.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 159557.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 159821.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 159874.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 159980.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 160244.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 160297.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 160403.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 160667.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 160720.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 160826.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 161090.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 161143.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 161249.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 161513.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 161566.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 161672.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 161936.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 161989.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 162095.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 162359.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 162412.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 162518.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 162782.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 162835.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 162941.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 163205.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 163258.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 163364.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 163628.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 163681.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 163787.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 164051.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 164104.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 164210.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 164474.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 164527.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 164633.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 164897.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 164950.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 165055.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 165319.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 165372.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 165490.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 167157.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 168847.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 168848.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 169058.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 169059.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 169269.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 169270.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 169481.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 169482.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 169692.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 169693.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 169903.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 169904.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 170114.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 170115.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 170326.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 170327.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 170537.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 172227.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 172228.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 172438.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 172439.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 172649.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 172650.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 172860.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 172861.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 173072.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 173073.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 173283.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 173284.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 173494.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 173495.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 173706.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 173707.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 173917.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 175607.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 175608.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 176030.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 176031.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 176452.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 176453.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 176664.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 176665.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 176875.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 176876.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 177086.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 177087.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 177297.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 177298.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 177720.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 177721.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 178143.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 178144.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 178565.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 178566.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 178988.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 180678.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 193354.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 194199.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 207720.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 207721.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 208143.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 208144.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 208565.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 208566.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 208988.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 208989.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 209410.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 209411.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 209833.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 209834.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 210255.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 210256.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 210678.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 210679.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 211100.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 211101.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 211523.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 211524.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 211945.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 211946.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 212368.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 212369.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 212790.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 212791.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 213213.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 213214.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 213636.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 213637.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 214058.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 214059.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 214481.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 214482.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 214903.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 214904.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 215326.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 215327.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 215748.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 215749.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 216171.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 216172.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 216593.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 216594.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 217016.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 217017.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 217438.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 217439.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 217861.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 217862.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 218283.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 218284.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 218706.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 218707.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 219128.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 219129.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 219551.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 219552.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 219974.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 219975.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 220396.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 220397.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 220819.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 220820.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 221241.0
+    Bpm: 568.0
+    Signature: 4
+SliderVelocities:
+  - StartTime: 7440.0
+    Multiplier: .inf
+  - StartTime: 7441.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 7863.0
+    Multiplier: .inf
+  - StartTime: 7864.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 8285.0
+    Multiplier: .inf
+  - StartTime: 8286.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 8708.0
+    Multiplier: .inf
+  - StartTime: 8709.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 9130.0
+    Multiplier: .inf
+  - StartTime: 9131.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 9553.0
+    Multiplier: .inf
+  - StartTime: 9554.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 9975.0
+    Multiplier: .inf
+  - StartTime: 9976.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 10398.0
+    Multiplier: .inf
+  - StartTime: 10399.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 10820.0
+    Multiplier: .inf
+  - StartTime: 10821.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 11243.0
+    Multiplier: .inf
+  - StartTime: 11244.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 11665.0
+    Multiplier: .inf
+  - StartTime: 11666.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 12088.0
+    Multiplier: .inf
+  - StartTime: 12089.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 12510.0
+    Multiplier: .inf
+  - StartTime: 12511.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 12933.0
+    Multiplier: .inf
+  - StartTime: 12934.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 13356.0
+    Multiplier: .inf
+  - StartTime: 13357.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 13778.0
+    Multiplier: .inf
+  - StartTime: 13779.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 14201.0
+    Multiplier: .inf
+  - StartTime: 14202.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 14623.0
+    Multiplier: .inf
+  - StartTime: 14624.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 15046.0
+    Multiplier: .inf
+  - StartTime: 15047.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 15468.0
+    Multiplier: .inf
+  - StartTime: 15469.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 15891.0
+    Multiplier: .inf
+  - StartTime: 15892.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 16313.0
+    Multiplier: .inf
+  - StartTime: 16314.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 16736.0
+    Multiplier: .inf
+  - StartTime: 16737.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 17158.0
+    Multiplier: .inf
+  - StartTime: 17159.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 17581.0
+    Multiplier: .inf
+  - StartTime: 17582.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 18003.0
+    Multiplier: .inf
+  - StartTime: 18004.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 18426.0
+    Multiplier: .inf
+  - StartTime: 18427.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 18849.0
+    Multiplier: .inf
+  - StartTime: 18850.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 19271.0
+    Multiplier: .inf
+  - StartTime: 19272.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 19694.0
+    Multiplier: .inf
+  - StartTime: 19695.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 20116.0
+    Multiplier: .inf
+  - StartTime: 20117.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 20539.0
+    Multiplier: .inf
+  - StartTime: 20540.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 20961.0
+    Multiplier: .inf
+  - StartTime: 20962.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 21384.0
+    Multiplier: .inf
+  - StartTime: 21385.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 21806.0
+    Multiplier: .inf
+  - StartTime: 21807.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 22229.0
+    Multiplier: .inf
+  - StartTime: 22230.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 22651.0
+    Multiplier: .inf
+  - StartTime: 22652.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 23074.0
+    Multiplier: .inf
+  - StartTime: 23075.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 23496.0
+    Multiplier: .inf
+  - StartTime: 23497.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 23919.0
+    Multiplier: .inf
+  - StartTime: 23920.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 24341.0
+    Multiplier: .inf
+  - StartTime: 24342.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 24764.0
+    Multiplier: .inf
+  - StartTime: 24765.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 25187.0
+    Multiplier: .inf
+  - StartTime: 25188.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 25609.0
+    Multiplier: .inf
+  - StartTime: 25610.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 26032.0
+    Multiplier: 0.25
+  - StartTime: 27722.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 29412.0
+    Multiplier: .inf
+  - StartTime: 29413.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 29834.0
+    Multiplier: .inf
+  - StartTime: 29835.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 30257.0
+    Multiplier: .inf
+  - StartTime: 30258.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 30679.0
+    Multiplier: .inf
+  - StartTime: 30680.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 31102.0
+    Multiplier: .inf
+  - StartTime: 31103.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 31524.0
+    Multiplier: .inf
+  - StartTime: 31525.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 31947.0
+    Multiplier: .inf
+  - StartTime: 31948.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 32370.0
+    Multiplier: .inf
+  - StartTime: 32371.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 32792.0
+    Multiplier: .inf
+  - StartTime: 32793.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 33215.0
+    Multiplier: .inf
+  - StartTime: 33216.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 33637.0
+    Multiplier: .inf
+  - StartTime: 33638.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 34060.0
+    Multiplier: .inf
+  - StartTime: 34061.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 34482.0
+    Multiplier: .inf
+  - StartTime: 34483.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 34905.0
+    Multiplier: .inf
+  - StartTime: 34906.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 35327.0
+    Multiplier: .inf
+  - StartTime: 35328.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 35750.0
+    Multiplier: .inf
+  - StartTime: 35751.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 36172.0
+    Multiplier: .inf
+  - StartTime: 36173.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 36595.0
+    Multiplier: .inf
+  - StartTime: 36596.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 37017.0
+    Multiplier: .inf
+  - StartTime: 37018.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 37440.0
+    Multiplier: .inf
+  - StartTime: 37441.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 37862.0
+    Multiplier: .inf
+  - StartTime: 37863.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 38285.0
+    Multiplier: .inf
+  - StartTime: 38286.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 38708.0
+    Multiplier: .inf
+  - StartTime: 38709.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 39130.0
+    Multiplier: .inf
+  - StartTime: 39131.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 39553.0
+    Multiplier: .inf
+  - StartTime: 39554.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 39975.0
+    Multiplier: .inf
+  - StartTime: 39976.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 40398.0
+    Multiplier: .inf
+  - StartTime: 40399.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 40820.0
+    Multiplier: .inf
+  - StartTime: 40821.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 41243.0
+    Multiplier: 0.25
+  - StartTime: 42933.0
+    Multiplier: .inf
+  - StartTime: 42934.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 43355.0
+    Multiplier: .inf
+  - StartTime: 43356.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 43778.0
+    Multiplier: .inf
+  - StartTime: 43779.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 44201.0
+    Multiplier: .inf
+  - StartTime: 44202.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 44623.0
+    Multiplier: .inf
+  - StartTime: 44624.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 45046.0
+    Multiplier: .inf
+  - StartTime: 45047.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 45468.0
+    Multiplier: .inf
+  - StartTime: 45469.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 45891.0
+    Multiplier: .inf
+  - StartTime: 45892.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 46313.0
+    Multiplier: .inf
+  - StartTime: 46314.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 46736.0
+    Multiplier: .inf
+  - StartTime: 46737.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 47158.0
+    Multiplier: .inf
+  - StartTime: 47159.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 47581.0
+    Multiplier: .inf
+  - StartTime: 47582.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 48003.0
+    Multiplier: .inf
+  - StartTime: 48004.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 48426.0
+    Multiplier: .inf
+  - StartTime: 48427.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 48848.0
+    Multiplier: .inf
+  - StartTime: 48849.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 49271.0
+    Multiplier: .inf
+  - StartTime: 49272.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 49693.0
+    Multiplier: .inf
+  - StartTime: 49694.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 50116.0
+    Multiplier: .inf
+  - StartTime: 50117.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 50539.0
+    Multiplier: .inf
+  - StartTime: 50540.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 50961.0
+    Multiplier: .inf
+  - StartTime: 50962.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 51384.0
+    Multiplier: .inf
+  - StartTime: 51385.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 51806.0
+    Multiplier: .inf
+  - StartTime: 51807.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 52229.0
+    Multiplier: .inf
+  - StartTime: 52230.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 52651.0
+    Multiplier: .inf
+  - StartTime: 52652.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 53074.0
+    Multiplier: .inf
+  - StartTime: 53075.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 53496.0
+    Multiplier: .inf
+  - StartTime: 53497.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 53919.0
+    Multiplier: .inf
+  - StartTime: 53920.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 54341.0
+    Multiplier: .inf
+  - StartTime: 54342.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 54764.0
+    Multiplier: 0.25
+  - StartTime: 56454.0
+    Multiplier: 1.0
+  - StartTime: 69130.0
+    Multiplier: 0.5
+  - StartTime: 69975.0
+    Multiplier: 1.0
+  - StartTime: 81806.0
+    Multiplier: 0.25
+  - StartTime: 83496.0
+    Multiplier: .inf
+  - StartTime: 83497.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 83918.0
+    Multiplier: .inf
+  - StartTime: 83919.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 84341.0
+    Multiplier: .inf
+  - StartTime: 84342.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 84763.0
+    Multiplier: .inf
+  - StartTime: 84764.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 85186.0
+    Multiplier: .inf
+  - StartTime: 85187.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 85608.0
+    Multiplier: .inf
+  - StartTime: 85609.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 86031.0
+    Multiplier: .inf
+  - StartTime: 86032.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 86454.0
+    Multiplier: .inf
+  - StartTime: 86455.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 86876.0
+    Multiplier: .inf
+  - StartTime: 86877.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 87299.0
+    Multiplier: .inf
+  - StartTime: 87300.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 87721.0
+    Multiplier: .inf
+  - StartTime: 87722.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 88144.0
+    Multiplier: .inf
+  - StartTime: 88145.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 88566.0
+    Multiplier: .inf
+  - StartTime: 88567.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 88989.0
+    Multiplier: .inf
+  - StartTime: 88990.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 89411.0
+    Multiplier: .inf
+  - StartTime: 89412.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 89834.0
+    Multiplier: .inf
+  - StartTime: 89835.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 90256.0
+    Multiplier: .inf
+  - StartTime: 90257.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 90679.0
+    Multiplier: .inf
+  - StartTime: 90680.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 91101.0
+    Multiplier: .inf
+  - StartTime: 91102.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 91524.0
+    Multiplier: .inf
+  - StartTime: 91525.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 91946.0
+    Multiplier: .inf
+  - StartTime: 91947.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 92369.0
+    Multiplier: .inf
+  - StartTime: 92370.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 92792.0
+    Multiplier: .inf
+  - StartTime: 92793.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 93214.0
+    Multiplier: .inf
+  - StartTime: 93215.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 93637.0
+    Multiplier: .inf
+  - StartTime: 93638.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 94059.0
+    Multiplier: .inf
+  - StartTime: 94060.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 94482.0
+    Multiplier: .inf
+  - StartTime: 94483.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 94904.0
+    Multiplier: .inf
+  - StartTime: 94905.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 95327.0
+    Multiplier: 0.25
+  - StartTime: 97017.0
+    Multiplier: .inf
+  - StartTime: 97018.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 97439.0
+    Multiplier: .inf
+  - StartTime: 97440.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 97862.0
+    Multiplier: .inf
+  - StartTime: 97863.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 98284.0
+    Multiplier: .inf
+  - StartTime: 98285.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 98707.0
+    Multiplier: .inf
+  - StartTime: 98708.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 99130.0
+    Multiplier: .inf
+  - StartTime: 99131.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 99552.0
+    Multiplier: .inf
+  - StartTime: 99553.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 99975.0
+    Multiplier: .inf
+  - StartTime: 99976.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 100397.0
+    Multiplier: .inf
+  - StartTime: 100398.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 100820.0
+    Multiplier: .inf
+  - StartTime: 100821.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 101242.0
+    Multiplier: .inf
+  - StartTime: 101243.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 101665.0
+    Multiplier: .inf
+  - StartTime: 101666.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 102087.0
+    Multiplier: .inf
+  - StartTime: 102088.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 102510.0
+    Multiplier: .inf
+  - StartTime: 102511.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 102932.0
+    Multiplier: .inf
+  - StartTime: 102933.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 103355.0
+    Multiplier: .inf
+  - StartTime: 103356.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 103777.0
+    Multiplier: .inf
+  - StartTime: 103778.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 104200.0
+    Multiplier: .inf
+  - StartTime: 104201.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 104623.0
+    Multiplier: .inf
+  - StartTime: 104624.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 105045.0
+    Multiplier: .inf
+  - StartTime: 105046.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 105468.0
+    Multiplier: .inf
+  - StartTime: 105469.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 105890.0
+    Multiplier: .inf
+  - StartTime: 105891.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 106313.0
+    Multiplier: .inf
+  - StartTime: 106314.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 106735.0
+    Multiplier: .inf
+  - StartTime: 106736.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 107158.0
+    Multiplier: .inf
+  - StartTime: 107159.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 107580.0
+    Multiplier: .inf
+  - StartTime: 107581.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 108003.0
+    Multiplier: .inf
+  - StartTime: 108004.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 108425.0
+    Multiplier: .inf
+  - StartTime: 108426.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 110538.0
+    Multiplier: 0.25
+  - StartTime: 112228.0
+    Multiplier: 1.0
+  - StartTime: 124904.0
+    Multiplier: 0.5
+  - StartTime: 125749.0
+    Multiplier: 1.0
+  - StartTime: 141858.0
+    Multiplier: 0.7499999403953552
+  - StartTime: 141910.0
+    Multiplier: 0.5
+  - StartTime: 141963.0
+    Multiplier: 0.25
+  - StartTime: 142016.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 142227.0
+    Multiplier: 0.25
+  - StartTime: 142438.0
+    Multiplier: 0.5
+  - StartTime: 142544.0
+    Multiplier: 0.7499999403953552
+  - StartTime: 142650.0
+    Multiplier: 1.0
+  - StartTime: 145238.0
+    Multiplier: 0.7499999403953552
+  - StartTime: 145290.0
+    Multiplier: 0.5
+  - StartTime: 145343.0
+    Multiplier: 0.25
+  - StartTime: 145396.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 145607.0
+    Multiplier: 0.25
+  - StartTime: 145818.0
+    Multiplier: 0.5
+  - StartTime: 145924.0
+    Multiplier: 0.7499999403953552
+  - StartTime: 146030.0
+    Multiplier: 1.0
+  - StartTime: 151101.0
+    Multiplier: 0.7499999403953552
+  - StartTime: 151171.0
+    Multiplier: 0.5
+  - StartTime: 151241.0
+    Multiplier: 0.25
+  - StartTime: 151312.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 151945.0
+    Multiplier: 0.5
+  - StartTime: 153899.0
+    Multiplier: 0.25
+  - StartTime: 153952.0
+    Multiplier: 2.007042169570923
+  - StartTime: 154058.0
+    Multiplier: 0.5
+  - StartTime: 154322.0
+    Multiplier: 0.25
+  - StartTime: 154375.0
+    Multiplier: 2.007042169570923
+  - StartTime: 154481.0
+    Multiplier: 0.5
+  - StartTime: 154745.0
+    Multiplier: 0.25
+  - StartTime: 154798.0
+    Multiplier: 2.007042169570923
+  - StartTime: 154904.0
+    Multiplier: 0.5
+  - StartTime: 155168.0
+    Multiplier: 0.25
+  - StartTime: 155221.0
+    Multiplier: 2.007042169570923
+  - StartTime: 155327.0
+    Multiplier: 0.5
+  - StartTime: 155591.0
+    Multiplier: 0.25
+  - StartTime: 155644.0
+    Multiplier: 2.007042169570923
+  - StartTime: 155750.0
+    Multiplier: 0.5
+  - StartTime: 156014.0
+    Multiplier: 0.25
+  - StartTime: 156067.0
+    Multiplier: 2.007042169570923
+  - StartTime: 156173.0
+    Multiplier: 0.5
+  - StartTime: 156437.0
+    Multiplier: 0.25
+  - StartTime: 156490.0
+    Multiplier: 2.007042169570923
+  - StartTime: 156596.0
+    Multiplier: 0.5
+  - StartTime: 156860.0
+    Multiplier: 0.25
+  - StartTime: 156913.0
+    Multiplier: 2.007042169570923
+  - StartTime: 157019.0
+    Multiplier: 0.5
+  - StartTime: 157283.0
+    Multiplier: 0.25
+  - StartTime: 157336.0
+    Multiplier: 2.007042169570923
+  - StartTime: 157442.0
+    Multiplier: 0.5
+  - StartTime: 157706.0
+    Multiplier: 0.25
+  - StartTime: 157759.0
+    Multiplier: 2.007042169570923
+  - StartTime: 157865.0
+    Multiplier: 0.5
+  - StartTime: 158129.0
+    Multiplier: 0.25
+  - StartTime: 158182.0
+    Multiplier: 2.007042169570923
+  - StartTime: 158288.0
+    Multiplier: 0.5
+  - StartTime: 158552.0
+    Multiplier: 0.25
+  - StartTime: 158605.0
+    Multiplier: 2.007042169570923
+  - StartTime: 158711.0
+    Multiplier: 0.5
+  - StartTime: 158975.0
+    Multiplier: 0.25
+  - StartTime: 159028.0
+    Multiplier: 2.007042169570923
+  - StartTime: 159134.0
+    Multiplier: 0.5
+  - StartTime: 159398.0
+    Multiplier: 0.25
+  - StartTime: 159451.0
+    Multiplier: 2.007042169570923
+  - StartTime: 159557.0
+    Multiplier: 0.5
+  - StartTime: 159821.0
+    Multiplier: 0.25
+  - StartTime: 159874.0
+    Multiplier: 2.007042169570923
+  - StartTime: 159980.0
+    Multiplier: 0.5
+  - StartTime: 160244.0
+    Multiplier: 0.25
+  - StartTime: 160297.0
+    Multiplier: 2.007042169570923
+  - StartTime: 160403.0
+    Multiplier: 0.5
+  - StartTime: 160667.0
+    Multiplier: 0.25
+  - StartTime: 160720.0
+    Multiplier: 2.007042169570923
+  - StartTime: 160826.0
+    Multiplier: 0.5
+  - StartTime: 161090.0
+    Multiplier: 0.25
+  - StartTime: 161143.0
+    Multiplier: 2.007042169570923
+  - StartTime: 161249.0
+    Multiplier: 0.5
+  - StartTime: 161513.0
+    Multiplier: 0.25
+  - StartTime: 161566.0
+    Multiplier: 2.007042169570923
+  - StartTime: 161672.0
+    Multiplier: 0.5
+  - StartTime: 161936.0
+    Multiplier: 0.25
+  - StartTime: 161989.0
+    Multiplier: 2.007042169570923
+  - StartTime: 162095.0
+    Multiplier: 0.5
+  - StartTime: 162359.0
+    Multiplier: 0.25
+  - StartTime: 162412.0
+    Multiplier: 2.007042169570923
+  - StartTime: 162518.0
+    Multiplier: 0.5
+  - StartTime: 162782.0
+    Multiplier: 0.25
+  - StartTime: 162835.0
+    Multiplier: 2.007042169570923
+  - StartTime: 162941.0
+    Multiplier: 0.5
+  - StartTime: 163205.0
+    Multiplier: 0.25
+  - StartTime: 163258.0
+    Multiplier: 2.007042169570923
+  - StartTime: 163364.0
+    Multiplier: 0.5
+  - StartTime: 163628.0
+    Multiplier: 0.25
+  - StartTime: 163681.0
+    Multiplier: 2.007042169570923
+  - StartTime: 163787.0
+    Multiplier: 0.5
+  - StartTime: 164051.0
+    Multiplier: 0.25
+  - StartTime: 164104.0
+    Multiplier: 2.007042169570923
+  - StartTime: 164210.0
+    Multiplier: 0.5
+  - StartTime: 164474.0
+    Multiplier: 0.25
+  - StartTime: 164527.0
+    Multiplier: 2.007042169570923
+  - StartTime: 164633.0
+    Multiplier: 0.5
+  - StartTime: 164897.0
+    Multiplier: 0.25
+  - StartTime: 164950.0
+    Multiplier: 2.007042169570923
+  - StartTime: 165055.0
+    Multiplier: 0.5
+  - StartTime: 165319.0
+    Multiplier: 0.25
+  - StartTime: 165372.0
+    Multiplier: 2.007042169570923
+  - StartTime: 165490.0
+    Multiplier: 0.25
+  - StartTime: 167157.0
+    Multiplier: 1.0
+  - StartTime: 168847.0
+    Multiplier: .inf
+  - StartTime: 168848.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 169058.0
+    Multiplier: .inf
+  - StartTime: 169059.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 169269.0
+    Multiplier: .inf
+  - StartTime: 169270.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 169481.0
+    Multiplier: .inf
+  - StartTime: 169482.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 169692.0
+    Multiplier: .inf
+  - StartTime: 169693.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 169903.0
+    Multiplier: .inf
+  - StartTime: 169904.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 170114.0
+    Multiplier: .inf
+  - StartTime: 170115.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 170326.0
+    Multiplier: .inf
+  - StartTime: 170327.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 170537.0
+    Multiplier: 1.0
+  - StartTime: 172227.0
+    Multiplier: .inf
+  - StartTime: 172228.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 172438.0
+    Multiplier: .inf
+  - StartTime: 172439.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 172649.0
+    Multiplier: .inf
+  - StartTime: 172650.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 172860.0
+    Multiplier: .inf
+  - StartTime: 172861.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 173072.0
+    Multiplier: .inf
+  - StartTime: 173073.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 173283.0
+    Multiplier: .inf
+  - StartTime: 173284.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 173494.0
+    Multiplier: .inf
+  - StartTime: 173495.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 173706.0
+    Multiplier: .inf
+  - StartTime: 173707.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 173917.0
+    Multiplier: 1.0
+  - StartTime: 175607.0
+    Multiplier: .inf
+  - StartTime: 175608.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 176030.0
+    Multiplier: .inf
+  - StartTime: 176031.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 176452.0
+    Multiplier: .inf
+  - StartTime: 176453.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 176664.0
+    Multiplier: .inf
+  - StartTime: 176665.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 176875.0
+    Multiplier: .inf
+  - StartTime: 176876.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 177086.0
+    Multiplier: .inf
+  - StartTime: 177087.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 177297.0
+    Multiplier: .inf
+  - StartTime: 177298.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 177720.0
+    Multiplier: .inf
+  - StartTime: 177721.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 178143.0
+    Multiplier: .inf
+  - StartTime: 178144.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 178565.0
+    Multiplier: .inf
+  - StartTime: 178566.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 178988.0
+    Multiplier: 0.25
+  - StartTime: 180678.0
+    Multiplier: 1.0
+  - StartTime: 193354.0
+    Multiplier: 0.5
+  - StartTime: 194199.0
+    Multiplier: 1.0
+  - StartTime: 207720.0
+    Multiplier: .inf
+  - StartTime: 207721.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 208143.0
+    Multiplier: .inf
+  - StartTime: 208144.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 208565.0
+    Multiplier: .inf
+  - StartTime: 208566.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 208988.0
+    Multiplier: .inf
+  - StartTime: 208989.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 209410.0
+    Multiplier: .inf
+  - StartTime: 209411.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 209833.0
+    Multiplier: .inf
+  - StartTime: 209834.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 210255.0
+    Multiplier: .inf
+  - StartTime: 210256.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 210678.0
+    Multiplier: .inf
+  - StartTime: 210679.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 211100.0
+    Multiplier: .inf
+  - StartTime: 211101.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 211523.0
+    Multiplier: .inf
+  - StartTime: 211524.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 211945.0
+    Multiplier: .inf
+  - StartTime: 211946.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 212368.0
+    Multiplier: .inf
+  - StartTime: 212369.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 212790.0
+    Multiplier: .inf
+  - StartTime: 212791.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 213213.0
+    Multiplier: .inf
+  - StartTime: 213214.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 213636.0
+    Multiplier: .inf
+  - StartTime: 213637.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 214058.0
+    Multiplier: .inf
+  - StartTime: 214059.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 214481.0
+    Multiplier: .inf
+  - StartTime: 214482.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 214903.0
+    Multiplier: .inf
+  - StartTime: 214904.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 215326.0
+    Multiplier: .inf
+  - StartTime: 215327.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 215748.0
+    Multiplier: .inf
+  - StartTime: 215749.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 216171.0
+    Multiplier: .inf
+  - StartTime: 216172.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 216593.0
+    Multiplier: .inf
+  - StartTime: 216594.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 217016.0
+    Multiplier: .inf
+  - StartTime: 217017.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 217438.0
+    Multiplier: .inf
+  - StartTime: 217439.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 217861.0
+    Multiplier: .inf
+  - StartTime: 217862.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 218283.0
+    Multiplier: .inf
+  - StartTime: 218284.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 218706.0
+    Multiplier: .inf
+  - StartTime: 218707.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 219128.0
+    Multiplier: .inf
+  - StartTime: 219129.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 219551.0
+    Multiplier: .inf
+  - StartTime: 219552.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 219974.0
+    Multiplier: .inf
+  - StartTime: 219975.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 220396.0
+    Multiplier: .inf
+  - StartTime: 220397.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 220819.0
+    Multiplier: .inf
+  - StartTime: 220820.0
+    Multiplier: 0.000004216901743347989
+  - StartTime: 221241.0
+    Multiplier: 4.0
+HitObjects:
+  - StartTime: 680
+    Lane: 4
+    EndTime: 0
+  - StartTime: 1102
+    Lane: 4
+    EndTime: 0
+  - StartTime: 1525
+    Lane: 4
+    EndTime: 0
+  - StartTime: 1947
+    Lane: 4
+    EndTime: 0
+  - StartTime: 2370
+    Lane: 4
+    EndTime: 0
+  - StartTime: 2792
+    Lane: 4
+    EndTime: 0
+  - StartTime: 3215
+    Lane: 4
+    EndTime: 0
+  - StartTime: 3637
+    Lane: 4
+    EndTime: 0
+  - StartTime: 4060
+    Lane: 4
+    EndTime: 0
+  - StartTime: 4482
+    Lane: 4
+    EndTime: 0
+  - StartTime: 4905
+    Lane: 4
+    EndTime: 0
+  - StartTime: 5327
+    Lane: 4
+    EndTime: 0
+  - StartTime: 5750
+    Lane: 4
+    EndTime: 0
+  - StartTime: 6172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 6595
+    Lane: 4
+    EndTime: 0
+  - StartTime: 7018
+    Lane: 4
+    EndTime: 0
+  - StartTime: 7440
+    Lane: 4
+    EndTime: 0
+  - StartTime: 7863
+    Lane: 2
+    EndTime: 0
+  - StartTime: 8285
+    Lane: 3
+    EndTime: 0
+  - StartTime: 8708
+    Lane: 4
+    EndTime: 0
+  - StartTime: 9130
+    Lane: 4
+    EndTime: 0
+  - StartTime: 9553
+    Lane: 2
+    EndTime: 0
+  - StartTime: 9975
+    Lane: 4
+    EndTime: 0
+  - StartTime: 10398
+    Lane: 4
+    EndTime: 0
+  - StartTime: 10820
+    Lane: 3
+    EndTime: 0
+  - StartTime: 11243
+    Lane: 3
+    EndTime: 0
+  - StartTime: 11665
+    Lane: 2
+    EndTime: 0
+  - StartTime: 12088
+    Lane: 2
+    EndTime: 0
+  - StartTime: 12510
+    Lane: 1
+    EndTime: 0
+  - StartTime: 12933
+    Lane: 4
+    EndTime: 0
+  - StartTime: 13356
+    Lane: 1
+    EndTime: 0
+  - StartTime: 13778
+    Lane: 4
+    EndTime: 0
+  - StartTime: 14201
+    Lane: 4
+    EndTime: 0
+  - StartTime: 14623
+    Lane: 2
+    EndTime: 0
+  - StartTime: 15046
+    Lane: 3
+    EndTime: 0
+  - StartTime: 15468
+    Lane: 4
+    EndTime: 0
+  - StartTime: 15891
+    Lane: 4
+    EndTime: 0
+  - StartTime: 16313
+    Lane: 2
+    EndTime: 0
+  - StartTime: 16736
+    Lane: 4
+    EndTime: 0
+  - StartTime: 17158
+    Lane: 4
+    EndTime: 0
+  - StartTime: 17581
+    Lane: 3
+    EndTime: 0
+  - StartTime: 18003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 18426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 18849
+    Lane: 2
+    EndTime: 0
+  - StartTime: 19271
+    Lane: 1
+    EndTime: 0
+  - StartTime: 19694
+    Lane: 4
+    EndTime: 0
+  - StartTime: 20116
+    Lane: 1
+    EndTime: 0
+  - StartTime: 20539
+    Lane: 4
+    EndTime: 0
+  - StartTime: 20961
+    Lane: 4
+    EndTime: 0
+  - StartTime: 21384
+    Lane: 2
+    EndTime: 0
+  - StartTime: 21806
+    Lane: 3
+    EndTime: 0
+  - StartTime: 22229
+    Lane: 4
+    EndTime: 0
+  - StartTime: 22651
+    Lane: 4
+    EndTime: 0
+  - StartTime: 23074
+    Lane: 2
+    EndTime: 0
+  - StartTime: 23496
+    Lane: 4
+    EndTime: 0
+  - StartTime: 23919
+    Lane: 4
+    EndTime: 0
+  - StartTime: 24341
+    Lane: 3
+    EndTime: 0
+  - StartTime: 24764
+    Lane: 3
+    EndTime: 0
+  - StartTime: 25187
+    Lane: 2
+    EndTime: 0
+  - StartTime: 25609
+    Lane: 2
+    EndTime: 0
+  - StartTime: 27722
+    Lane: 2
+    EndTime: 29412
+  - StartTime: 29412
+    Lane: 4
+    EndTime: 0
+  - StartTime: 29834
+    Lane: 2
+    EndTime: 0
+  - StartTime: 30257
+    Lane: 3
+    EndTime: 0
+  - StartTime: 30679
+    Lane: 4
+    EndTime: 0
+  - StartTime: 31102
+    Lane: 4
+    EndTime: 0
+  - StartTime: 31524
+    Lane: 2
+    EndTime: 0
+  - StartTime: 31947
+    Lane: 4
+    EndTime: 0
+  - StartTime: 32370
+    Lane: 4
+    EndTime: 0
+  - StartTime: 32792
+    Lane: 3
+    EndTime: 0
+  - StartTime: 33215
+    Lane: 3
+    EndTime: 0
+  - StartTime: 33637
+    Lane: 2
+    EndTime: 0
+  - StartTime: 34060
+    Lane: 2
+    EndTime: 0
+  - StartTime: 34482
+    Lane: 1
+    EndTime: 0
+  - StartTime: 34905
+    Lane: 4
+    EndTime: 0
+  - StartTime: 35327
+    Lane: 1
+    EndTime: 0
+  - StartTime: 35750
+    Lane: 4
+    EndTime: 0
+  - StartTime: 36172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 36595
+    Lane: 2
+    EndTime: 0
+  - StartTime: 37017
+    Lane: 3
+    EndTime: 0
+  - StartTime: 37440
+    Lane: 4
+    EndTime: 0
+  - StartTime: 37862
+    Lane: 4
+    EndTime: 0
+  - StartTime: 38285
+    Lane: 2
+    EndTime: 0
+  - StartTime: 38708
+    Lane: 4
+    EndTime: 0
+  - StartTime: 39130
+    Lane: 4
+    EndTime: 0
+  - StartTime: 39553
+    Lane: 3
+    EndTime: 0
+  - StartTime: 39975
+    Lane: 3
+    EndTime: 0
+  - StartTime: 40398
+    Lane: 2
+    EndTime: 0
+  - StartTime: 40820
+    Lane: 2
+    EndTime: 0
+  - StartTime: 41243
+    Lane: 4
+    EndTime: 0
+  - StartTime: 41665
+    Lane: 3
+    EndTime: 0
+  - StartTime: 42088
+    Lane: 1
+    EndTime: 0
+  - StartTime: 42510
+    Lane: 1
+    EndTime: 0
+  - StartTime: 42933
+    Lane: 4
+    EndTime: 0
+  - StartTime: 43355
+    Lane: 2
+    EndTime: 0
+  - StartTime: 43778
+    Lane: 3
+    EndTime: 0
+  - StartTime: 44201
+    Lane: 4
+    EndTime: 0
+  - StartTime: 44623
+    Lane: 4
+    EndTime: 0
+  - StartTime: 45046
+    Lane: 2
+    EndTime: 0
+  - StartTime: 45468
+    Lane: 4
+    EndTime: 0
+  - StartTime: 45891
+    Lane: 4
+    EndTime: 0
+  - StartTime: 46313
+    Lane: 3
+    EndTime: 0
+  - StartTime: 46736
+    Lane: 3
+    EndTime: 0
+  - StartTime: 47158
+    Lane: 2
+    EndTime: 0
+  - StartTime: 47581
+    Lane: 2
+    EndTime: 0
+  - StartTime: 48003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 48426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 48848
+    Lane: 1
+    EndTime: 0
+  - StartTime: 49271
+    Lane: 4
+    EndTime: 0
+  - StartTime: 49693
+    Lane: 4
+    EndTime: 0
+  - StartTime: 50116
+    Lane: 2
+    EndTime: 0
+  - StartTime: 50539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 50961
+    Lane: 4
+    EndTime: 0
+  - StartTime: 51384
+    Lane: 4
+    EndTime: 0
+  - StartTime: 51806
+    Lane: 2
+    EndTime: 0
+  - StartTime: 52229
+    Lane: 4
+    EndTime: 0
+  - StartTime: 52651
+    Lane: 4
+    EndTime: 0
+  - StartTime: 53074
+    Lane: 3
+    EndTime: 0
+  - StartTime: 53496
+    Lane: 3
+    EndTime: 0
+  - StartTime: 53919
+    Lane: 2
+    EndTime: 0
+  - StartTime: 54341
+    Lane: 2
+    EndTime: 0
+  - StartTime: 54764
+    Lane: 1
+    EndTime: 0
+  - StartTime: 55186
+    Lane: 2
+    EndTime: 0
+  - StartTime: 55609
+    Lane: 4
+    EndTime: 0
+  - StartTime: 56031
+    Lane: 4
+    EndTime: 0
+  - StartTime: 56454
+    Lane: 4
+    EndTime: 56876
+  - StartTime: 56454
+    Lane: 3
+    EndTime: 0
+  - StartTime: 56665
+    Lane: 1
+    EndTime: 0
+  - StartTime: 56876
+    Lane: 2
+    EndTime: 0
+  - StartTime: 57087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 57299
+    Lane: 2
+    EndTime: 0
+  - StartTime: 57299
+    Lane: 1
+    EndTime: 0
+  - StartTime: 57510
+    Lane: 3
+    EndTime: 0
+  - StartTime: 57510
+    Lane: 4
+    EndTime: 0
+  - StartTime: 57615
+    Lane: 1
+    EndTime: 0
+  - StartTime: 57615
+    Lane: 2
+    EndTime: 0
+  - StartTime: 57721
+    Lane: 1
+    EndTime: 0
+  - StartTime: 57721
+    Lane: 4
+    EndTime: 0
+  - StartTime: 57721
+    Lane: 3
+    EndTime: 0
+  - StartTime: 57932
+    Lane: 2
+    EndTime: 0
+  - StartTime: 58144
+    Lane: 1
+    EndTime: 0
+  - StartTime: 58144
+    Lane: 3
+    EndTime: 0
+  - StartTime: 58355
+    Lane: 4
+    EndTime: 0
+  - StartTime: 58566
+    Lane: 2
+    EndTime: 0
+  - StartTime: 58566
+    Lane: 1
+    EndTime: 0
+  - StartTime: 58777
+    Lane: 3
+    EndTime: 0
+  - StartTime: 58989
+    Lane: 4
+    EndTime: 0
+  - StartTime: 59200
+    Lane: 1
+    EndTime: 0
+  - StartTime: 59200
+    Lane: 2
+    EndTime: 0
+  - StartTime: 59306
+    Lane: 3
+    EndTime: 0
+  - StartTime: 59306
+    Lane: 4
+    EndTime: 0
+  - StartTime: 59411
+    Lane: 1
+    EndTime: 0
+  - StartTime: 59411
+    Lane: 4
+    EndTime: 0
+  - StartTime: 59411
+    Lane: 2
+    EndTime: 0
+  - StartTime: 59623
+    Lane: 3
+    EndTime: 0
+  - StartTime: 59834
+    Lane: 1
+    EndTime: 0
+  - StartTime: 59834
+    Lane: 4
+    EndTime: 0
+  - StartTime: 60045
+    Lane: 3
+    EndTime: 0
+  - StartTime: 60256
+    Lane: 2
+    EndTime: 0
+  - StartTime: 60256
+    Lane: 4
+    EndTime: 0
+  - StartTime: 60468
+    Lane: 1
+    EndTime: 0
+  - StartTime: 60679
+    Lane: 4
+    EndTime: 0
+  - StartTime: 60890
+    Lane: 2
+    EndTime: 0
+  - StartTime: 60890
+    Lane: 3
+    EndTime: 0
+  - StartTime: 60996
+    Lane: 1
+    EndTime: 0
+  - StartTime: 60996
+    Lane: 4
+    EndTime: 0
+  - StartTime: 61101
+    Lane: 3
+    EndTime: 0
+  - StartTime: 61101
+    Lane: 1
+    EndTime: 0
+  - StartTime: 61101
+    Lane: 2
+    EndTime: 0
+  - StartTime: 61313
+    Lane: 3
+    EndTime: 0
+  - StartTime: 61524
+    Lane: 2
+    EndTime: 0
+  - StartTime: 61524
+    Lane: 4
+    EndTime: 0
+  - StartTime: 61735
+    Lane: 1
+    EndTime: 0
+  - StartTime: 61946
+    Lane: 2
+    EndTime: 0
+  - StartTime: 61946
+    Lane: 4
+    EndTime: 0
+  - StartTime: 62158
+    Lane: 3
+    EndTime: 0
+  - StartTime: 62369
+    Lane: 4
+    EndTime: 0
+  - StartTime: 62580
+    Lane: 3
+    EndTime: 0
+  - StartTime: 62580
+    Lane: 1
+    EndTime: 0
+  - StartTime: 62686
+    Lane: 2
+    EndTime: 0
+  - StartTime: 62686
+    Lane: 4
+    EndTime: 0
+  - StartTime: 62792
+    Lane: 4
+    EndTime: 0
+  - StartTime: 62792
+    Lane: 1
+    EndTime: 0
+  - StartTime: 62792
+    Lane: 3
+    EndTime: 0
+  - StartTime: 63003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 63214
+    Lane: 4
+    EndTime: 0
+  - StartTime: 63214
+    Lane: 3
+    EndTime: 0
+  - StartTime: 63425
+    Lane: 1
+    EndTime: 0
+  - StartTime: 63637
+    Lane: 4
+    EndTime: 0
+  - StartTime: 63637
+    Lane: 2
+    EndTime: 0
+  - StartTime: 63848
+    Lane: 3
+    EndTime: 0
+  - StartTime: 64059
+    Lane: 4
+    EndTime: 0
+  - StartTime: 64270
+    Lane: 2
+    EndTime: 0
+  - StartTime: 64270
+    Lane: 3
+    EndTime: 0
+  - StartTime: 64376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 64376
+    Lane: 1
+    EndTime: 0
+  - StartTime: 64482
+    Lane: 2
+    EndTime: 0
+  - StartTime: 64482
+    Lane: 3
+    EndTime: 0
+  - StartTime: 64482
+    Lane: 1
+    EndTime: 0
+  - StartTime: 64693
+    Lane: 4
+    EndTime: 0
+  - StartTime: 64904
+    Lane: 1
+    EndTime: 0
+  - StartTime: 64904
+    Lane: 3
+    EndTime: 0
+  - StartTime: 65115
+    Lane: 4
+    EndTime: 0
+  - StartTime: 65327
+    Lane: 2
+    EndTime: 0
+  - StartTime: 65327
+    Lane: 1
+    EndTime: 0
+  - StartTime: 65538
+    Lane: 4
+    EndTime: 0
+  - StartTime: 65749
+    Lane: 2
+    EndTime: 0
+  - StartTime: 65961
+    Lane: 3
+    EndTime: 0
+  - StartTime: 65961
+    Lane: 1
+    EndTime: 0
+  - StartTime: 66066
+    Lane: 2
+    EndTime: 0
+  - StartTime: 66066
+    Lane: 4
+    EndTime: 0
+  - StartTime: 66172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 66172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 66172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 66383
+    Lane: 3
+    EndTime: 0
+  - StartTime: 66594
+    Lane: 2
+    EndTime: 0
+  - StartTime: 66594
+    Lane: 1
+    EndTime: 0
+  - StartTime: 66806
+    Lane: 4
+    EndTime: 0
+  - StartTime: 67017
+    Lane: 4
+    EndTime: 0
+  - StartTime: 67017
+    Lane: 2
+    EndTime: 0
+  - StartTime: 67228
+    Lane: 1
+    EndTime: 0
+  - StartTime: 67439
+    Lane: 3
+    EndTime: 0
+  - StartTime: 67651
+    Lane: 4
+    EndTime: 0
+  - StartTime: 67651
+    Lane: 2
+    EndTime: 0
+  - StartTime: 67756
+    Lane: 3
+    EndTime: 0
+  - StartTime: 67756
+    Lane: 1
+    EndTime: 0
+  - StartTime: 67862
+    Lane: 1
+    EndTime: 0
+  - StartTime: 67862
+    Lane: 4
+    EndTime: 0
+  - StartTime: 67862
+    Lane: 2
+    EndTime: 0
+  - StartTime: 68073
+    Lane: 3
+    EndTime: 0
+  - StartTime: 68284
+    Lane: 4
+    EndTime: 0
+  - StartTime: 68284
+    Lane: 2
+    EndTime: 0
+  - StartTime: 68496
+    Lane: 1
+    EndTime: 0
+  - StartTime: 68496
+    Lane: 3
+    EndTime: 0
+  - StartTime: 68707
+    Lane: 4
+    EndTime: 0
+  - StartTime: 68707
+    Lane: 2
+    EndTime: 0
+  - StartTime: 68918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 68918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 69130
+    Lane: 2
+    EndTime: 0
+  - StartTime: 69130
+    Lane: 4
+    EndTime: 0
+  - StartTime: 69235
+    Lane: 3
+    EndTime: 0
+  - StartTime: 69341
+    Lane: 2
+    EndTime: 0
+  - StartTime: 69446
+    Lane: 3
+    EndTime: 0
+  - StartTime: 69552
+    Lane: 1
+    EndTime: 0
+  - StartTime: 69552
+    Lane: 2
+    EndTime: 0
+  - StartTime: 69658
+    Lane: 4
+    EndTime: 0
+  - StartTime: 69763
+    Lane: 1
+    EndTime: 0
+  - StartTime: 69869
+    Lane: 4
+    EndTime: 0
+  - StartTime: 69975
+    Lane: 3
+    EndTime: 0
+  - StartTime: 69975
+    Lane: 1
+    EndTime: 0
+  - StartTime: 69975
+    Lane: 2
+    EndTime: 0
+  - StartTime: 70186
+    Lane: 1
+    EndTime: 0
+  - StartTime: 70186
+    Lane: 4
+    EndTime: 0
+  - StartTime: 70397
+    Lane: 2
+    EndTime: 0
+  - StartTime: 70397
+    Lane: 3
+    EndTime: 0
+  - StartTime: 70608
+    Lane: 1
+    EndTime: 0
+  - StartTime: 70714
+    Lane: 1
+    EndTime: 0
+  - StartTime: 70714
+    Lane: 2
+    EndTime: 0
+  - StartTime: 70925
+    Lane: 4
+    EndTime: 0
+  - StartTime: 71031
+    Lane: 4
+    EndTime: 0
+  - StartTime: 71031
+    Lane: 3
+    EndTime: 0
+  - StartTime: 71242
+    Lane: 2
+    EndTime: 0
+  - StartTime: 71242
+    Lane: 3
+    EndTime: 0
+  - StartTime: 71453
+    Lane: 2
+    EndTime: 0
+  - StartTime: 71453
+    Lane: 1
+    EndTime: 0
+  - StartTime: 71665
+    Lane: 1
+    EndTime: 0
+  - StartTime: 71665
+    Lane: 3
+    EndTime: 0
+  - StartTime: 71876
+    Lane: 2
+    EndTime: 0
+  - StartTime: 71876
+    Lane: 4
+    EndTime: 0
+  - StartTime: 72087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 72087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 72298
+    Lane: 1
+    EndTime: 0
+  - StartTime: 72404
+    Lane: 1
+    EndTime: 0
+  - StartTime: 72404
+    Lane: 3
+    EndTime: 0
+  - StartTime: 72615
+    Lane: 4
+    EndTime: 0
+  - StartTime: 72721
+    Lane: 4
+    EndTime: 0
+  - StartTime: 72721
+    Lane: 2
+    EndTime: 0
+  - StartTime: 72932
+    Lane: 3
+    EndTime: 0
+  - StartTime: 72932
+    Lane: 4
+    EndTime: 0
+  - StartTime: 73144
+    Lane: 1
+    EndTime: 0
+  - StartTime: 73144
+    Lane: 2
+    EndTime: 0
+  - StartTime: 73355
+    Lane: 2
+    EndTime: 0
+  - StartTime: 73355
+    Lane: 4
+    EndTime: 0
+  - StartTime: 73566
+    Lane: 1
+    EndTime: 0
+  - StartTime: 73566
+    Lane: 3
+    EndTime: 0
+  - StartTime: 73777
+    Lane: 1
+    EndTime: 0
+  - StartTime: 73777
+    Lane: 2
+    EndTime: 0
+  - StartTime: 73989
+    Lane: 3
+    EndTime: 0
+  - StartTime: 74094
+    Lane: 4
+    EndTime: 0
+  - StartTime: 74094
+    Lane: 3
+    EndTime: 0
+  - StartTime: 74305
+    Lane: 2
+    EndTime: 0
+  - StartTime: 74411
+    Lane: 1
+    EndTime: 0
+  - StartTime: 74411
+    Lane: 2
+    EndTime: 0
+  - StartTime: 74622
+    Lane: 3
+    EndTime: 0
+  - StartTime: 74622
+    Lane: 1
+    EndTime: 0
+  - StartTime: 74834
+    Lane: 4
+    EndTime: 0
+  - StartTime: 74834
+    Lane: 3
+    EndTime: 0
+  - StartTime: 75045
+    Lane: 4
+    EndTime: 0
+  - StartTime: 75045
+    Lane: 2
+    EndTime: 0
+  - StartTime: 75256
+    Lane: 1
+    EndTime: 0
+  - StartTime: 75256
+    Lane: 2
+    EndTime: 0
+  - StartTime: 75467
+    Lane: 3
+    EndTime: 0
+  - StartTime: 75467
+    Lane: 4
+    EndTime: 0
+  - StartTime: 75679
+    Lane: 4
+    EndTime: 0
+  - StartTime: 75784
+    Lane: 4
+    EndTime: 0
+  - StartTime: 75784
+    Lane: 1
+    EndTime: 0
+  - StartTime: 75996
+    Lane: 2
+    EndTime: 0
+  - StartTime: 76101
+    Lane: 3
+    EndTime: 0
+  - StartTime: 76101
+    Lane: 2
+    EndTime: 0
+  - StartTime: 76313
+    Lane: 1
+    EndTime: 0
+  - StartTime: 76313
+    Lane: 3
+    EndTime: 0
+  - StartTime: 76524
+    Lane: 2
+    EndTime: 0
+  - StartTime: 76524
+    Lane: 4
+    EndTime: 0
+  - StartTime: 76735
+    Lane: 1
+    EndTime: 0
+  - StartTime: 76735
+    Lane: 3
+    EndTime: 0
+  - StartTime: 76946
+    Lane: 2
+    EndTime: 0
+  - StartTime: 76946
+    Lane: 3
+    EndTime: 0
+  - StartTime: 77158
+    Lane: 1
+    EndTime: 0
+  - StartTime: 77158
+    Lane: 2
+    EndTime: 0
+  - StartTime: 77369
+    Lane: 4
+    EndTime: 0
+  - StartTime: 77475
+    Lane: 4
+    EndTime: 0
+  - StartTime: 77475
+    Lane: 2
+    EndTime: 0
+  - StartTime: 77686
+    Lane: 1
+    EndTime: 0
+  - StartTime: 77791
+    Lane: 3
+    EndTime: 0
+  - StartTime: 77791
+    Lane: 1
+    EndTime: 0
+  - StartTime: 78003
+    Lane: 4
+    EndTime: 0
+  - StartTime: 78003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 78214
+    Lane: 1
+    EndTime: 0
+  - StartTime: 78214
+    Lane: 4
+    EndTime: 0
+  - StartTime: 78425
+    Lane: 1
+    EndTime: 0
+  - StartTime: 78425
+    Lane: 2
+    EndTime: 0
+  - StartTime: 78636
+    Lane: 2
+    EndTime: 0
+  - StartTime: 78636
+    Lane: 3
+    EndTime: 0
+  - StartTime: 78848
+    Lane: 3
+    EndTime: 0
+  - StartTime: 78848
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79059
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79165
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79165
+    Lane: 1
+    EndTime: 0
+  - StartTime: 79376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 79482
+    Lane: 3
+    EndTime: 0
+  - StartTime: 79482
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79693
+    Lane: 1
+    EndTime: 0
+  - StartTime: 79693
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79693
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79904
+    Lane: 3
+    EndTime: 0
+  - StartTime: 79904
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79904
+    Lane: 1
+    EndTime: 0
+  - StartTime: 80115
+    Lane: 4
+    EndTime: 0
+  - StartTime: 80115
+    Lane: 1
+    EndTime: 0
+  - StartTime: 80115
+    Lane: 3
+    EndTime: 0
+  - StartTime: 80327
+    Lane: 3
+    EndTime: 0
+  - StartTime: 80327
+    Lane: 2
+    EndTime: 0
+  - StartTime: 80538
+    Lane: 3
+    EndTime: 0
+  - StartTime: 80538
+    Lane: 1
+    EndTime: 0
+  - StartTime: 80749
+    Lane: 4
+    EndTime: 0
+  - StartTime: 80855
+    Lane: 2
+    EndTime: 0
+  - StartTime: 80855
+    Lane: 4
+    EndTime: 0
+  - StartTime: 81066
+    Lane: 1
+    EndTime: 0
+  - StartTime: 81172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 81172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 81383
+    Lane: 2
+    EndTime: 81594
+  - StartTime: 81383
+    Lane: 4
+    EndTime: 0
+  - StartTime: 81594
+    Lane: 3
+    EndTime: 0
+  - StartTime: 81594
+    Lane: 1
+    EndTime: 0
+  - StartTime: 81806
+    Lane: 4
+    EndTime: 0
+  - StartTime: 82228
+    Lane: 3
+    EndTime: 0
+  - StartTime: 82651
+    Lane: 2
+    EndTime: 0
+  - StartTime: 83073
+    Lane: 1
+    EndTime: 0
+  - StartTime: 83496
+    Lane: 4
+    EndTime: 0
+  - StartTime: 83918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 84763
+    Lane: 3
+    EndTime: 0
+  - StartTime: 84763
+    Lane: 4
+    EndTime: 0
+  - StartTime: 85186
+    Lane: 1
+    EndTime: 0
+  - StartTime: 85186
+    Lane: 2
+    EndTime: 0
+  - StartTime: 85608
+    Lane: 2
+    EndTime: 0
+  - StartTime: 85608
+    Lane: 3
+    EndTime: 0
+  - StartTime: 86031
+    Lane: 1
+    EndTime: 0
+  - StartTime: 86031
+    Lane: 4
+    EndTime: 0
+  - StartTime: 86454
+    Lane: 2
+    EndTime: 0
+  - StartTime: 86454
+    Lane: 4
+    EndTime: 0
+  - StartTime: 86876
+    Lane: 3
+    EndTime: 0
+  - StartTime: 87299
+    Lane: 3
+    EndTime: 0
+  - StartTime: 87721
+    Lane: 2
+    EndTime: 0
+  - StartTime: 88144
+    Lane: 1
+    EndTime: 0
+  - StartTime: 88144
+    Lane: 2
+    EndTime: 0
+  - StartTime: 88566
+    Lane: 1
+    EndTime: 0
+  - StartTime: 88566
+    Lane: 4
+    EndTime: 0
+  - StartTime: 88989
+    Lane: 1
+    EndTime: 0
+  - StartTime: 88989
+    Lane: 3
+    EndTime: 0
+  - StartTime: 89411
+    Lane: 2
+    EndTime: 0
+  - StartTime: 89411
+    Lane: 4
+    EndTime: 0
+  - StartTime: 89834
+    Lane: 1
+    EndTime: 0
+  - StartTime: 89834
+    Lane: 2
+    EndTime: 0
+  - StartTime: 90256
+    Lane: 4
+    EndTime: 0
+  - StartTime: 90679
+    Lane: 2
+    EndTime: 0
+  - StartTime: 91101
+    Lane: 3
+    EndTime: 0
+  - StartTime: 91524
+    Lane: 4
+    EndTime: 0
+  - StartTime: 91946
+    Lane: 1
+    EndTime: 0
+  - StartTime: 91946
+    Lane: 2
+    EndTime: 0
+  - StartTime: 92369
+    Lane: 2
+    EndTime: 0
+  - StartTime: 92369
+    Lane: 3
+    EndTime: 0
+  - StartTime: 92792
+    Lane: 1
+    EndTime: 0
+  - StartTime: 92792
+    Lane: 4
+    EndTime: 0
+  - StartTime: 93214
+    Lane: 2
+    EndTime: 0
+  - StartTime: 93214
+    Lane: 4
+    EndTime: 0
+  - StartTime: 93637
+    Lane: 3
+    EndTime: 0
+  - StartTime: 94059
+    Lane: 3
+    EndTime: 0
+  - StartTime: 94482
+    Lane: 2
+    EndTime: 0
+  - StartTime: 94904
+    Lane: 2
+    EndTime: 0
+  - StartTime: 95327
+    Lane: 4
+    EndTime: 0
+  - StartTime: 95749
+    Lane: 2
+    EndTime: 0
+  - StartTime: 96172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 96594
+    Lane: 1
+    EndTime: 0
+  - StartTime: 97017
+    Lane: 4
+    EndTime: 0
+  - StartTime: 97439
+    Lane: 2
+    EndTime: 0
+  - StartTime: 98284
+    Lane: 3
+    EndTime: 0
+  - StartTime: 98284
+    Lane: 4
+    EndTime: 0
+  - StartTime: 98707
+    Lane: 1
+    EndTime: 0
+  - StartTime: 98707
+    Lane: 2
+    EndTime: 0
+  - StartTime: 99130
+    Lane: 2
+    EndTime: 0
+  - StartTime: 99130
+    Lane: 3
+    EndTime: 0
+  - StartTime: 99552
+    Lane: 1
+    EndTime: 0
+  - StartTime: 99552
+    Lane: 4
+    EndTime: 0
+  - StartTime: 99975
+    Lane: 2
+    EndTime: 0
+  - StartTime: 99975
+    Lane: 4
+    EndTime: 0
+  - StartTime: 100397
+    Lane: 3
+    EndTime: 0
+  - StartTime: 100820
+    Lane: 3
+    EndTime: 0
+  - StartTime: 101242
+    Lane: 2
+    EndTime: 0
+  - StartTime: 101665
+    Lane: 1
+    EndTime: 0
+  - StartTime: 101665
+    Lane: 2
+    EndTime: 0
+  - StartTime: 102087
+    Lane: 1
+    EndTime: 0
+  - StartTime: 102087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 102510
+    Lane: 1
+    EndTime: 0
+  - StartTime: 102510
+    Lane: 3
+    EndTime: 0
+  - StartTime: 102932
+    Lane: 2
+    EndTime: 0
+  - StartTime: 102932
+    Lane: 4
+    EndTime: 0
+  - StartTime: 103355
+    Lane: 1
+    EndTime: 0
+  - StartTime: 103355
+    Lane: 2
+    EndTime: 0
+  - StartTime: 103777
+    Lane: 4
+    EndTime: 0
+  - StartTime: 104200
+    Lane: 2
+    EndTime: 0
+  - StartTime: 104623
+    Lane: 3
+    EndTime: 0
+  - StartTime: 105045
+    Lane: 4
+    EndTime: 0
+  - StartTime: 105468
+    Lane: 1
+    EndTime: 0
+  - StartTime: 105468
+    Lane: 2
+    EndTime: 0
+  - StartTime: 105890
+    Lane: 2
+    EndTime: 0
+  - StartTime: 105890
+    Lane: 3
+    EndTime: 0
+  - StartTime: 106313
+    Lane: 1
+    EndTime: 0
+  - StartTime: 106313
+    Lane: 4
+    EndTime: 0
+  - StartTime: 106735
+    Lane: 2
+    EndTime: 0
+  - StartTime: 106735
+    Lane: 4
+    EndTime: 0
+  - StartTime: 107158
+    Lane: 3
+    EndTime: 0
+  - StartTime: 107580
+    Lane: 3
+    EndTime: 0
+  - StartTime: 108003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 108425
+    Lane: 2
+    EndTime: 0
+  - StartTime: 108848
+    Lane: 4
+    EndTime: 0
+  - StartTime: 110538
+    Lane: 4
+    EndTime: 0
+  - StartTime: 110960
+    Lane: 2
+    EndTime: 0
+  - StartTime: 111383
+    Lane: 3
+    EndTime: 0
+  - StartTime: 111805
+    Lane: 1
+    EndTime: 0
+  - StartTime: 112228
+    Lane: 4
+    EndTime: 112650
+  - StartTime: 112228
+    Lane: 3
+    EndTime: 0
+  - StartTime: 112439
+    Lane: 1
+    EndTime: 0
+  - StartTime: 112650
+    Lane: 2
+    EndTime: 0
+  - StartTime: 112861
+    Lane: 4
+    EndTime: 0
+  - StartTime: 113073
+    Lane: 2
+    EndTime: 0
+  - StartTime: 113073
+    Lane: 1
+    EndTime: 0
+  - StartTime: 113284
+    Lane: 3
+    EndTime: 0
+  - StartTime: 113284
+    Lane: 4
+    EndTime: 0
+  - StartTime: 113389
+    Lane: 1
+    EndTime: 0
+  - StartTime: 113389
+    Lane: 2
+    EndTime: 0
+  - StartTime: 113495
+    Lane: 1
+    EndTime: 0
+  - StartTime: 113495
+    Lane: 4
+    EndTime: 0
+  - StartTime: 113495
+    Lane: 3
+    EndTime: 0
+  - StartTime: 113706
+    Lane: 2
+    EndTime: 0
+  - StartTime: 113918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 113918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 114129
+    Lane: 4
+    EndTime: 0
+  - StartTime: 114340
+    Lane: 2
+    EndTime: 0
+  - StartTime: 114340
+    Lane: 1
+    EndTime: 0
+  - StartTime: 114551
+    Lane: 3
+    EndTime: 0
+  - StartTime: 114763
+    Lane: 4
+    EndTime: 0
+  - StartTime: 114974
+    Lane: 1
+    EndTime: 0
+  - StartTime: 114974
+    Lane: 2
+    EndTime: 0
+  - StartTime: 115080
+    Lane: 3
+    EndTime: 0
+  - StartTime: 115080
+    Lane: 4
+    EndTime: 0
+  - StartTime: 115185
+    Lane: 1
+    EndTime: 0
+  - StartTime: 115185
+    Lane: 4
+    EndTime: 0
+  - StartTime: 115185
+    Lane: 2
+    EndTime: 0
+  - StartTime: 115397
+    Lane: 3
+    EndTime: 0
+  - StartTime: 115608
+    Lane: 1
+    EndTime: 0
+  - StartTime: 115608
+    Lane: 4
+    EndTime: 0
+  - StartTime: 115819
+    Lane: 3
+    EndTime: 0
+  - StartTime: 116030
+    Lane: 2
+    EndTime: 0
+  - StartTime: 116030
+    Lane: 4
+    EndTime: 0
+  - StartTime: 116242
+    Lane: 1
+    EndTime: 0
+  - StartTime: 116453
+    Lane: 2
+    EndTime: 0
+  - StartTime: 116664
+    Lane: 4
+    EndTime: 0
+  - StartTime: 116664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 116770
+    Lane: 2
+    EndTime: 0
+  - StartTime: 116770
+    Lane: 1
+    EndTime: 0
+  - StartTime: 116875
+    Lane: 1
+    EndTime: 0
+  - StartTime: 116875
+    Lane: 4
+    EndTime: 0
+  - StartTime: 116875
+    Lane: 3
+    EndTime: 0
+  - StartTime: 117087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 117298
+    Lane: 2
+    EndTime: 0
+  - StartTime: 117298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 117509
+    Lane: 1
+    EndTime: 0
+  - StartTime: 117720
+    Lane: 2
+    EndTime: 0
+  - StartTime: 117720
+    Lane: 4
+    EndTime: 0
+  - StartTime: 117932
+    Lane: 3
+    EndTime: 0
+  - StartTime: 118143
+    Lane: 4
+    EndTime: 0
+  - StartTime: 118354
+    Lane: 3
+    EndTime: 0
+  - StartTime: 118354
+    Lane: 1
+    EndTime: 0
+  - StartTime: 118460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 118460
+    Lane: 4
+    EndTime: 0
+  - StartTime: 118566
+    Lane: 4
+    EndTime: 0
+  - StartTime: 118566
+    Lane: 1
+    EndTime: 0
+  - StartTime: 118566
+    Lane: 3
+    EndTime: 0
+  - StartTime: 118777
+    Lane: 2
+    EndTime: 0
+  - StartTime: 118988
+    Lane: 4
+    EndTime: 0
+  - StartTime: 118988
+    Lane: 3
+    EndTime: 0
+  - StartTime: 119199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 119411
+    Lane: 4
+    EndTime: 0
+  - StartTime: 119411
+    Lane: 2
+    EndTime: 0
+  - StartTime: 119622
+    Lane: 3
+    EndTime: 0
+  - StartTime: 119833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 120044
+    Lane: 2
+    EndTime: 0
+  - StartTime: 120044
+    Lane: 3
+    EndTime: 0
+  - StartTime: 120150
+    Lane: 4
+    EndTime: 0
+  - StartTime: 120150
+    Lane: 1
+    EndTime: 0
+  - StartTime: 120256
+    Lane: 2
+    EndTime: 0
+  - StartTime: 120256
+    Lane: 3
+    EndTime: 0
+  - StartTime: 120256
+    Lane: 1
+    EndTime: 0
+  - StartTime: 120467
+    Lane: 4
+    EndTime: 0
+  - StartTime: 120678
+    Lane: 1
+    EndTime: 0
+  - StartTime: 120678
+    Lane: 3
+    EndTime: 0
+  - StartTime: 120889
+    Lane: 4
+    EndTime: 0
+  - StartTime: 121101
+    Lane: 2
+    EndTime: 0
+  - StartTime: 121101
+    Lane: 1
+    EndTime: 0
+  - StartTime: 121312
+    Lane: 4
+    EndTime: 0
+  - StartTime: 121523
+    Lane: 3
+    EndTime: 0
+  - StartTime: 121735
+    Lane: 1
+    EndTime: 0
+  - StartTime: 121735
+    Lane: 2
+    EndTime: 0
+  - StartTime: 121840
+    Lane: 3
+    EndTime: 0
+  - StartTime: 121840
+    Lane: 4
+    EndTime: 0
+  - StartTime: 121946
+    Lane: 1
+    EndTime: 0
+  - StartTime: 121946
+    Lane: 4
+    EndTime: 0
+  - StartTime: 121946
+    Lane: 2
+    EndTime: 0
+  - StartTime: 122157
+    Lane: 3
+    EndTime: 0
+  - StartTime: 122368
+    Lane: 2
+    EndTime: 0
+  - StartTime: 122368
+    Lane: 1
+    EndTime: 0
+  - StartTime: 122580
+    Lane: 4
+    EndTime: 0
+  - StartTime: 122791
+    Lane: 4
+    EndTime: 0
+  - StartTime: 122791
+    Lane: 2
+    EndTime: 0
+  - StartTime: 123002
+    Lane: 1
+    EndTime: 0
+  - StartTime: 123213
+    Lane: 3
+    EndTime: 0
+  - StartTime: 123425
+    Lane: 4
+    EndTime: 0
+  - StartTime: 123425
+    Lane: 2
+    EndTime: 0
+  - StartTime: 123530
+    Lane: 3
+    EndTime: 0
+  - StartTime: 123530
+    Lane: 1
+    EndTime: 0
+  - StartTime: 123636
+    Lane: 1
+    EndTime: 0
+  - StartTime: 123636
+    Lane: 4
+    EndTime: 0
+  - StartTime: 123636
+    Lane: 2
+    EndTime: 0
+  - StartTime: 123847
+    Lane: 3
+    EndTime: 0
+  - StartTime: 124058
+    Lane: 4
+    EndTime: 0
+  - StartTime: 124058
+    Lane: 2
+    EndTime: 0
+  - StartTime: 124270
+    Lane: 1
+    EndTime: 0
+  - StartTime: 124270
+    Lane: 3
+    EndTime: 0
+  - StartTime: 124481
+    Lane: 4
+    EndTime: 0
+  - StartTime: 124481
+    Lane: 2
+    EndTime: 0
+  - StartTime: 124692
+    Lane: 1
+    EndTime: 0
+  - StartTime: 124692
+    Lane: 3
+    EndTime: 0
+  - StartTime: 124904
+    Lane: 1
+    EndTime: 0
+  - StartTime: 124904
+    Lane: 4
+    EndTime: 0
+  - StartTime: 125009
+    Lane: 3
+    EndTime: 0
+  - StartTime: 125115
+    Lane: 1
+    EndTime: 0
+  - StartTime: 125220
+    Lane: 3
+    EndTime: 0
+  - StartTime: 125326
+    Lane: 4
+    EndTime: 0
+  - StartTime: 125326
+    Lane: 1
+    EndTime: 0
+  - StartTime: 125432
+    Lane: 2
+    EndTime: 0
+  - StartTime: 125537
+    Lane: 4
+    EndTime: 0
+  - StartTime: 125643
+    Lane: 2
+    EndTime: 0
+  - StartTime: 125749
+    Lane: 4
+    EndTime: 0
+  - StartTime: 125749
+    Lane: 1
+    EndTime: 0
+  - StartTime: 125749
+    Lane: 3
+    EndTime: 0
+  - StartTime: 125854
+    Lane: 1
+    EndTime: 0
+  - StartTime: 126065
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126065
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126065
+    Lane: 3
+    EndTime: 0
+  - StartTime: 126277
+    Lane: 1
+    EndTime: 0
+  - StartTime: 126277
+    Lane: 3
+    EndTime: 0
+  - StartTime: 126277
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126488
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126488
+    Lane: 3
+    EndTime: 0
+  - StartTime: 126488
+    Lane: 1
+    EndTime: 0
+  - StartTime: 126699
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126699
+    Lane: 3
+    EndTime: 0
+  - StartTime: 126805
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126805
+    Lane: 1
+    EndTime: 0
+  - StartTime: 126910
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126910
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127122
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127122
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127122
+    Lane: 4
+    EndTime: 0
+  - StartTime: 127333
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127333
+    Lane: 2
+    EndTime: 0
+  - StartTime: 127439
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127439
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127544
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127544
+    Lane: 2
+    EndTime: 0
+  - StartTime: 127756
+    Lane: 4
+    EndTime: 0
+  - StartTime: 127756
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127756
+    Lane: 2
+    EndTime: 0
+  - StartTime: 127967
+    Lane: 2
+    EndTime: 0
+  - StartTime: 127967
+    Lane: 4
+    EndTime: 0
+  - StartTime: 127967
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128178
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128178
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128178
+    Lane: 4
+    EndTime: 0
+  - StartTime: 128389
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128389
+    Lane: 2
+    EndTime: 0
+  - StartTime: 128495
+    Lane: 4
+    EndTime: 0
+  - StartTime: 128495
+    Lane: 2
+    EndTime: 0
+  - StartTime: 128601
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128601
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128706
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128706
+    Lane: 2
+    EndTime: 0
+  - StartTime: 128812
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128812
+    Lane: 4
+    EndTime: 0
+  - StartTime: 128918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129023
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129023
+    Lane: 3
+    EndTime: 0
+  - StartTime: 129129
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129129
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129234
+    Lane: 1
+    EndTime: 0
+  - StartTime: 129234
+    Lane: 3
+    EndTime: 0
+  - StartTime: 129446
+    Lane: 1
+    EndTime: 0
+  - StartTime: 129446
+    Lane: 3
+    EndTime: 0
+  - StartTime: 129446
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129657
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129657
+    Lane: 1
+    EndTime: 0
+  - StartTime: 129657
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129868
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129868
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129868
+    Lane: 3
+    EndTime: 0
+  - StartTime: 130079
+    Lane: 4
+    EndTime: 0
+  - StartTime: 130079
+    Lane: 1
+    EndTime: 0
+  - StartTime: 130185
+    Lane: 1
+    EndTime: 0
+  - StartTime: 130185
+    Lane: 3
+    EndTime: 0
+  - StartTime: 130291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 130291
+    Lane: 3
+    EndTime: 0
+  - StartTime: 130502
+    Lane: 1
+    EndTime: 0
+  - StartTime: 130502
+    Lane: 2
+    EndTime: 0
+  - StartTime: 130502
+    Lane: 4
+    EndTime: 0
+  - StartTime: 130713
+    Lane: 2
+    EndTime: 0
+  - StartTime: 130713
+    Lane: 3
+    EndTime: 0
+  - StartTime: 130819
+    Lane: 4
+    EndTime: 0
+  - StartTime: 130819
+    Lane: 2
+    EndTime: 0
+  - StartTime: 130925
+    Lane: 1
+    EndTime: 0
+  - StartTime: 130925
+    Lane: 4
+    EndTime: 0
+  - StartTime: 131136
+    Lane: 1
+    EndTime: 0
+  - StartTime: 131136
+    Lane: 2
+    EndTime: 0
+  - StartTime: 131136
+    Lane: 3
+    EndTime: 0
+  - StartTime: 131347
+    Lane: 4
+    EndTime: 0
+  - StartTime: 131347
+    Lane: 3
+    EndTime: 0
+  - StartTime: 131347
+    Lane: 2
+    EndTime: 0
+  - StartTime: 131558
+    Lane: 1
+    EndTime: 0
+  - StartTime: 131558
+    Lane: 2
+    EndTime: 0
+  - StartTime: 131558
+    Lane: 4
+    EndTime: 0
+  - StartTime: 131770
+    Lane: 1
+    EndTime: 0
+  - StartTime: 131770
+    Lane: 4
+    EndTime: 0
+  - StartTime: 131875
+    Lane: 4
+    EndTime: 0
+  - StartTime: 131875
+    Lane: 2
+    EndTime: 0
+  - StartTime: 131981
+    Lane: 1
+    EndTime: 0
+  - StartTime: 131981
+    Lane: 3
+    EndTime: 0
+  - StartTime: 132087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 132087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 132192
+    Lane: 2
+    EndTime: 0
+  - StartTime: 132192
+    Lane: 1
+    EndTime: 0
+  - StartTime: 132298
+    Lane: 2
+    EndTime: 0
+  - StartTime: 132298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 132403
+    Lane: 1
+    EndTime: 0
+  - StartTime: 132403
+    Lane: 3
+    EndTime: 0
+  - StartTime: 132509
+    Lane: 1
+    EndTime: 0
+  - StartTime: 132509
+    Lane: 4
+    EndTime: 0
+  - StartTime: 132615
+    Lane: 2
+    EndTime: 0
+  - StartTime: 132615
+    Lane: 4
+    EndTime: 0
+  - StartTime: 132826
+    Lane: 4
+    EndTime: 0
+  - StartTime: 132826
+    Lane: 1
+    EndTime: 0
+  - StartTime: 132826
+    Lane: 2
+    EndTime: 0
+  - StartTime: 133037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 133037
+    Lane: 3
+    EndTime: 0
+  - StartTime: 133037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 133249
+    Lane: 2
+    EndTime: 0
+  - StartTime: 133249
+    Lane: 4
+    EndTime: 0
+  - StartTime: 133249
+    Lane: 3
+    EndTime: 0
+  - StartTime: 133460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 133460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 133565
+    Lane: 4
+    EndTime: 0
+  - StartTime: 133565
+    Lane: 2
+    EndTime: 0
+  - StartTime: 133671
+    Lane: 3
+    EndTime: 0
+  - StartTime: 133671
+    Lane: 2
+    EndTime: 0
+  - StartTime: 133882
+    Lane: 1
+    EndTime: 0
+  - StartTime: 133882
+    Lane: 2
+    EndTime: 0
+  - StartTime: 133882
+    Lane: 4
+    EndTime: 0
+  - StartTime: 134094
+    Lane: 4
+    EndTime: 0
+  - StartTime: 134094
+    Lane: 1
+    EndTime: 0
+  - StartTime: 134199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 134199
+    Lane: 3
+    EndTime: 0
+  - StartTime: 134305
+    Lane: 2
+    EndTime: 0
+  - StartTime: 134305
+    Lane: 3
+    EndTime: 0
+  - StartTime: 134516
+    Lane: 3
+    EndTime: 0
+  - StartTime: 134516
+    Lane: 2
+    EndTime: 0
+  - StartTime: 134516
+    Lane: 1
+    EndTime: 0
+  - StartTime: 134727
+    Lane: 4
+    EndTime: 0
+  - StartTime: 134727
+    Lane: 2
+    EndTime: 0
+  - StartTime: 134727
+    Lane: 3
+    EndTime: 0
+  - StartTime: 134939
+    Lane: 2
+    EndTime: 0
+  - StartTime: 134939
+    Lane: 4
+    EndTime: 0
+  - StartTime: 134939
+    Lane: 1
+    EndTime: 0
+  - StartTime: 135150
+    Lane: 1
+    EndTime: 0
+  - StartTime: 135150
+    Lane: 3
+    EndTime: 0
+  - StartTime: 135256
+    Lane: 3
+    EndTime: 0
+  - StartTime: 135256
+    Lane: 2
+    EndTime: 0
+  - StartTime: 135361
+    Lane: 4
+    EndTime: 0
+  - StartTime: 135361
+    Lane: 1
+    EndTime: 0
+  - StartTime: 135467
+    Lane: 1
+    EndTime: 0
+  - StartTime: 135467
+    Lane: 3
+    EndTime: 0
+  - StartTime: 135572
+    Lane: 2
+    EndTime: 0
+  - StartTime: 135572
+    Lane: 4
+    EndTime: 0
+  - StartTime: 135678
+    Lane: 4
+    EndTime: 0
+  - StartTime: 135678
+    Lane: 3
+    EndTime: 0
+  - StartTime: 135784
+    Lane: 1
+    EndTime: 0
+  - StartTime: 135784
+    Lane: 2
+    EndTime: 0
+  - StartTime: 135889
+    Lane: 4
+    EndTime: 138425
+  - StartTime: 135889
+    Lane: 1
+    EndTime: 0
+  - StartTime: 135995
+    Lane: 2
+    EndTime: 0
+  - StartTime: 135995
+    Lane: 3
+    EndTime: 0
+  - StartTime: 136206
+    Lane: 3
+    EndTime: 0
+  - StartTime: 136206
+    Lane: 1
+    EndTime: 0
+  - StartTime: 136418
+    Lane: 2
+    EndTime: 0
+  - StartTime: 136418
+    Lane: 3
+    EndTime: 0
+  - StartTime: 136629
+    Lane: 2
+    EndTime: 0
+  - StartTime: 136629
+    Lane: 1
+    EndTime: 0
+  - StartTime: 136840
+    Lane: 3
+    EndTime: 0
+  - StartTime: 136946
+    Lane: 1
+    EndTime: 0
+  - StartTime: 136946
+    Lane: 3
+    EndTime: 0
+  - StartTime: 137051
+    Lane: 1
+    EndTime: 0
+  - StartTime: 137263
+    Lane: 2
+    EndTime: 0
+  - StartTime: 137263
+    Lane: 3
+    EndTime: 0
+  - StartTime: 137474
+    Lane: 1
+    EndTime: 0
+  - StartTime: 137579
+    Lane: 1
+    EndTime: 0
+  - StartTime: 137579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 137685
+    Lane: 3
+    EndTime: 0
+  - StartTime: 137896
+    Lane: 1
+    EndTime: 0
+  - StartTime: 138108
+    Lane: 2
+    EndTime: 0
+  - StartTime: 138319
+    Lane: 3
+    EndTime: 0
+  - StartTime: 138530
+    Lane: 2
+    EndTime: 0
+  - StartTime: 138530
+    Lane: 3
+    EndTime: 0
+  - StartTime: 138636
+    Lane: 1
+    EndTime: 0
+  - StartTime: 138636
+    Lane: 4
+    EndTime: 0
+  - StartTime: 138741
+    Lane: 2
+    EndTime: 0
+  - StartTime: 138741
+    Lane: 3
+    EndTime: 0
+  - StartTime: 138953
+    Lane: 1
+    EndTime: 0
+  - StartTime: 138953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 139058
+    Lane: 3
+    EndTime: 0
+  - StartTime: 139058
+    Lane: 4
+    EndTime: 0
+  - StartTime: 139164
+    Lane: 1
+    EndTime: 0
+  - StartTime: 139164
+    Lane: 4
+    EndTime: 0
+  - StartTime: 139164
+    Lane: 2
+    EndTime: 0
+  - StartTime: 139481
+    Lane: 4
+    EndTime: 0
+  - StartTime: 139587
+    Lane: 3
+    EndTime: 0
+  - StartTime: 139692
+    Lane: 4
+    EndTime: 0
+  - StartTime: 139692
+    Lane: 1
+    EndTime: 0
+  - StartTime: 139692
+    Lane: 2
+    EndTime: 0
+  - StartTime: 139798
+    Lane: 3
+    EndTime: 0
+  - StartTime: 139903
+    Lane: 2
+    EndTime: 0
+  - StartTime: 140115
+    Lane: 3
+    EndTime: 0
+  - StartTime: 140115
+    Lane: 1
+    EndTime: 0
+  - StartTime: 140326
+    Lane: 4
+    EndTime: 0
+  - StartTime: 140537
+    Lane: 1
+    EndTime: 0
+  - StartTime: 140537
+    Lane: 2
+    EndTime: 0
+  - StartTime: 140960
+    Lane: 2
+    EndTime: 0
+  - StartTime: 140960
+    Lane: 3
+    EndTime: 0
+  - StartTime: 141065
+    Lane: 1
+    EndTime: 0
+  - StartTime: 141171
+    Lane: 2
+    EndTime: 0
+  - StartTime: 141277
+    Lane: 3
+    EndTime: 0
+  - StartTime: 141277
+    Lane: 4
+    EndTime: 0
+  - StartTime: 141382
+    Lane: 2
+    EndTime: 0
+  - StartTime: 141594
+    Lane: 3
+    EndTime: 0
+  - StartTime: 141805
+    Lane: 1
+    EndTime: 142650
+  - StartTime: 141805
+    Lane: 4
+    EndTime: 142650
+  - StartTime: 142650
+    Lane: 3
+    EndTime: 0
+  - StartTime: 142966
+    Lane: 2
+    EndTime: 0
+  - StartTime: 143072
+    Lane: 1
+    EndTime: 0
+  - StartTime: 143072
+    Lane: 4
+    EndTime: 0
+  - StartTime: 143178
+    Lane: 3
+    EndTime: 0
+  - StartTime: 143283
+    Lane: 4
+    EndTime: 0
+  - StartTime: 143389
+    Lane: 1
+    EndTime: 0
+  - StartTime: 143442
+    Lane: 2
+    EndTime: 0
+  - StartTime: 143495
+    Lane: 3
+    EndTime: 0
+  - StartTime: 143600
+    Lane: 2
+    EndTime: 0
+  - StartTime: 143706
+    Lane: 1
+    EndTime: 0
+  - StartTime: 143776
+    Lane: 3
+    EndTime: 0
+  - StartTime: 143847
+    Lane: 4
+    EndTime: 0
+  - StartTime: 143917
+    Lane: 1
+    EndTime: 0
+  - StartTime: 144023
+    Lane: 2
+    EndTime: 0
+  - StartTime: 144128
+    Lane: 3
+    EndTime: 0
+  - StartTime: 144234
+    Lane: 1
+    EndTime: 0
+  - StartTime: 144340
+    Lane: 4
+    EndTime: 0
+  - StartTime: 144445
+    Lane: 3
+    EndTime: 0
+  - StartTime: 144551
+    Lane: 2
+    EndTime: 0
+  - StartTime: 144657
+    Lane: 1
+    EndTime: 0
+  - StartTime: 144762
+    Lane: 1
+    EndTime: 0
+  - StartTime: 144868
+    Lane: 2
+    EndTime: 0
+  - StartTime: 145026
+    Lane: 3
+    EndTime: 0
+  - StartTime: 145185
+    Lane: 1
+    EndTime: 146030
+  - StartTime: 145185
+    Lane: 4
+    EndTime: 146030
+  - StartTime: 146030
+    Lane: 3
+    EndTime: 0
+  - StartTime: 146135
+    Lane: 2
+    EndTime: 0
+  - StartTime: 146241
+    Lane: 4
+    EndTime: 0
+  - StartTime: 146346
+    Lane: 1
+    EndTime: 0
+  - StartTime: 146875
+    Lane: 4
+    EndTime: 0
+  - StartTime: 147086
+    Lane: 2
+    EndTime: 0
+  - StartTime: 147720
+    Lane: 1
+    EndTime: 0
+  - StartTime: 147931
+    Lane: 2
+    EndTime: 0
+  - StartTime: 148565
+    Lane: 2
+    EndTime: 0
+  - StartTime: 148776
+    Lane: 4
+    EndTime: 0
+  - StartTime: 149410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 149515
+    Lane: 2
+    EndTime: 0
+  - StartTime: 149621
+    Lane: 3
+    EndTime: 0
+  - StartTime: 149727
+    Lane: 2
+    EndTime: 0
+  - StartTime: 149832
+    Lane: 4
+    EndTime: 0
+  - StartTime: 150044
+    Lane: 3
+    EndTime: 0
+  - StartTime: 150149
+    Lane: 1
+    EndTime: 0
+  - StartTime: 150202
+    Lane: 2
+    EndTime: 0
+  - StartTime: 150308
+    Lane: 4
+    EndTime: 0
+  - StartTime: 150360
+    Lane: 3
+    EndTime: 0
+  - StartTime: 150572
+    Lane: 3
+    EndTime: 0
+  - StartTime: 151100
+    Lane: 4
+    EndTime: 151312
+  - StartTime: 151101
+    Lane: 1
+    EndTime: 151312
+  - StartTime: 151945
+    Lane: 1
+    EndTime: 0
+  - StartTime: 152367
+    Lane: 1
+    EndTime: 0
+  - StartTime: 152790
+    Lane: 1
+    EndTime: 0
+  - StartTime: 153212
+    Lane: 1
+    EndTime: 0
+  - StartTime: 153635
+    Lane: 4
+    EndTime: 0
+  - StartTime: 153635
+    Lane: 3
+    EndTime: 0
+  - StartTime: 153846
+    Lane: 1
+    EndTime: 0
+  - StartTime: 154058
+    Lane: 2
+    EndTime: 0
+  - StartTime: 154058
+    Lane: 3
+    EndTime: 0
+  - StartTime: 154269
+    Lane: 4
+    EndTime: 0
+  - StartTime: 154481
+    Lane: 1
+    EndTime: 0
+  - StartTime: 154481
+    Lane: 2
+    EndTime: 0
+  - StartTime: 154692
+    Lane: 3
+    EndTime: 0
+  - StartTime: 154904
+    Lane: 4
+    EndTime: 0
+  - StartTime: 154904
+    Lane: 2
+    EndTime: 0
+  - StartTime: 155115
+    Lane: 1
+    EndTime: 0
+  - StartTime: 155327
+    Lane: 4
+    EndTime: 0
+  - StartTime: 155327
+    Lane: 3
+    EndTime: 0
+  - StartTime: 155538
+    Lane: 2
+    EndTime: 0
+  - StartTime: 155750
+    Lane: 1
+    EndTime: 0
+  - StartTime: 155750
+    Lane: 4
+    EndTime: 0
+  - StartTime: 155961
+    Lane: 2
+    EndTime: 0
+  - StartTime: 156173
+    Lane: 3
+    EndTime: 0
+  - StartTime: 156173
+    Lane: 4
+    EndTime: 0
+  - StartTime: 156384
+    Lane: 2
+    EndTime: 0
+  - StartTime: 156596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 156596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 156807
+    Lane: 1
+    EndTime: 0
+  - StartTime: 157019
+    Lane: 4
+    EndTime: 0
+  - StartTime: 157019
+    Lane: 2
+    EndTime: 0
+  - StartTime: 157230
+    Lane: 3
+    EndTime: 0
+  - StartTime: 157442
+    Lane: 1
+    EndTime: 0
+  - StartTime: 157442
+    Lane: 4
+    EndTime: 0
+  - StartTime: 157653
+    Lane: 2
+    EndTime: 0
+  - StartTime: 157865
+    Lane: 3
+    EndTime: 0
+  - StartTime: 157865
+    Lane: 1
+    EndTime: 0
+  - StartTime: 158076
+    Lane: 2
+    EndTime: 0
+  - StartTime: 158288
+    Lane: 4
+    EndTime: 0
+  - StartTime: 158288
+    Lane: 3
+    EndTime: 0
+  - StartTime: 158499
+    Lane: 2
+    EndTime: 0
+  - StartTime: 158711
+    Lane: 1
+    EndTime: 0
+  - StartTime: 158711
+    Lane: 4
+    EndTime: 0
+  - StartTime: 158922
+    Lane: 3
+    EndTime: 0
+  - StartTime: 159134
+    Lane: 1
+    EndTime: 0
+  - StartTime: 159134
+    Lane: 2
+    EndTime: 0
+  - StartTime: 159345
+    Lane: 3
+    EndTime: 0
+  - StartTime: 159557
+    Lane: 4
+    EndTime: 0
+  - StartTime: 159557
+    Lane: 1
+    EndTime: 0
+  - StartTime: 159768
+    Lane: 2
+    EndTime: 0
+  - StartTime: 159980
+    Lane: 4
+    EndTime: 0
+  - StartTime: 159980
+    Lane: 3
+    EndTime: 0
+  - StartTime: 160191
+    Lane: 1
+    EndTime: 0
+  - StartTime: 160403
+    Lane: 4
+    EndTime: 0
+  - StartTime: 160403
+    Lane: 3
+    EndTime: 0
+  - StartTime: 160614
+    Lane: 2
+    EndTime: 0
+  - StartTime: 160826
+    Lane: 1
+    EndTime: 0
+  - StartTime: 160826
+    Lane: 3
+    EndTime: 0
+  - StartTime: 161037
+    Lane: 2
+    EndTime: 0
+  - StartTime: 161249
+    Lane: 4
+    EndTime: 0
+  - StartTime: 161249
+    Lane: 1
+    EndTime: 0
+  - StartTime: 161460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 161672
+    Lane: 2
+    EndTime: 0
+  - StartTime: 161672
+    Lane: 1
+    EndTime: 0
+  - StartTime: 161883
+    Lane: 4
+    EndTime: 0
+  - StartTime: 162095
+    Lane: 1
+    EndTime: 0
+  - StartTime: 162095
+    Lane: 3
+    EndTime: 0
+  - StartTime: 162306
+    Lane: 4
+    EndTime: 0
+  - StartTime: 162518
+    Lane: 2
+    EndTime: 0
+  - StartTime: 162518
+    Lane: 1
+    EndTime: 0
+  - StartTime: 162729
+    Lane: 3
+    EndTime: 0
+  - StartTime: 162941
+    Lane: 1
+    EndTime: 0
+  - StartTime: 162941
+    Lane: 4
+    EndTime: 0
+  - StartTime: 163152
+    Lane: 2
+    EndTime: 0
+  - StartTime: 163364
+    Lane: 3
+    EndTime: 0
+  - StartTime: 163364
+    Lane: 1
+    EndTime: 0
+  - StartTime: 163575
+    Lane: 2
+    EndTime: 0
+  - StartTime: 163787
+    Lane: 3
+    EndTime: 0
+  - StartTime: 163787
+    Lane: 4
+    EndTime: 0
+  - StartTime: 163998
+    Lane: 2
+    EndTime: 0
+  - StartTime: 164210
+    Lane: 1
+    EndTime: 0
+  - StartTime: 164210
+    Lane: 4
+    EndTime: 0
+  - StartTime: 164421
+    Lane: 3
+    EndTime: 0
+  - StartTime: 164633
+    Lane: 4
+    EndTime: 0
+  - StartTime: 164633
+    Lane: 1
+    EndTime: 0
+  - StartTime: 164844
+    Lane: 2
+    EndTime: 0
+  - StartTime: 165055
+    Lane: 1
+    EndTime: 0
+  - StartTime: 165055
+    Lane: 4
+    EndTime: 0
+  - StartTime: 165266
+    Lane: 3
+    EndTime: 0
+  - StartTime: 165466
+    Lane: 1
+    EndTime: 0
+  - StartTime: 165888
+    Lane: 1
+    EndTime: 0
+  - StartTime: 166311
+    Lane: 1
+    EndTime: 0
+  - StartTime: 166733
+    Lane: 1
+    EndTime: 0
+  - StartTime: 167157
+    Lane: 4
+    EndTime: 0
+  - StartTime: 167368
+    Lane: 2
+    EndTime: 0
+  - StartTime: 167368
+    Lane: 3
+    EndTime: 0
+  - StartTime: 167579
+    Lane: 1
+    EndTime: 0
+  - StartTime: 167790
+    Lane: 2
+    EndTime: 0
+  - StartTime: 167790
+    Lane: 4
+    EndTime: 0
+  - StartTime: 168002
+    Lane: 3
+    EndTime: 0
+  - StartTime: 168213
+    Lane: 1
+    EndTime: 0
+  - StartTime: 168213
+    Lane: 2
+    EndTime: 0
+  - StartTime: 168424
+    Lane: 3
+    EndTime: 0
+  - StartTime: 168635
+    Lane: 2
+    EndTime: 0
+  - StartTime: 168635
+    Lane: 1
+    EndTime: 0
+  - StartTime: 168847
+    Lane: 4
+    EndTime: 0
+  - StartTime: 169058
+    Lane: 3
+    EndTime: 0
+  - StartTime: 169058
+    Lane: 4
+    EndTime: 0
+  - StartTime: 169269
+    Lane: 2
+    EndTime: 0
+  - StartTime: 169481
+    Lane: 1
+    EndTime: 0
+  - StartTime: 169481
+    Lane: 2
+    EndTime: 0
+  - StartTime: 169692
+    Lane: 1
+    EndTime: 0
+  - StartTime: 169692
+    Lane: 4
+    EndTime: 0
+  - StartTime: 169903
+    Lane: 3
+    EndTime: 0
+  - StartTime: 170114
+    Lane: 1
+    EndTime: 0
+  - StartTime: 170114
+    Lane: 3
+    EndTime: 0
+  - StartTime: 170326
+    Lane: 4
+    EndTime: 0
+  - StartTime: 170537
+    Lane: 2
+    EndTime: 0
+  - StartTime: 170748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 170748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 170959
+    Lane: 3
+    EndTime: 0
+  - StartTime: 171170
+    Lane: 2
+    EndTime: 0
+  - StartTime: 171170
+    Lane: 3
+    EndTime: 0
+  - StartTime: 171382
+    Lane: 4
+    EndTime: 0
+  - StartTime: 171593
+    Lane: 4
+    EndTime: 0
+  - StartTime: 171593
+    Lane: 3
+    EndTime: 0
+  - StartTime: 171804
+    Lane: 2
+    EndTime: 0
+  - StartTime: 172015
+    Lane: 1
+    EndTime: 0
+  - StartTime: 172015
+    Lane: 4
+    EndTime: 0
+  - StartTime: 172227
+    Lane: 3
+    EndTime: 0
+  - StartTime: 172438
+    Lane: 3
+    EndTime: 0
+  - StartTime: 172649
+    Lane: 2
+    EndTime: 0
+  - StartTime: 172860
+    Lane: 2
+    EndTime: 0
+  - StartTime: 173072
+    Lane: 1
+    EndTime: 0
+  - StartTime: 173283
+    Lane: 4
+    EndTime: 0
+  - StartTime: 173494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 173494
+    Lane: 1
+    EndTime: 0
+  - StartTime: 173706
+    Lane: 1
+    EndTime: 0
+  - StartTime: 173706
+    Lane: 3
+    EndTime: 0
+  - StartTime: 173917
+    Lane: 4
+    EndTime: 0
+  - StartTime: 173917
+    Lane: 2
+    EndTime: 0
+  - StartTime: 174128
+    Lane: 3
+    EndTime: 0
+  - StartTime: 174339
+    Lane: 1
+    EndTime: 0
+  - StartTime: 174339
+    Lane: 3
+    EndTime: 0
+  - StartTime: 174550
+    Lane: 2
+    EndTime: 0
+  - StartTime: 174762
+    Lane: 4
+    EndTime: 0
+  - StartTime: 174762
+    Lane: 3
+    EndTime: 0
+  - StartTime: 174973
+    Lane: 2
+    EndTime: 0
+  - StartTime: 175184
+    Lane: 4
+    EndTime: 0
+  - StartTime: 175184
+    Lane: 3
+    EndTime: 0
+  - StartTime: 175395
+    Lane: 1
+    EndTime: 0
+  - StartTime: 175607
+    Lane: 3
+    EndTime: 0
+  - StartTime: 175607
+    Lane: 2
+    EndTime: 0
+  - StartTime: 175607
+    Lane: 1
+    EndTime: 0
+  - StartTime: 176030
+    Lane: 3
+    EndTime: 0
+  - StartTime: 176030
+    Lane: 2
+    EndTime: 0
+  - StartTime: 176030
+    Lane: 4
+    EndTime: 0
+  - StartTime: 176452
+    Lane: 2
+    EndTime: 0
+  - StartTime: 176452
+    Lane: 1
+    EndTime: 0
+  - StartTime: 176664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 176664
+    Lane: 4
+    EndTime: 0
+  - StartTime: 176875
+    Lane: 1
+    EndTime: 0
+  - StartTime: 176875
+    Lane: 4
+    EndTime: 0
+  - StartTime: 177086
+    Lane: 3
+    EndTime: 0
+  - StartTime: 177086
+    Lane: 1
+    EndTime: 0
+  - StartTime: 177297
+    Lane: 4
+    EndTime: 0
+  - StartTime: 177297
+    Lane: 2
+    EndTime: 0
+  - StartTime: 177720
+    Lane: 2
+    EndTime: 0
+  - StartTime: 177720
+    Lane: 3
+    EndTime: 0
+  - StartTime: 178143
+    Lane: 4
+    EndTime: 0
+  - StartTime: 178565
+    Lane: 1
+    EndTime: 0
+  - StartTime: 178988
+    Lane: 2
+    EndTime: 180678
+  - StartTime: 178988
+    Lane: 3
+    EndTime: 180678
+  - StartTime: 180678
+    Lane: 4
+    EndTime: 0
+  - StartTime: 180678
+    Lane: 1
+    EndTime: 0
+  - StartTime: 180889
+    Lane: 4
+    EndTime: 0
+  - StartTime: 181100
+    Lane: 2
+    EndTime: 0
+  - StartTime: 181311
+    Lane: 3
+    EndTime: 0
+  - StartTime: 181523
+    Lane: 1
+    EndTime: 0
+  - StartTime: 181523
+    Lane: 4
+    EndTime: 0
+  - StartTime: 181734
+    Lane: 2
+    EndTime: 0
+  - StartTime: 181839
+    Lane: 4
+    EndTime: 0
+  - StartTime: 182156
+    Lane: 2
+    EndTime: 0
+  - StartTime: 182156
+    Lane: 3
+    EndTime: 0
+  - StartTime: 182156
+    Lane: 1
+    EndTime: 0
+  - StartTime: 182368
+    Lane: 2
+    EndTime: 0
+  - StartTime: 182368
+    Lane: 3
+    EndTime: 0
+  - StartTime: 182368
+    Lane: 4
+    EndTime: 0
+  - StartTime: 182579
+    Lane: 1
+    EndTime: 0
+  - StartTime: 182790
+    Lane: 2
+    EndTime: 0
+  - StartTime: 183001
+    Lane: 3
+    EndTime: 0
+  - StartTime: 183001
+    Lane: 1
+    EndTime: 0
+  - StartTime: 183213
+    Lane: 4
+    EndTime: 0
+  - StartTime: 183213
+    Lane: 2
+    EndTime: 0
+  - StartTime: 183424
+    Lane: 3
+    EndTime: 0
+  - StartTime: 183530
+    Lane: 4
+    EndTime: 0
+  - StartTime: 183635
+    Lane: 1
+    EndTime: 0
+  - StartTime: 183635
+    Lane: 2
+    EndTime: 0
+  - StartTime: 183635
+    Lane: 3
+    EndTime: 0
+  - StartTime: 183847
+    Lane: 4
+    EndTime: 0
+  - StartTime: 183847
+    Lane: 1
+    EndTime: 0
+  - StartTime: 183847
+    Lane: 2
+    EndTime: 0
+  - StartTime: 184058
+    Lane: 1
+    EndTime: 0
+  - StartTime: 184058
+    Lane: 3
+    EndTime: 0
+  - StartTime: 184058
+    Lane: 4
+    EndTime: 0
+  - StartTime: 184269
+    Lane: 2
+    EndTime: 0
+  - StartTime: 184480
+    Lane: 3
+    EndTime: 0
+  - StartTime: 184692
+    Lane: 2
+    EndTime: 0
+  - StartTime: 184903
+    Lane: 1
+    EndTime: 0
+  - StartTime: 184903
+    Lane: 3
+    EndTime: 0
+  - StartTime: 185114
+    Lane: 4
+    EndTime: 0
+  - StartTime: 185220
+    Lane: 2
+    EndTime: 0
+  - StartTime: 185325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 185325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 185325
+    Lane: 4
+    EndTime: 0
+  - StartTime: 185537
+    Lane: 4
+    EndTime: 0
+  - StartTime: 185537
+    Lane: 1
+    EndTime: 0
+  - StartTime: 185537
+    Lane: 2
+    EndTime: 0
+  - StartTime: 185642
+    Lane: 3
+    EndTime: 0
+  - StartTime: 185748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 185748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 185748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 185959
+    Lane: 3
+    EndTime: 0
+  - StartTime: 186170
+    Lane: 2
+    EndTime: 0
+  - StartTime: 186170
+    Lane: 4
+    EndTime: 0
+  - StartTime: 186382
+    Lane: 1
+    EndTime: 0
+  - StartTime: 186593
+    Lane: 4
+    EndTime: 0
+  - StartTime: 186804
+    Lane: 2
+    EndTime: 0
+  - StartTime: 186910
+    Lane: 1
+    EndTime: 0
+  - StartTime: 187016
+    Lane: 4
+    EndTime: 0
+  - StartTime: 187068
+    Lane: 3
+    EndTime: 0
+  - StartTime: 187121
+    Lane: 1
+    EndTime: 0
+  - StartTime: 187174
+    Lane: 2
+    EndTime: 0
+  - StartTime: 187227
+    Lane: 4
+    EndTime: 0
+  - StartTime: 187280
+    Lane: 3
+    EndTime: 0
+  - StartTime: 187332
+    Lane: 1
+    EndTime: 0
+  - StartTime: 187385
+    Lane: 2
+    EndTime: 0
+  - StartTime: 187438
+    Lane: 4
+    EndTime: 0
+  - StartTime: 187438
+    Lane: 3
+    EndTime: 0
+  - StartTime: 187544
+    Lane: 2
+    EndTime: 0
+  - StartTime: 187649
+    Lane: 1
+    EndTime: 0
+  - StartTime: 187649
+    Lane: 3
+    EndTime: 0
+  - StartTime: 187755
+    Lane: 2
+    EndTime: 0
+  - StartTime: 187861
+    Lane: 4
+    EndTime: 0
+  - StartTime: 187861
+    Lane: 3
+    EndTime: 0
+  - StartTime: 187966
+    Lane: 2
+    EndTime: 0
+  - StartTime: 188072
+    Lane: 4
+    EndTime: 0
+  - StartTime: 188072
+    Lane: 1
+    EndTime: 0
+  - StartTime: 188178
+    Lane: 3
+    EndTime: 0
+  - StartTime: 188283
+    Lane: 2
+    EndTime: 0
+  - StartTime: 188283
+    Lane: 4
+    EndTime: 0
+  - StartTime: 188389
+    Lane: 1
+    EndTime: 0
+  - StartTime: 188494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 188494
+    Lane: 2
+    EndTime: 0
+  - StartTime: 188600
+    Lane: 1
+    EndTime: 0
+  - StartTime: 188600
+    Lane: 3
+    EndTime: 0
+  - StartTime: 188706
+    Lane: 2
+    EndTime: 0
+  - StartTime: 188706
+    Lane: 1
+    EndTime: 0
+  - StartTime: 188706
+    Lane: 4
+    EndTime: 0
+  - StartTime: 188917
+    Lane: 2
+    EndTime: 0
+  - StartTime: 188917
+    Lane: 3
+    EndTime: 0
+  - StartTime: 188917
+    Lane: 1
+    EndTime: 0
+  - StartTime: 189128
+    Lane: 2
+    EndTime: 0
+  - StartTime: 189128
+    Lane: 4
+    EndTime: 0
+  - StartTime: 189128
+    Lane: 3
+    EndTime: 0
+  - StartTime: 189234
+    Lane: 1
+    EndTime: 0
+  - StartTime: 189339
+    Lane: 3
+    EndTime: 0
+  - StartTime: 189339
+    Lane: 4
+    EndTime: 0
+  - StartTime: 189445
+    Lane: 2
+    EndTime: 0
+  - StartTime: 189551
+    Lane: 4
+    EndTime: 0
+  - StartTime: 189551
+    Lane: 1
+    EndTime: 0
+  - StartTime: 189656
+    Lane: 3
+    EndTime: 0
+  - StartTime: 189762
+    Lane: 4
+    EndTime: 0
+  - StartTime: 189762
+    Lane: 1
+    EndTime: 0
+  - StartTime: 189868
+    Lane: 2
+    EndTime: 0
+  - StartTime: 189973
+    Lane: 3
+    EndTime: 0
+  - StartTime: 189973
+    Lane: 1
+    EndTime: 0
+  - StartTime: 190079
+    Lane: 4
+    EndTime: 0
+  - StartTime: 190185
+    Lane: 1
+    EndTime: 0
+  - StartTime: 190185
+    Lane: 3
+    EndTime: 0
+  - StartTime: 190290
+    Lane: 4
+    EndTime: 0
+  - StartTime: 190290
+    Lane: 2
+    EndTime: 0
+  - StartTime: 190396
+    Lane: 1
+    EndTime: 0
+  - StartTime: 190396
+    Lane: 3
+    EndTime: 0
+  - StartTime: 190396
+    Lane: 4
+    EndTime: 0
+  - StartTime: 190607
+    Lane: 1
+    EndTime: 0
+  - StartTime: 190607
+    Lane: 4
+    EndTime: 0
+  - StartTime: 190607
+    Lane: 2
+    EndTime: 0
+  - StartTime: 190818
+    Lane: 3
+    EndTime: 0
+  - StartTime: 190818
+    Lane: 2
+    EndTime: 0
+  - StartTime: 190818
+    Lane: 4
+    EndTime: 0
+  - StartTime: 190924
+    Lane: 1
+    EndTime: 0
+  - StartTime: 191030
+    Lane: 3
+    EndTime: 0
+  - StartTime: 191030
+    Lane: 4
+    EndTime: 0
+  - StartTime: 191135
+    Lane: 2
+    EndTime: 0
+  - StartTime: 191241
+    Lane: 1
+    EndTime: 0
+  - StartTime: 191241
+    Lane: 3
+    EndTime: 0
+  - StartTime: 191347
+    Lane: 4
+    EndTime: 0
+  - StartTime: 191452
+    Lane: 2
+    EndTime: 0
+  - StartTime: 191452
+    Lane: 3
+    EndTime: 0
+  - StartTime: 191558
+    Lane: 1
+    EndTime: 0
+  - StartTime: 191663
+    Lane: 2
+    EndTime: 0
+  - StartTime: 191663
+    Lane: 3
+    EndTime: 0
+  - StartTime: 191769
+    Lane: 4
+    EndTime: 0
+  - StartTime: 191875
+    Lane: 1
+    EndTime: 0
+  - StartTime: 191875
+    Lane: 3
+    EndTime: 0
+  - StartTime: 191980
+    Lane: 2
+    EndTime: 0
+  - StartTime: 192086
+    Lane: 1
+    EndTime: 0
+  - StartTime: 192086
+    Lane: 3
+    EndTime: 0
+  - StartTime: 192192
+    Lane: 4
+    EndTime: 0
+  - StartTime: 192297
+    Lane: 1
+    EndTime: 0
+  - StartTime: 192297
+    Lane: 3
+    EndTime: 0
+  - StartTime: 192508
+    Lane: 1
+    EndTime: 0
+  - StartTime: 192508
+    Lane: 2
+    EndTime: 0
+  - StartTime: 192508
+    Lane: 3
+    EndTime: 0
+  - StartTime: 192720
+    Lane: 4
+    EndTime: 0
+  - StartTime: 192720
+    Lane: 3
+    EndTime: 0
+  - StartTime: 192720
+    Lane: 2
+    EndTime: 0
+  - StartTime: 192931
+    Lane: 1
+    EndTime: 0
+  - StartTime: 192931
+    Lane: 2
+    EndTime: 0
+  - StartTime: 192931
+    Lane: 4
+    EndTime: 0
+  - StartTime: 193142
+    Lane: 4
+    EndTime: 0
+  - StartTime: 193142
+    Lane: 3
+    EndTime: 0
+  - StartTime: 193142
+    Lane: 1
+    EndTime: 0
+  - StartTime: 193354
+    Lane: 1
+    EndTime: 0
+  - StartTime: 193354
+    Lane: 4
+    EndTime: 0
+  - StartTime: 193459
+    Lane: 3
+    EndTime: 0
+  - StartTime: 193459
+    Lane: 2
+    EndTime: 0
+  - StartTime: 193565
+    Lane: 1
+    EndTime: 0
+  - StartTime: 193565
+    Lane: 4
+    EndTime: 0
+  - StartTime: 193670
+    Lane: 2
+    EndTime: 0
+  - StartTime: 193670
+    Lane: 3
+    EndTime: 0
+  - StartTime: 193776
+    Lane: 4
+    EndTime: 0
+  - StartTime: 193776
+    Lane: 1
+    EndTime: 0
+  - StartTime: 193882
+    Lane: 3
+    EndTime: 0
+  - StartTime: 193882
+    Lane: 2
+    EndTime: 0
+  - StartTime: 193987
+    Lane: 1
+    EndTime: 0
+  - StartTime: 193987
+    Lane: 4
+    EndTime: 0
+  - StartTime: 194093
+    Lane: 2
+    EndTime: 0
+  - StartTime: 194093
+    Lane: 3
+    EndTime: 0
+  - StartTime: 194199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 194199
+    Lane: 4
+    EndTime: 0
+  - StartTime: 194304
+    Lane: 3
+    EndTime: 0
+  - StartTime: 194410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 194410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 194515
+    Lane: 1
+    EndTime: 0
+  - StartTime: 194621
+    Lane: 2
+    EndTime: 0
+  - StartTime: 194621
+    Lane: 3
+    EndTime: 0
+  - StartTime: 194621
+    Lane: 4
+    EndTime: 0
+  - StartTime: 194727
+    Lane: 1
+    EndTime: 0
+  - StartTime: 194832
+    Lane: 2
+    EndTime: 0
+  - StartTime: 194832
+    Lane: 4
+    EndTime: 0
+  - StartTime: 194938
+    Lane: 3
+    EndTime: 0
+  - StartTime: 195044
+    Lane: 2
+    EndTime: 0
+  - StartTime: 195044
+    Lane: 4
+    EndTime: 0
+  - StartTime: 195149
+    Lane: 1
+    EndTime: 0
+  - StartTime: 195255
+    Lane: 3
+    EndTime: 0
+  - StartTime: 195255
+    Lane: 4
+    EndTime: 0
+  - StartTime: 195360
+    Lane: 1
+    EndTime: 0
+  - StartTime: 195360
+    Lane: 2
+    EndTime: 0
+  - StartTime: 195466
+    Lane: 3
+    EndTime: 0
+  - StartTime: 195466
+    Lane: 1
+    EndTime: 0
+  - StartTime: 195466
+    Lane: 4
+    EndTime: 0
+  - StartTime: 195572
+    Lane: 2
+    EndTime: 0
+  - StartTime: 195677
+    Lane: 1
+    EndTime: 0
+  - StartTime: 195677
+    Lane: 4
+    EndTime: 0
+  - StartTime: 195783
+    Lane: 3
+    EndTime: 0
+  - StartTime: 195889
+    Lane: 2
+    EndTime: 0
+  - StartTime: 195889
+    Lane: 4
+    EndTime: 0
+  - StartTime: 195994
+    Lane: 1
+    EndTime: 0
+  - StartTime: 196100
+    Lane: 2
+    EndTime: 0
+  - StartTime: 196100
+    Lane: 3
+    EndTime: 0
+  - StartTime: 196206
+    Lane: 4
+    EndTime: 0
+  - StartTime: 196311
+    Lane: 1
+    EndTime: 0
+  - StartTime: 196311
+    Lane: 2
+    EndTime: 0
+  - StartTime: 196311
+    Lane: 3
+    EndTime: 0
+  - StartTime: 196417
+    Lane: 4
+    EndTime: 0
+  - StartTime: 196522
+    Lane: 2
+    EndTime: 0
+  - StartTime: 196522
+    Lane: 1
+    EndTime: 0
+  - StartTime: 196628
+    Lane: 3
+    EndTime: 0
+  - StartTime: 196734
+    Lane: 4
+    EndTime: 0
+  - StartTime: 196734
+    Lane: 1
+    EndTime: 0
+  - StartTime: 196839
+    Lane: 3
+    EndTime: 0
+  - StartTime: 196945
+    Lane: 1
+    EndTime: 0
+  - StartTime: 196945
+    Lane: 2
+    EndTime: 0
+  - StartTime: 197051
+    Lane: 3
+    EndTime: 0
+  - StartTime: 197051
+    Lane: 4
+    EndTime: 0
+  - StartTime: 197156
+    Lane: 2
+    EndTime: 0
+  - StartTime: 197156
+    Lane: 4
+    EndTime: 0
+  - StartTime: 197156
+    Lane: 1
+    EndTime: 0
+  - StartTime: 197262
+    Lane: 3
+    EndTime: 0
+  - StartTime: 197368
+    Lane: 1
+    EndTime: 0
+  - StartTime: 197368
+    Lane: 2
+    EndTime: 0
+  - StartTime: 197473
+    Lane: 4
+    EndTime: 0
+  - StartTime: 197579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 197579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 197684
+    Lane: 4
+    EndTime: 0
+  - StartTime: 197790
+    Lane: 1
+    EndTime: 0
+  - StartTime: 197790
+    Lane: 2
+    EndTime: 0
+  - StartTime: 197896
+    Lane: 3
+    EndTime: 0
+  - StartTime: 198001
+    Lane: 4
+    EndTime: 0
+  - StartTime: 198001
+    Lane: 1
+    EndTime: 0
+  - StartTime: 198001
+    Lane: 2
+    EndTime: 0
+  - StartTime: 198107
+    Lane: 3
+    EndTime: 0
+  - StartTime: 198213
+    Lane: 1
+    EndTime: 0
+  - StartTime: 198213
+    Lane: 2
+    EndTime: 0
+  - StartTime: 198318
+    Lane: 4
+    EndTime: 0
+  - StartTime: 198424
+    Lane: 1
+    EndTime: 0
+  - StartTime: 198424
+    Lane: 3
+    EndTime: 0
+  - StartTime: 198529
+    Lane: 2
+    EndTime: 0
+  - StartTime: 198635
+    Lane: 1
+    EndTime: 0
+  - StartTime: 198635
+    Lane: 3
+    EndTime: 0
+  - StartTime: 198741
+    Lane: 2
+    EndTime: 0
+  - StartTime: 198741
+    Lane: 4
+    EndTime: 0
+  - StartTime: 198846
+    Lane: 3
+    EndTime: 0
+  - StartTime: 198846
+    Lane: 1
+    EndTime: 0
+  - StartTime: 198846
+    Lane: 4
+    EndTime: 0
+  - StartTime: 198952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 199058
+    Lane: 3
+    EndTime: 0
+  - StartTime: 199058
+    Lane: 4
+    EndTime: 0
+  - StartTime: 199163
+    Lane: 1
+    EndTime: 0
+  - StartTime: 199269
+    Lane: 2
+    EndTime: 0
+  - StartTime: 199269
+    Lane: 4
+    EndTime: 0
+  - StartTime: 199375
+    Lane: 3
+    EndTime: 0
+  - StartTime: 199480
+    Lane: 1
+    EndTime: 0
+  - StartTime: 199480
+    Lane: 4
+    EndTime: 0
+  - StartTime: 199586
+    Lane: 3
+    EndTime: 0
+  - StartTime: 199691
+    Lane: 1
+    EndTime: 0
+  - StartTime: 199691
+    Lane: 2
+    EndTime: 0
+  - StartTime: 199797
+    Lane: 4
+    EndTime: 0
+  - StartTime: 199903
+    Lane: 1
+    EndTime: 0
+  - StartTime: 199903
+    Lane: 3
+    EndTime: 0
+  - StartTime: 200008
+    Lane: 2
+    EndTime: 0
+  - StartTime: 200114
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200114
+    Lane: 3
+    EndTime: 0
+  - StartTime: 200220
+    Lane: 2
+    EndTime: 0
+  - StartTime: 200325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 200325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 200431
+    Lane: 2
+    EndTime: 0
+  - StartTime: 200431
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200537
+    Lane: 1
+    EndTime: 0
+  - StartTime: 200537
+    Lane: 3
+    EndTime: 0
+  - StartTime: 200537
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200642
+    Lane: 2
+    EndTime: 0
+  - StartTime: 200748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 200748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200853
+    Lane: 1
+    EndTime: 0
+  - StartTime: 200959
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200959
+    Lane: 2
+    EndTime: 0
+  - StartTime: 200959
+    Lane: 3
+    EndTime: 0
+  - StartTime: 201065
+    Lane: 1
+    EndTime: 0
+  - StartTime: 201170
+    Lane: 2
+    EndTime: 0
+  - StartTime: 201170
+    Lane: 3
+    EndTime: 0
+  - StartTime: 201276
+    Lane: 4
+    EndTime: 0
+  - StartTime: 201382
+    Lane: 1
+    EndTime: 0
+  - StartTime: 201382
+    Lane: 2
+    EndTime: 0
+  - StartTime: 201487
+    Lane: 3
+    EndTime: 0
+  - StartTime: 201593
+    Lane: 4
+    EndTime: 0
+  - StartTime: 201593
+    Lane: 2
+    EndTime: 0
+  - StartTime: 201699
+    Lane: 3
+    EndTime: 0
+  - StartTime: 201804
+    Lane: 1
+    EndTime: 0
+  - StartTime: 201804
+    Lane: 4
+    EndTime: 0
+  - StartTime: 201910
+    Lane: 2
+    EndTime: 0
+  - StartTime: 202015
+    Lane: 3
+    EndTime: 0
+  - StartTime: 202015
+    Lane: 4
+    EndTime: 0
+  - StartTime: 202121
+    Lane: 1
+    EndTime: 0
+  - StartTime: 202121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 202227
+    Lane: 4
+    EndTime: 0
+  - StartTime: 202227
+    Lane: 1
+    EndTime: 0
+  - StartTime: 202227
+    Lane: 3
+    EndTime: 0
+  - StartTime: 202332
+    Lane: 2
+    EndTime: 0
+  - StartTime: 202438
+    Lane: 1
+    EndTime: 0
+  - StartTime: 202438
+    Lane: 4
+    EndTime: 0
+  - StartTime: 202544
+    Lane: 3
+    EndTime: 0
+  - StartTime: 202649
+    Lane: 2
+    EndTime: 0
+  - StartTime: 202649
+    Lane: 4
+    EndTime: 0
+  - StartTime: 202755
+    Lane: 1
+    EndTime: 0
+  - StartTime: 202860
+    Lane: 2
+    EndTime: 0
+  - StartTime: 202860
+    Lane: 4
+    EndTime: 0
+  - StartTime: 202966
+    Lane: 3
+    EndTime: 0
+  - StartTime: 203072
+    Lane: 1
+    EndTime: 0
+  - StartTime: 203072
+    Lane: 2
+    EndTime: 0
+  - StartTime: 203177
+    Lane: 4
+    EndTime: 0
+  - StartTime: 203283
+    Lane: 1
+    EndTime: 0
+  - StartTime: 203283
+    Lane: 3
+    EndTime: 0
+  - StartTime: 203389
+    Lane: 2
+    EndTime: 0
+  - StartTime: 203494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 203494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 203600
+    Lane: 1
+    EndTime: 0
+  - StartTime: 203600
+    Lane: 2
+    EndTime: 0
+  - StartTime: 203706
+    Lane: 3
+    EndTime: 0
+  - StartTime: 203706
+    Lane: 4
+    EndTime: 0
+  - StartTime: 203811
+    Lane: 1
+    EndTime: 0
+  - StartTime: 203811
+    Lane: 4
+    EndTime: 0
+  - StartTime: 203811
+    Lane: 2
+    EndTime: 0
+  - StartTime: 203917
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204022
+    Lane: 2
+    EndTime: 0
+  - StartTime: 204128
+    Lane: 1
+    EndTime: 0
+  - StartTime: 204128
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204234
+    Lane: 4
+    EndTime: 0
+  - StartTime: 204339
+    Lane: 2
+    EndTime: 0
+  - StartTime: 204445
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204551
+    Lane: 1
+    EndTime: 0
+  - StartTime: 204551
+    Lane: 2
+    EndTime: 0
+  - StartTime: 204656
+    Lane: 4
+    EndTime: 0
+  - StartTime: 204762
+    Lane: 2
+    EndTime: 0
+  - StartTime: 204762
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204762
+    Lane: 1
+    EndTime: 0
+  - StartTime: 204868
+    Lane: 4
+    EndTime: 0
+  - StartTime: 204973
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204973
+    Lane: 1
+    EndTime: 0
+  - StartTime: 205079
+    Lane: 2
+    EndTime: 0
+  - StartTime: 205184
+    Lane: 3
+    EndTime: 0
+  - StartTime: 205184
+    Lane: 4
+    EndTime: 0
+  - StartTime: 205290
+    Lane: 2
+    EndTime: 0
+  - StartTime: 205396
+    Lane: 3
+    EndTime: 0
+  - StartTime: 205396
+    Lane: 4
+    EndTime: 0
+  - StartTime: 205501
+    Lane: 2
+    EndTime: 0
+  - StartTime: 205501
+    Lane: 1
+    EndTime: 0
+  - StartTime: 205607
+    Lane: 1
+    EndTime: 0
+  - StartTime: 205607
+    Lane: 3
+    EndTime: 0
+  - StartTime: 205607
+    Lane: 4
+    EndTime: 0
+  - StartTime: 205713
+    Lane: 2
+    EndTime: 0
+  - StartTime: 205818
+    Lane: 1
+    EndTime: 0
+  - StartTime: 205818
+    Lane: 4
+    EndTime: 0
+  - StartTime: 205924
+    Lane: 3
+    EndTime: 0
+  - StartTime: 206029
+    Lane: 1
+    EndTime: 0
+  - StartTime: 206029
+    Lane: 2
+    EndTime: 0
+  - StartTime: 206029
+    Lane: 4
+    EndTime: 0
+  - StartTime: 206241
+    Lane: 4
+    EndTime: 0
+  - StartTime: 206241
+    Lane: 3
+    EndTime: 0
+  - StartTime: 206241
+    Lane: 1
+    EndTime: 0
+  - StartTime: 206452
+    Lane: 2
+    EndTime: 0
+  - StartTime: 206452
+    Lane: 3
+    EndTime: 0
+  - StartTime: 206452
+    Lane: 4
+    EndTime: 0
+  - StartTime: 206663
+    Lane: 1
+    EndTime: 0
+  - StartTime: 206663
+    Lane: 2
+    EndTime: 0
+  - StartTime: 206663
+    Lane: 4
+    EndTime: 0
+  - StartTime: 206875
+    Lane: 1
+    EndTime: 0
+  - StartTime: 206875
+    Lane: 2
+    EndTime: 0
+  - StartTime: 206980
+    Lane: 3
+    EndTime: 0
+  - StartTime: 206980
+    Lane: 1
+    EndTime: 0
+  - StartTime: 207086
+    Lane: 3
+    EndTime: 0
+  - StartTime: 207086
+    Lane: 4
+    EndTime: 0
+  - StartTime: 207191
+    Lane: 1
+    EndTime: 0
+  - StartTime: 207191
+    Lane: 2
+    EndTime: 0
+  - StartTime: 207297
+    Lane: 2
+    EndTime: 0
+  - StartTime: 207403
+    Lane: 3
+    EndTime: 0
+  - StartTime: 207403
+    Lane: 4
+    EndTime: 0
+  - StartTime: 207508
+    Lane: 1
+    EndTime: 0
+  - StartTime: 207508
+    Lane: 2
+    EndTime: 0
+  - StartTime: 207508
+    Lane: 4
+    EndTime: 0
+  - StartTime: 207614
+    Lane: 1
+    EndTime: 0
+  - StartTime: 207720
+    Lane: 4
+    EndTime: 0
+  - StartTime: 208143
+    Lane: 2
+    EndTime: 0
+  - StartTime: 208565
+    Lane: 3
+    EndTime: 0
+  - StartTime: 208988
+    Lane: 4
+    EndTime: 0
+  - StartTime: 209410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 209833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 210255
+    Lane: 4
+    EndTime: 0
+  - StartTime: 210678
+    Lane: 4
+    EndTime: 0
+  - StartTime: 211100
+    Lane: 3
+    EndTime: 0
+  - StartTime: 211523
+    Lane: 3
+    EndTime: 0
+  - StartTime: 211945
+    Lane: 2
+    EndTime: 0
+  - StartTime: 212368
+    Lane: 2
+    EndTime: 0
+  - StartTime: 212790
+    Lane: 1
+    EndTime: 0
+  - StartTime: 213213
+    Lane: 4
+    EndTime: 0
+  - StartTime: 213636
+    Lane: 1
+    EndTime: 0
+  - StartTime: 214058
+    Lane: 4
+    EndTime: 0
+  - StartTime: 214481
+    Lane: 4
+    EndTime: 0
+  - StartTime: 214903
+    Lane: 2
+    EndTime: 0
+  - StartTime: 215326
+    Lane: 3
+    EndTime: 0
+  - StartTime: 215748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 216171
+    Lane: 4
+    EndTime: 0
+  - StartTime: 216593
+    Lane: 2
+    EndTime: 0
+  - StartTime: 217016
+    Lane: 4
+    EndTime: 0
+  - StartTime: 217438
+    Lane: 4
+    EndTime: 0
+  - StartTime: 217861
+    Lane: 3
+    EndTime: 0
+  - StartTime: 218283
+    Lane: 3
+    EndTime: 0
+  - StartTime: 218706
+    Lane: 2
+    EndTime: 0
+  - StartTime: 219128
+    Lane: 2
+    EndTime: 0
+  - StartTime: 219551
+    Lane: 1
+    EndTime: 0
+  - StartTime: 219974
+    Lane: 4
+    EndTime: 0
+  - StartTime: 220396
+    Lane: 1
+    EndTime: 0
+  - StartTime: 220819
+    Lane: 4
+    EndTime: 0
+  - StartTime: 221241
+    Lane: 4
+    EndTime: 221927
+  - StartTime: 221241
+    Lane: 2
+    EndTime: 222033
+  - StartTime: 221241
+    Lane: 3
+    EndTime: 221980
+  - StartTime: 221241
+    Lane: 1
+    EndTime: 222086

--- a/Quaver.API.Tests/Quaver/Resources/cheat.qua
+++ b/Quaver.API.Tests/Quaver/Resources/cheat.qua
@@ -1,0 +1,5979 @@
+---
+Mode: Keys4
+Title: Shiawase ni Nareru Kakushi Command ga Arurashii
+Artist: Utata-P feat. Yuzuki Yukari
+Creator: Kamikaze
+DifficultyName: Cheat Code
+AudioFile: audiooooo.mp3
+BPMDoesNotAffectScrollVelocity: false
+InitialScrollVelocity: 0.0
+TimingPoints:
+  - StartTime: 680.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 7440.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 7441.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 7863.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 7864.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 8285.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 8286.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 8708.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 8709.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 9130.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 9131.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 9553.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 9554.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 9975.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 9976.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 10398.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 10399.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 10820.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 10821.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 11243.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 11244.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 11665.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 11666.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 12088.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 12089.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 12510.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 12511.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 12933.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 12934.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 13356.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 13357.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 13778.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 13779.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 14201.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 14202.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 14623.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 14624.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 15046.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 15047.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 15468.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 15469.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 15891.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 15892.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 16313.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 16314.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 16736.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 16737.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 17158.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 17159.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 17581.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 17582.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 18003.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 18004.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 18426.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 18427.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 18849.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 18850.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 19271.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 19272.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 19694.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 19695.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 20116.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 20117.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 20539.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 20540.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 20961.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 20962.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 21384.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 21385.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 21806.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 21807.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 22229.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 22230.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 22651.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 22652.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 23074.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 23075.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 23496.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 23497.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 23919.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 23920.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 24341.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 24342.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 24764.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 24765.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 25187.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 25188.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 25609.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 25610.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 26032.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 27722.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 29412.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 29413.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 29834.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 29835.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 30257.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 30258.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 30679.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 30680.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 31102.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 31103.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 31524.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 31525.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 31947.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 31948.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 32370.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 32371.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 32792.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 32793.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 33215.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 33216.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 33637.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 33638.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 34060.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 34061.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 34482.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 34483.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 34905.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 34906.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 35327.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 35328.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 35750.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 35751.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 36172.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 36173.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 36595.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 36596.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 37017.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 37018.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 37440.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 37441.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 37862.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 37863.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 38285.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 38286.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 38708.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 38709.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 39130.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 39131.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 39553.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 39554.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 39975.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 39976.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 40398.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 40399.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 40820.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 40821.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 41243.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 42933.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 42934.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 43355.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 43356.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 43778.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 43779.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 44201.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 44202.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 44623.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 44624.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 45046.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 45047.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 45468.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 45469.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 45891.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 45892.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 46313.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 46314.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 46736.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 46737.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 47158.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 47159.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 47581.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 47582.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 48003.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 48004.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 48426.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 48427.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 48848.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 48849.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 49271.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 49272.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 49693.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 49694.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 50116.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 50117.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 50539.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 50540.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 50961.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 50962.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 51384.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 51385.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 51806.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 51807.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 52229.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 52230.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 52651.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 52652.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 53074.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 53075.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 53496.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 53497.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 53919.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 53920.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 54341.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 54342.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 54764.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 56454.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 69130.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 69975.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 81806.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 83496.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 83497.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 83918.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 83919.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 84341.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 84342.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 84763.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 84764.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 85186.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 85187.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 85608.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 85609.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 86031.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 86032.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 86454.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 86455.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 86876.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 86877.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 87299.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 87300.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 87721.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 87722.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 88144.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 88145.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 88566.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 88567.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 88989.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 88990.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 89411.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 89412.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 89834.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 89835.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 90256.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 90257.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 90679.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 90680.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 91101.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 91102.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 91524.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 91525.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 91946.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 91947.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 92369.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 92370.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 92792.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 92793.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 93214.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 93215.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 93637.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 93638.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 94059.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 94060.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 94482.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 94483.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 94904.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 94905.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 95327.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 97017.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 97018.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 97439.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 97440.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 97862.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 97863.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 98284.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 98285.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 98707.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 98708.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 99130.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 99131.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 99552.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 99553.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 99975.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 99976.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 100397.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 100398.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 100820.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 100821.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 101242.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 101243.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 101665.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 101666.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 102087.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 102088.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 102510.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 102511.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 102932.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 102933.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 103355.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 103356.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 103777.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 103778.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 104200.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 104201.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 104623.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 104624.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 105045.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 105046.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 105468.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 105469.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 105890.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 105891.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 106313.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 106314.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 106735.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 106736.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 107158.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 107159.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 107580.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 107581.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 108003.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 108004.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 108425.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 108426.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 108848.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 110538.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 112228.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 124904.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 125749.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 141805.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 141858.0
+    Bpm: 106.49999237060547
+    Signature: 4
+  - StartTime: 141910.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 141963.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 142016.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 142227.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 142438.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 142544.0
+    Bpm: 106.49999237060547
+    Signature: 4
+  - StartTime: 142650.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 145185.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 145238.0
+    Bpm: 106.49999237060547
+    Signature: 4
+  - StartTime: 145290.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 145343.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 145396.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 145607.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 145818.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 145924.0
+    Bpm: 106.49999237060547
+    Signature: 4
+  - StartTime: 146030.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 151101.0
+    Bpm: 106.49999237060547
+    Signature: 4
+  - StartTime: 151171.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 151241.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 151312.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 151945.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 153635.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 153899.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 153952.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 154058.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 154322.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 154375.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 154481.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 154745.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 154798.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 154904.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 155168.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 155221.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 155327.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 155591.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 155644.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 155750.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 156014.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 156067.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 156173.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 156437.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 156490.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 156596.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 156860.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 156913.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 157019.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 157283.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 157336.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 157442.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 157706.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 157759.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 157865.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 158129.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 158182.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 158288.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 158552.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 158605.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 158711.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 158975.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 159028.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 159134.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 159398.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 159451.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 159557.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 159821.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 159874.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 159980.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 160244.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 160297.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 160403.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 160667.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 160720.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 160826.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 161090.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 161143.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 161249.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 161513.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 161566.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 161672.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 161936.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 161989.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 162095.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 162359.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 162412.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 162518.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 162782.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 162835.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 162941.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 163205.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 163258.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 163364.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 163628.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 163681.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 163787.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 164051.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 164104.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 164210.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 164474.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 164527.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 164633.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 164897.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 164950.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 165055.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 165319.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 165372.0
+    Bpm: 285.0
+    Signature: 4
+  - StartTime: 165490.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 167157.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 168847.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 168848.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 169058.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 169059.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 169269.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 169270.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 169481.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 169482.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 169692.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 169693.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 169903.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 169904.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 170114.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 170115.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 170326.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 170327.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 170537.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 172227.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 172228.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 172438.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 172439.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 172649.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 172650.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 172860.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 172861.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 173072.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 173073.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 173283.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 173284.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 173494.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 173495.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 173706.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 173707.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 173917.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 175607.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 175608.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 176030.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 176031.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 176452.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 176453.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 176664.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 176665.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 176875.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 176876.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 177086.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 177087.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 177297.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 177298.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 177720.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 177721.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 178143.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 178144.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 178565.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 178566.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 178988.0
+    Bpm: 35.5
+    Signature: 4
+  - StartTime: 180678.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 193354.0
+    Bpm: 71.0
+    Signature: 4
+  - StartTime: 194199.0
+    Bpm: 142.0
+    Signature: 4
+  - StartTime: 207720.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 207721.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 208143.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 208144.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 208565.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 208566.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 208988.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 208989.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 209410.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 209411.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 209833.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 209834.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 210255.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 210256.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 210678.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 210679.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 211100.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 211101.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 211523.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 211524.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 211945.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 211946.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 212368.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 212369.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 212790.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 212791.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 213213.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 213214.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 213636.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 213637.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 214058.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 214059.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 214481.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 214482.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 214903.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 214904.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 215326.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 215327.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 215748.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 215749.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 216171.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 216172.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 216593.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 216594.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 217016.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 217017.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 217438.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 217439.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 217861.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 217862.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 218283.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 218284.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 218706.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 218707.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 219128.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 219129.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 219551.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 219552.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 219974.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 219975.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 220396.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 220397.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 220819.0
+    Bpm: .inf
+    Signature: 4
+  - StartTime: 220820.0
+    Bpm: 0.0005988000193610787
+    Signature: 4
+  - StartTime: 221241.0
+    Bpm: 568.0
+    Signature: 4
+SliderVelocities: []
+HitObjects:
+  - StartTime: 680
+    Lane: 4
+    EndTime: 0
+  - StartTime: 1102
+    Lane: 4
+    EndTime: 0
+  - StartTime: 1525
+    Lane: 4
+    EndTime: 0
+  - StartTime: 1947
+    Lane: 4
+    EndTime: 0
+  - StartTime: 2370
+    Lane: 4
+    EndTime: 0
+  - StartTime: 2792
+    Lane: 4
+    EndTime: 0
+  - StartTime: 3215
+    Lane: 4
+    EndTime: 0
+  - StartTime: 3637
+    Lane: 4
+    EndTime: 0
+  - StartTime: 4060
+    Lane: 4
+    EndTime: 0
+  - StartTime: 4482
+    Lane: 4
+    EndTime: 0
+  - StartTime: 4905
+    Lane: 4
+    EndTime: 0
+  - StartTime: 5327
+    Lane: 4
+    EndTime: 0
+  - StartTime: 5750
+    Lane: 4
+    EndTime: 0
+  - StartTime: 6172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 6595
+    Lane: 4
+    EndTime: 0
+  - StartTime: 7018
+    Lane: 4
+    EndTime: 0
+  - StartTime: 7440
+    Lane: 4
+    EndTime: 0
+  - StartTime: 7863
+    Lane: 2
+    EndTime: 0
+  - StartTime: 8285
+    Lane: 3
+    EndTime: 0
+  - StartTime: 8708
+    Lane: 4
+    EndTime: 0
+  - StartTime: 9130
+    Lane: 4
+    EndTime: 0
+  - StartTime: 9553
+    Lane: 2
+    EndTime: 0
+  - StartTime: 9975
+    Lane: 4
+    EndTime: 0
+  - StartTime: 10398
+    Lane: 4
+    EndTime: 0
+  - StartTime: 10820
+    Lane: 3
+    EndTime: 0
+  - StartTime: 11243
+    Lane: 3
+    EndTime: 0
+  - StartTime: 11665
+    Lane: 2
+    EndTime: 0
+  - StartTime: 12088
+    Lane: 2
+    EndTime: 0
+  - StartTime: 12510
+    Lane: 1
+    EndTime: 0
+  - StartTime: 12933
+    Lane: 4
+    EndTime: 0
+  - StartTime: 13356
+    Lane: 1
+    EndTime: 0
+  - StartTime: 13778
+    Lane: 4
+    EndTime: 0
+  - StartTime: 14201
+    Lane: 4
+    EndTime: 0
+  - StartTime: 14623
+    Lane: 2
+    EndTime: 0
+  - StartTime: 15046
+    Lane: 3
+    EndTime: 0
+  - StartTime: 15468
+    Lane: 4
+    EndTime: 0
+  - StartTime: 15891
+    Lane: 4
+    EndTime: 0
+  - StartTime: 16313
+    Lane: 2
+    EndTime: 0
+  - StartTime: 16736
+    Lane: 4
+    EndTime: 0
+  - StartTime: 17158
+    Lane: 4
+    EndTime: 0
+  - StartTime: 17581
+    Lane: 3
+    EndTime: 0
+  - StartTime: 18003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 18426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 18849
+    Lane: 2
+    EndTime: 0
+  - StartTime: 19271
+    Lane: 1
+    EndTime: 0
+  - StartTime: 19694
+    Lane: 4
+    EndTime: 0
+  - StartTime: 20116
+    Lane: 1
+    EndTime: 0
+  - StartTime: 20539
+    Lane: 4
+    EndTime: 0
+  - StartTime: 20961
+    Lane: 4
+    EndTime: 0
+  - StartTime: 21384
+    Lane: 2
+    EndTime: 0
+  - StartTime: 21806
+    Lane: 3
+    EndTime: 0
+  - StartTime: 22229
+    Lane: 4
+    EndTime: 0
+  - StartTime: 22651
+    Lane: 4
+    EndTime: 0
+  - StartTime: 23074
+    Lane: 2
+    EndTime: 0
+  - StartTime: 23496
+    Lane: 4
+    EndTime: 0
+  - StartTime: 23919
+    Lane: 4
+    EndTime: 0
+  - StartTime: 24341
+    Lane: 3
+    EndTime: 0
+  - StartTime: 24764
+    Lane: 3
+    EndTime: 0
+  - StartTime: 25187
+    Lane: 2
+    EndTime: 0
+  - StartTime: 25609
+    Lane: 2
+    EndTime: 0
+  - StartTime: 27722
+    Lane: 2
+    EndTime: 29412
+  - StartTime: 29412
+    Lane: 4
+    EndTime: 0
+  - StartTime: 29834
+    Lane: 2
+    EndTime: 0
+  - StartTime: 30257
+    Lane: 3
+    EndTime: 0
+  - StartTime: 30679
+    Lane: 4
+    EndTime: 0
+  - StartTime: 31102
+    Lane: 4
+    EndTime: 0
+  - StartTime: 31524
+    Lane: 2
+    EndTime: 0
+  - StartTime: 31947
+    Lane: 4
+    EndTime: 0
+  - StartTime: 32370
+    Lane: 4
+    EndTime: 0
+  - StartTime: 32792
+    Lane: 3
+    EndTime: 0
+  - StartTime: 33215
+    Lane: 3
+    EndTime: 0
+  - StartTime: 33637
+    Lane: 2
+    EndTime: 0
+  - StartTime: 34060
+    Lane: 2
+    EndTime: 0
+  - StartTime: 34482
+    Lane: 1
+    EndTime: 0
+  - StartTime: 34905
+    Lane: 4
+    EndTime: 0
+  - StartTime: 35327
+    Lane: 1
+    EndTime: 0
+  - StartTime: 35750
+    Lane: 4
+    EndTime: 0
+  - StartTime: 36172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 36595
+    Lane: 2
+    EndTime: 0
+  - StartTime: 37017
+    Lane: 3
+    EndTime: 0
+  - StartTime: 37440
+    Lane: 4
+    EndTime: 0
+  - StartTime: 37862
+    Lane: 4
+    EndTime: 0
+  - StartTime: 38285
+    Lane: 2
+    EndTime: 0
+  - StartTime: 38708
+    Lane: 4
+    EndTime: 0
+  - StartTime: 39130
+    Lane: 4
+    EndTime: 0
+  - StartTime: 39553
+    Lane: 3
+    EndTime: 0
+  - StartTime: 39975
+    Lane: 3
+    EndTime: 0
+  - StartTime: 40398
+    Lane: 2
+    EndTime: 0
+  - StartTime: 40820
+    Lane: 2
+    EndTime: 0
+  - StartTime: 41243
+    Lane: 4
+    EndTime: 0
+  - StartTime: 41665
+    Lane: 3
+    EndTime: 0
+  - StartTime: 42088
+    Lane: 1
+    EndTime: 0
+  - StartTime: 42510
+    Lane: 1
+    EndTime: 0
+  - StartTime: 42933
+    Lane: 4
+    EndTime: 0
+  - StartTime: 43355
+    Lane: 2
+    EndTime: 0
+  - StartTime: 43778
+    Lane: 3
+    EndTime: 0
+  - StartTime: 44201
+    Lane: 4
+    EndTime: 0
+  - StartTime: 44623
+    Lane: 4
+    EndTime: 0
+  - StartTime: 45046
+    Lane: 2
+    EndTime: 0
+  - StartTime: 45468
+    Lane: 4
+    EndTime: 0
+  - StartTime: 45891
+    Lane: 4
+    EndTime: 0
+  - StartTime: 46313
+    Lane: 3
+    EndTime: 0
+  - StartTime: 46736
+    Lane: 3
+    EndTime: 0
+  - StartTime: 47158
+    Lane: 2
+    EndTime: 0
+  - StartTime: 47581
+    Lane: 2
+    EndTime: 0
+  - StartTime: 48003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 48426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 48848
+    Lane: 1
+    EndTime: 0
+  - StartTime: 49271
+    Lane: 4
+    EndTime: 0
+  - StartTime: 49693
+    Lane: 4
+    EndTime: 0
+  - StartTime: 50116
+    Lane: 2
+    EndTime: 0
+  - StartTime: 50539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 50961
+    Lane: 4
+    EndTime: 0
+  - StartTime: 51384
+    Lane: 4
+    EndTime: 0
+  - StartTime: 51806
+    Lane: 2
+    EndTime: 0
+  - StartTime: 52229
+    Lane: 4
+    EndTime: 0
+  - StartTime: 52651
+    Lane: 4
+    EndTime: 0
+  - StartTime: 53074
+    Lane: 3
+    EndTime: 0
+  - StartTime: 53496
+    Lane: 3
+    EndTime: 0
+  - StartTime: 53919
+    Lane: 2
+    EndTime: 0
+  - StartTime: 54341
+    Lane: 2
+    EndTime: 0
+  - StartTime: 54764
+    Lane: 1
+    EndTime: 0
+  - StartTime: 55186
+    Lane: 2
+    EndTime: 0
+  - StartTime: 55609
+    Lane: 4
+    EndTime: 0
+  - StartTime: 56031
+    Lane: 4
+    EndTime: 0
+  - StartTime: 56454
+    Lane: 4
+    EndTime: 56876
+  - StartTime: 56454
+    Lane: 3
+    EndTime: 0
+  - StartTime: 56665
+    Lane: 1
+    EndTime: 0
+  - StartTime: 56876
+    Lane: 2
+    EndTime: 0
+  - StartTime: 57087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 57299
+    Lane: 2
+    EndTime: 0
+  - StartTime: 57299
+    Lane: 1
+    EndTime: 0
+  - StartTime: 57510
+    Lane: 3
+    EndTime: 0
+  - StartTime: 57510
+    Lane: 4
+    EndTime: 0
+  - StartTime: 57615
+    Lane: 1
+    EndTime: 0
+  - StartTime: 57615
+    Lane: 2
+    EndTime: 0
+  - StartTime: 57721
+    Lane: 1
+    EndTime: 0
+  - StartTime: 57721
+    Lane: 4
+    EndTime: 0
+  - StartTime: 57721
+    Lane: 3
+    EndTime: 0
+  - StartTime: 57932
+    Lane: 2
+    EndTime: 0
+  - StartTime: 58144
+    Lane: 1
+    EndTime: 0
+  - StartTime: 58144
+    Lane: 3
+    EndTime: 0
+  - StartTime: 58355
+    Lane: 4
+    EndTime: 0
+  - StartTime: 58566
+    Lane: 2
+    EndTime: 0
+  - StartTime: 58566
+    Lane: 1
+    EndTime: 0
+  - StartTime: 58777
+    Lane: 3
+    EndTime: 0
+  - StartTime: 58989
+    Lane: 4
+    EndTime: 0
+  - StartTime: 59200
+    Lane: 1
+    EndTime: 0
+  - StartTime: 59200
+    Lane: 2
+    EndTime: 0
+  - StartTime: 59306
+    Lane: 3
+    EndTime: 0
+  - StartTime: 59306
+    Lane: 4
+    EndTime: 0
+  - StartTime: 59411
+    Lane: 1
+    EndTime: 0
+  - StartTime: 59411
+    Lane: 4
+    EndTime: 0
+  - StartTime: 59411
+    Lane: 2
+    EndTime: 0
+  - StartTime: 59623
+    Lane: 3
+    EndTime: 0
+  - StartTime: 59834
+    Lane: 1
+    EndTime: 0
+  - StartTime: 59834
+    Lane: 4
+    EndTime: 0
+  - StartTime: 60045
+    Lane: 3
+    EndTime: 0
+  - StartTime: 60256
+    Lane: 2
+    EndTime: 0
+  - StartTime: 60256
+    Lane: 4
+    EndTime: 0
+  - StartTime: 60468
+    Lane: 1
+    EndTime: 0
+  - StartTime: 60679
+    Lane: 4
+    EndTime: 0
+  - StartTime: 60890
+    Lane: 2
+    EndTime: 0
+  - StartTime: 60890
+    Lane: 3
+    EndTime: 0
+  - StartTime: 60996
+    Lane: 1
+    EndTime: 0
+  - StartTime: 60996
+    Lane: 4
+    EndTime: 0
+  - StartTime: 61101
+    Lane: 3
+    EndTime: 0
+  - StartTime: 61101
+    Lane: 1
+    EndTime: 0
+  - StartTime: 61101
+    Lane: 2
+    EndTime: 0
+  - StartTime: 61313
+    Lane: 3
+    EndTime: 0
+  - StartTime: 61524
+    Lane: 2
+    EndTime: 0
+  - StartTime: 61524
+    Lane: 4
+    EndTime: 0
+  - StartTime: 61735
+    Lane: 1
+    EndTime: 0
+  - StartTime: 61946
+    Lane: 2
+    EndTime: 0
+  - StartTime: 61946
+    Lane: 4
+    EndTime: 0
+  - StartTime: 62158
+    Lane: 3
+    EndTime: 0
+  - StartTime: 62369
+    Lane: 4
+    EndTime: 0
+  - StartTime: 62580
+    Lane: 3
+    EndTime: 0
+  - StartTime: 62580
+    Lane: 1
+    EndTime: 0
+  - StartTime: 62686
+    Lane: 2
+    EndTime: 0
+  - StartTime: 62686
+    Lane: 4
+    EndTime: 0
+  - StartTime: 62792
+    Lane: 4
+    EndTime: 0
+  - StartTime: 62792
+    Lane: 1
+    EndTime: 0
+  - StartTime: 62792
+    Lane: 3
+    EndTime: 0
+  - StartTime: 63003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 63214
+    Lane: 4
+    EndTime: 0
+  - StartTime: 63214
+    Lane: 3
+    EndTime: 0
+  - StartTime: 63425
+    Lane: 1
+    EndTime: 0
+  - StartTime: 63637
+    Lane: 4
+    EndTime: 0
+  - StartTime: 63637
+    Lane: 2
+    EndTime: 0
+  - StartTime: 63848
+    Lane: 3
+    EndTime: 0
+  - StartTime: 64059
+    Lane: 4
+    EndTime: 0
+  - StartTime: 64270
+    Lane: 2
+    EndTime: 0
+  - StartTime: 64270
+    Lane: 3
+    EndTime: 0
+  - StartTime: 64376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 64376
+    Lane: 1
+    EndTime: 0
+  - StartTime: 64482
+    Lane: 2
+    EndTime: 0
+  - StartTime: 64482
+    Lane: 3
+    EndTime: 0
+  - StartTime: 64482
+    Lane: 1
+    EndTime: 0
+  - StartTime: 64693
+    Lane: 4
+    EndTime: 0
+  - StartTime: 64904
+    Lane: 1
+    EndTime: 0
+  - StartTime: 64904
+    Lane: 3
+    EndTime: 0
+  - StartTime: 65115
+    Lane: 4
+    EndTime: 0
+  - StartTime: 65327
+    Lane: 2
+    EndTime: 0
+  - StartTime: 65327
+    Lane: 1
+    EndTime: 0
+  - StartTime: 65538
+    Lane: 4
+    EndTime: 0
+  - StartTime: 65749
+    Lane: 2
+    EndTime: 0
+  - StartTime: 65961
+    Lane: 3
+    EndTime: 0
+  - StartTime: 65961
+    Lane: 1
+    EndTime: 0
+  - StartTime: 66066
+    Lane: 2
+    EndTime: 0
+  - StartTime: 66066
+    Lane: 4
+    EndTime: 0
+  - StartTime: 66172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 66172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 66172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 66383
+    Lane: 3
+    EndTime: 0
+  - StartTime: 66594
+    Lane: 2
+    EndTime: 0
+  - StartTime: 66594
+    Lane: 1
+    EndTime: 0
+  - StartTime: 66806
+    Lane: 4
+    EndTime: 0
+  - StartTime: 67017
+    Lane: 4
+    EndTime: 0
+  - StartTime: 67017
+    Lane: 2
+    EndTime: 0
+  - StartTime: 67228
+    Lane: 1
+    EndTime: 0
+  - StartTime: 67439
+    Lane: 3
+    EndTime: 0
+  - StartTime: 67651
+    Lane: 4
+    EndTime: 0
+  - StartTime: 67651
+    Lane: 2
+    EndTime: 0
+  - StartTime: 67756
+    Lane: 3
+    EndTime: 0
+  - StartTime: 67756
+    Lane: 1
+    EndTime: 0
+  - StartTime: 67862
+    Lane: 1
+    EndTime: 0
+  - StartTime: 67862
+    Lane: 4
+    EndTime: 0
+  - StartTime: 67862
+    Lane: 2
+    EndTime: 0
+  - StartTime: 68073
+    Lane: 3
+    EndTime: 0
+  - StartTime: 68284
+    Lane: 4
+    EndTime: 0
+  - StartTime: 68284
+    Lane: 2
+    EndTime: 0
+  - StartTime: 68496
+    Lane: 1
+    EndTime: 0
+  - StartTime: 68496
+    Lane: 3
+    EndTime: 0
+  - StartTime: 68707
+    Lane: 4
+    EndTime: 0
+  - StartTime: 68707
+    Lane: 2
+    EndTime: 0
+  - StartTime: 68918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 68918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 69130
+    Lane: 2
+    EndTime: 0
+  - StartTime: 69130
+    Lane: 4
+    EndTime: 0
+  - StartTime: 69235
+    Lane: 3
+    EndTime: 0
+  - StartTime: 69341
+    Lane: 2
+    EndTime: 0
+  - StartTime: 69446
+    Lane: 3
+    EndTime: 0
+  - StartTime: 69552
+    Lane: 1
+    EndTime: 0
+  - StartTime: 69552
+    Lane: 2
+    EndTime: 0
+  - StartTime: 69658
+    Lane: 4
+    EndTime: 0
+  - StartTime: 69763
+    Lane: 1
+    EndTime: 0
+  - StartTime: 69869
+    Lane: 4
+    EndTime: 0
+  - StartTime: 69975
+    Lane: 3
+    EndTime: 0
+  - StartTime: 69975
+    Lane: 1
+    EndTime: 0
+  - StartTime: 69975
+    Lane: 2
+    EndTime: 0
+  - StartTime: 70186
+    Lane: 1
+    EndTime: 0
+  - StartTime: 70186
+    Lane: 4
+    EndTime: 0
+  - StartTime: 70397
+    Lane: 2
+    EndTime: 0
+  - StartTime: 70397
+    Lane: 3
+    EndTime: 0
+  - StartTime: 70608
+    Lane: 1
+    EndTime: 0
+  - StartTime: 70714
+    Lane: 1
+    EndTime: 0
+  - StartTime: 70714
+    Lane: 2
+    EndTime: 0
+  - StartTime: 70925
+    Lane: 4
+    EndTime: 0
+  - StartTime: 71031
+    Lane: 4
+    EndTime: 0
+  - StartTime: 71031
+    Lane: 3
+    EndTime: 0
+  - StartTime: 71242
+    Lane: 2
+    EndTime: 0
+  - StartTime: 71242
+    Lane: 3
+    EndTime: 0
+  - StartTime: 71453
+    Lane: 2
+    EndTime: 0
+  - StartTime: 71453
+    Lane: 1
+    EndTime: 0
+  - StartTime: 71665
+    Lane: 1
+    EndTime: 0
+  - StartTime: 71665
+    Lane: 3
+    EndTime: 0
+  - StartTime: 71876
+    Lane: 2
+    EndTime: 0
+  - StartTime: 71876
+    Lane: 4
+    EndTime: 0
+  - StartTime: 72087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 72087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 72298
+    Lane: 1
+    EndTime: 0
+  - StartTime: 72404
+    Lane: 1
+    EndTime: 0
+  - StartTime: 72404
+    Lane: 3
+    EndTime: 0
+  - StartTime: 72615
+    Lane: 4
+    EndTime: 0
+  - StartTime: 72721
+    Lane: 4
+    EndTime: 0
+  - StartTime: 72721
+    Lane: 2
+    EndTime: 0
+  - StartTime: 72932
+    Lane: 3
+    EndTime: 0
+  - StartTime: 72932
+    Lane: 4
+    EndTime: 0
+  - StartTime: 73144
+    Lane: 1
+    EndTime: 0
+  - StartTime: 73144
+    Lane: 2
+    EndTime: 0
+  - StartTime: 73355
+    Lane: 2
+    EndTime: 0
+  - StartTime: 73355
+    Lane: 4
+    EndTime: 0
+  - StartTime: 73566
+    Lane: 1
+    EndTime: 0
+  - StartTime: 73566
+    Lane: 3
+    EndTime: 0
+  - StartTime: 73777
+    Lane: 1
+    EndTime: 0
+  - StartTime: 73777
+    Lane: 2
+    EndTime: 0
+  - StartTime: 73989
+    Lane: 3
+    EndTime: 0
+  - StartTime: 74094
+    Lane: 4
+    EndTime: 0
+  - StartTime: 74094
+    Lane: 3
+    EndTime: 0
+  - StartTime: 74305
+    Lane: 2
+    EndTime: 0
+  - StartTime: 74411
+    Lane: 1
+    EndTime: 0
+  - StartTime: 74411
+    Lane: 2
+    EndTime: 0
+  - StartTime: 74622
+    Lane: 3
+    EndTime: 0
+  - StartTime: 74622
+    Lane: 1
+    EndTime: 0
+  - StartTime: 74834
+    Lane: 4
+    EndTime: 0
+  - StartTime: 74834
+    Lane: 3
+    EndTime: 0
+  - StartTime: 75045
+    Lane: 4
+    EndTime: 0
+  - StartTime: 75045
+    Lane: 2
+    EndTime: 0
+  - StartTime: 75256
+    Lane: 1
+    EndTime: 0
+  - StartTime: 75256
+    Lane: 2
+    EndTime: 0
+  - StartTime: 75467
+    Lane: 3
+    EndTime: 0
+  - StartTime: 75467
+    Lane: 4
+    EndTime: 0
+  - StartTime: 75679
+    Lane: 4
+    EndTime: 0
+  - StartTime: 75784
+    Lane: 4
+    EndTime: 0
+  - StartTime: 75784
+    Lane: 1
+    EndTime: 0
+  - StartTime: 75996
+    Lane: 2
+    EndTime: 0
+  - StartTime: 76101
+    Lane: 3
+    EndTime: 0
+  - StartTime: 76101
+    Lane: 2
+    EndTime: 0
+  - StartTime: 76313
+    Lane: 1
+    EndTime: 0
+  - StartTime: 76313
+    Lane: 3
+    EndTime: 0
+  - StartTime: 76524
+    Lane: 2
+    EndTime: 0
+  - StartTime: 76524
+    Lane: 4
+    EndTime: 0
+  - StartTime: 76735
+    Lane: 1
+    EndTime: 0
+  - StartTime: 76735
+    Lane: 3
+    EndTime: 0
+  - StartTime: 76946
+    Lane: 2
+    EndTime: 0
+  - StartTime: 76946
+    Lane: 3
+    EndTime: 0
+  - StartTime: 77158
+    Lane: 1
+    EndTime: 0
+  - StartTime: 77158
+    Lane: 2
+    EndTime: 0
+  - StartTime: 77369
+    Lane: 4
+    EndTime: 0
+  - StartTime: 77475
+    Lane: 4
+    EndTime: 0
+  - StartTime: 77475
+    Lane: 2
+    EndTime: 0
+  - StartTime: 77686
+    Lane: 1
+    EndTime: 0
+  - StartTime: 77791
+    Lane: 3
+    EndTime: 0
+  - StartTime: 77791
+    Lane: 1
+    EndTime: 0
+  - StartTime: 78003
+    Lane: 4
+    EndTime: 0
+  - StartTime: 78003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 78214
+    Lane: 1
+    EndTime: 0
+  - StartTime: 78214
+    Lane: 4
+    EndTime: 0
+  - StartTime: 78425
+    Lane: 1
+    EndTime: 0
+  - StartTime: 78425
+    Lane: 2
+    EndTime: 0
+  - StartTime: 78636
+    Lane: 2
+    EndTime: 0
+  - StartTime: 78636
+    Lane: 3
+    EndTime: 0
+  - StartTime: 78848
+    Lane: 3
+    EndTime: 0
+  - StartTime: 78848
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79059
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79165
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79165
+    Lane: 1
+    EndTime: 0
+  - StartTime: 79376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 79482
+    Lane: 3
+    EndTime: 0
+  - StartTime: 79482
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79693
+    Lane: 1
+    EndTime: 0
+  - StartTime: 79693
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79693
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79904
+    Lane: 3
+    EndTime: 0
+  - StartTime: 79904
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79904
+    Lane: 1
+    EndTime: 0
+  - StartTime: 80115
+    Lane: 4
+    EndTime: 0
+  - StartTime: 80115
+    Lane: 1
+    EndTime: 0
+  - StartTime: 80115
+    Lane: 3
+    EndTime: 0
+  - StartTime: 80327
+    Lane: 3
+    EndTime: 0
+  - StartTime: 80327
+    Lane: 2
+    EndTime: 0
+  - StartTime: 80538
+    Lane: 3
+    EndTime: 0
+  - StartTime: 80538
+    Lane: 1
+    EndTime: 0
+  - StartTime: 80749
+    Lane: 4
+    EndTime: 0
+  - StartTime: 80855
+    Lane: 2
+    EndTime: 0
+  - StartTime: 80855
+    Lane: 4
+    EndTime: 0
+  - StartTime: 81066
+    Lane: 1
+    EndTime: 0
+  - StartTime: 81172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 81172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 81383
+    Lane: 2
+    EndTime: 81594
+  - StartTime: 81383
+    Lane: 4
+    EndTime: 0
+  - StartTime: 81594
+    Lane: 3
+    EndTime: 0
+  - StartTime: 81594
+    Lane: 1
+    EndTime: 0
+  - StartTime: 81806
+    Lane: 4
+    EndTime: 0
+  - StartTime: 82228
+    Lane: 3
+    EndTime: 0
+  - StartTime: 82651
+    Lane: 2
+    EndTime: 0
+  - StartTime: 83073
+    Lane: 1
+    EndTime: 0
+  - StartTime: 83496
+    Lane: 4
+    EndTime: 0
+  - StartTime: 83918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 84763
+    Lane: 3
+    EndTime: 0
+  - StartTime: 84763
+    Lane: 4
+    EndTime: 0
+  - StartTime: 85186
+    Lane: 1
+    EndTime: 0
+  - StartTime: 85186
+    Lane: 2
+    EndTime: 0
+  - StartTime: 85608
+    Lane: 2
+    EndTime: 0
+  - StartTime: 85608
+    Lane: 3
+    EndTime: 0
+  - StartTime: 86031
+    Lane: 1
+    EndTime: 0
+  - StartTime: 86031
+    Lane: 4
+    EndTime: 0
+  - StartTime: 86454
+    Lane: 2
+    EndTime: 0
+  - StartTime: 86454
+    Lane: 4
+    EndTime: 0
+  - StartTime: 86876
+    Lane: 3
+    EndTime: 0
+  - StartTime: 87299
+    Lane: 3
+    EndTime: 0
+  - StartTime: 87721
+    Lane: 2
+    EndTime: 0
+  - StartTime: 88144
+    Lane: 1
+    EndTime: 0
+  - StartTime: 88144
+    Lane: 2
+    EndTime: 0
+  - StartTime: 88566
+    Lane: 1
+    EndTime: 0
+  - StartTime: 88566
+    Lane: 4
+    EndTime: 0
+  - StartTime: 88989
+    Lane: 1
+    EndTime: 0
+  - StartTime: 88989
+    Lane: 3
+    EndTime: 0
+  - StartTime: 89411
+    Lane: 2
+    EndTime: 0
+  - StartTime: 89411
+    Lane: 4
+    EndTime: 0
+  - StartTime: 89834
+    Lane: 1
+    EndTime: 0
+  - StartTime: 89834
+    Lane: 2
+    EndTime: 0
+  - StartTime: 90256
+    Lane: 4
+    EndTime: 0
+  - StartTime: 90679
+    Lane: 2
+    EndTime: 0
+  - StartTime: 91101
+    Lane: 3
+    EndTime: 0
+  - StartTime: 91524
+    Lane: 4
+    EndTime: 0
+  - StartTime: 91946
+    Lane: 1
+    EndTime: 0
+  - StartTime: 91946
+    Lane: 2
+    EndTime: 0
+  - StartTime: 92369
+    Lane: 2
+    EndTime: 0
+  - StartTime: 92369
+    Lane: 3
+    EndTime: 0
+  - StartTime: 92792
+    Lane: 1
+    EndTime: 0
+  - StartTime: 92792
+    Lane: 4
+    EndTime: 0
+  - StartTime: 93214
+    Lane: 2
+    EndTime: 0
+  - StartTime: 93214
+    Lane: 4
+    EndTime: 0
+  - StartTime: 93637
+    Lane: 3
+    EndTime: 0
+  - StartTime: 94059
+    Lane: 3
+    EndTime: 0
+  - StartTime: 94482
+    Lane: 2
+    EndTime: 0
+  - StartTime: 94904
+    Lane: 2
+    EndTime: 0
+  - StartTime: 95327
+    Lane: 4
+    EndTime: 0
+  - StartTime: 95749
+    Lane: 2
+    EndTime: 0
+  - StartTime: 96172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 96594
+    Lane: 1
+    EndTime: 0
+  - StartTime: 97017
+    Lane: 4
+    EndTime: 0
+  - StartTime: 97439
+    Lane: 2
+    EndTime: 0
+  - StartTime: 98284
+    Lane: 3
+    EndTime: 0
+  - StartTime: 98284
+    Lane: 4
+    EndTime: 0
+  - StartTime: 98707
+    Lane: 1
+    EndTime: 0
+  - StartTime: 98707
+    Lane: 2
+    EndTime: 0
+  - StartTime: 99130
+    Lane: 2
+    EndTime: 0
+  - StartTime: 99130
+    Lane: 3
+    EndTime: 0
+  - StartTime: 99552
+    Lane: 1
+    EndTime: 0
+  - StartTime: 99552
+    Lane: 4
+    EndTime: 0
+  - StartTime: 99975
+    Lane: 2
+    EndTime: 0
+  - StartTime: 99975
+    Lane: 4
+    EndTime: 0
+  - StartTime: 100397
+    Lane: 3
+    EndTime: 0
+  - StartTime: 100820
+    Lane: 3
+    EndTime: 0
+  - StartTime: 101242
+    Lane: 2
+    EndTime: 0
+  - StartTime: 101665
+    Lane: 1
+    EndTime: 0
+  - StartTime: 101665
+    Lane: 2
+    EndTime: 0
+  - StartTime: 102087
+    Lane: 1
+    EndTime: 0
+  - StartTime: 102087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 102510
+    Lane: 1
+    EndTime: 0
+  - StartTime: 102510
+    Lane: 3
+    EndTime: 0
+  - StartTime: 102932
+    Lane: 2
+    EndTime: 0
+  - StartTime: 102932
+    Lane: 4
+    EndTime: 0
+  - StartTime: 103355
+    Lane: 1
+    EndTime: 0
+  - StartTime: 103355
+    Lane: 2
+    EndTime: 0
+  - StartTime: 103777
+    Lane: 4
+    EndTime: 0
+  - StartTime: 104200
+    Lane: 2
+    EndTime: 0
+  - StartTime: 104623
+    Lane: 3
+    EndTime: 0
+  - StartTime: 105045
+    Lane: 4
+    EndTime: 0
+  - StartTime: 105468
+    Lane: 1
+    EndTime: 0
+  - StartTime: 105468
+    Lane: 2
+    EndTime: 0
+  - StartTime: 105890
+    Lane: 2
+    EndTime: 0
+  - StartTime: 105890
+    Lane: 3
+    EndTime: 0
+  - StartTime: 106313
+    Lane: 1
+    EndTime: 0
+  - StartTime: 106313
+    Lane: 4
+    EndTime: 0
+  - StartTime: 106735
+    Lane: 2
+    EndTime: 0
+  - StartTime: 106735
+    Lane: 4
+    EndTime: 0
+  - StartTime: 107158
+    Lane: 3
+    EndTime: 0
+  - StartTime: 107580
+    Lane: 3
+    EndTime: 0
+  - StartTime: 108003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 108425
+    Lane: 2
+    EndTime: 0
+  - StartTime: 108848
+    Lane: 4
+    EndTime: 0
+  - StartTime: 110538
+    Lane: 4
+    EndTime: 0
+  - StartTime: 110960
+    Lane: 2
+    EndTime: 0
+  - StartTime: 111383
+    Lane: 3
+    EndTime: 0
+  - StartTime: 111805
+    Lane: 1
+    EndTime: 0
+  - StartTime: 112228
+    Lane: 4
+    EndTime: 112650
+  - StartTime: 112228
+    Lane: 3
+    EndTime: 0
+  - StartTime: 112439
+    Lane: 1
+    EndTime: 0
+  - StartTime: 112650
+    Lane: 2
+    EndTime: 0
+  - StartTime: 112861
+    Lane: 4
+    EndTime: 0
+  - StartTime: 113073
+    Lane: 2
+    EndTime: 0
+  - StartTime: 113073
+    Lane: 1
+    EndTime: 0
+  - StartTime: 113284
+    Lane: 3
+    EndTime: 0
+  - StartTime: 113284
+    Lane: 4
+    EndTime: 0
+  - StartTime: 113389
+    Lane: 1
+    EndTime: 0
+  - StartTime: 113389
+    Lane: 2
+    EndTime: 0
+  - StartTime: 113495
+    Lane: 1
+    EndTime: 0
+  - StartTime: 113495
+    Lane: 4
+    EndTime: 0
+  - StartTime: 113495
+    Lane: 3
+    EndTime: 0
+  - StartTime: 113706
+    Lane: 2
+    EndTime: 0
+  - StartTime: 113918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 113918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 114129
+    Lane: 4
+    EndTime: 0
+  - StartTime: 114340
+    Lane: 2
+    EndTime: 0
+  - StartTime: 114340
+    Lane: 1
+    EndTime: 0
+  - StartTime: 114551
+    Lane: 3
+    EndTime: 0
+  - StartTime: 114763
+    Lane: 4
+    EndTime: 0
+  - StartTime: 114974
+    Lane: 1
+    EndTime: 0
+  - StartTime: 114974
+    Lane: 2
+    EndTime: 0
+  - StartTime: 115080
+    Lane: 3
+    EndTime: 0
+  - StartTime: 115080
+    Lane: 4
+    EndTime: 0
+  - StartTime: 115185
+    Lane: 1
+    EndTime: 0
+  - StartTime: 115185
+    Lane: 4
+    EndTime: 0
+  - StartTime: 115185
+    Lane: 2
+    EndTime: 0
+  - StartTime: 115397
+    Lane: 3
+    EndTime: 0
+  - StartTime: 115608
+    Lane: 1
+    EndTime: 0
+  - StartTime: 115608
+    Lane: 4
+    EndTime: 0
+  - StartTime: 115819
+    Lane: 3
+    EndTime: 0
+  - StartTime: 116030
+    Lane: 2
+    EndTime: 0
+  - StartTime: 116030
+    Lane: 4
+    EndTime: 0
+  - StartTime: 116242
+    Lane: 1
+    EndTime: 0
+  - StartTime: 116453
+    Lane: 2
+    EndTime: 0
+  - StartTime: 116664
+    Lane: 4
+    EndTime: 0
+  - StartTime: 116664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 116770
+    Lane: 2
+    EndTime: 0
+  - StartTime: 116770
+    Lane: 1
+    EndTime: 0
+  - StartTime: 116875
+    Lane: 1
+    EndTime: 0
+  - StartTime: 116875
+    Lane: 4
+    EndTime: 0
+  - StartTime: 116875
+    Lane: 3
+    EndTime: 0
+  - StartTime: 117087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 117298
+    Lane: 2
+    EndTime: 0
+  - StartTime: 117298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 117509
+    Lane: 1
+    EndTime: 0
+  - StartTime: 117720
+    Lane: 2
+    EndTime: 0
+  - StartTime: 117720
+    Lane: 4
+    EndTime: 0
+  - StartTime: 117932
+    Lane: 3
+    EndTime: 0
+  - StartTime: 118143
+    Lane: 4
+    EndTime: 0
+  - StartTime: 118354
+    Lane: 3
+    EndTime: 0
+  - StartTime: 118354
+    Lane: 1
+    EndTime: 0
+  - StartTime: 118460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 118460
+    Lane: 4
+    EndTime: 0
+  - StartTime: 118566
+    Lane: 4
+    EndTime: 0
+  - StartTime: 118566
+    Lane: 1
+    EndTime: 0
+  - StartTime: 118566
+    Lane: 3
+    EndTime: 0
+  - StartTime: 118777
+    Lane: 2
+    EndTime: 0
+  - StartTime: 118988
+    Lane: 4
+    EndTime: 0
+  - StartTime: 118988
+    Lane: 3
+    EndTime: 0
+  - StartTime: 119199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 119411
+    Lane: 4
+    EndTime: 0
+  - StartTime: 119411
+    Lane: 2
+    EndTime: 0
+  - StartTime: 119622
+    Lane: 3
+    EndTime: 0
+  - StartTime: 119833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 120044
+    Lane: 2
+    EndTime: 0
+  - StartTime: 120044
+    Lane: 3
+    EndTime: 0
+  - StartTime: 120150
+    Lane: 4
+    EndTime: 0
+  - StartTime: 120150
+    Lane: 1
+    EndTime: 0
+  - StartTime: 120256
+    Lane: 2
+    EndTime: 0
+  - StartTime: 120256
+    Lane: 3
+    EndTime: 0
+  - StartTime: 120256
+    Lane: 1
+    EndTime: 0
+  - StartTime: 120467
+    Lane: 4
+    EndTime: 0
+  - StartTime: 120678
+    Lane: 1
+    EndTime: 0
+  - StartTime: 120678
+    Lane: 3
+    EndTime: 0
+  - StartTime: 120889
+    Lane: 4
+    EndTime: 0
+  - StartTime: 121101
+    Lane: 2
+    EndTime: 0
+  - StartTime: 121101
+    Lane: 1
+    EndTime: 0
+  - StartTime: 121312
+    Lane: 4
+    EndTime: 0
+  - StartTime: 121523
+    Lane: 3
+    EndTime: 0
+  - StartTime: 121735
+    Lane: 1
+    EndTime: 0
+  - StartTime: 121735
+    Lane: 2
+    EndTime: 0
+  - StartTime: 121840
+    Lane: 3
+    EndTime: 0
+  - StartTime: 121840
+    Lane: 4
+    EndTime: 0
+  - StartTime: 121946
+    Lane: 1
+    EndTime: 0
+  - StartTime: 121946
+    Lane: 4
+    EndTime: 0
+  - StartTime: 121946
+    Lane: 2
+    EndTime: 0
+  - StartTime: 122157
+    Lane: 3
+    EndTime: 0
+  - StartTime: 122368
+    Lane: 2
+    EndTime: 0
+  - StartTime: 122368
+    Lane: 1
+    EndTime: 0
+  - StartTime: 122580
+    Lane: 4
+    EndTime: 0
+  - StartTime: 122791
+    Lane: 4
+    EndTime: 0
+  - StartTime: 122791
+    Lane: 2
+    EndTime: 0
+  - StartTime: 123002
+    Lane: 1
+    EndTime: 0
+  - StartTime: 123213
+    Lane: 3
+    EndTime: 0
+  - StartTime: 123425
+    Lane: 4
+    EndTime: 0
+  - StartTime: 123425
+    Lane: 2
+    EndTime: 0
+  - StartTime: 123530
+    Lane: 3
+    EndTime: 0
+  - StartTime: 123530
+    Lane: 1
+    EndTime: 0
+  - StartTime: 123636
+    Lane: 1
+    EndTime: 0
+  - StartTime: 123636
+    Lane: 4
+    EndTime: 0
+  - StartTime: 123636
+    Lane: 2
+    EndTime: 0
+  - StartTime: 123847
+    Lane: 3
+    EndTime: 0
+  - StartTime: 124058
+    Lane: 4
+    EndTime: 0
+  - StartTime: 124058
+    Lane: 2
+    EndTime: 0
+  - StartTime: 124270
+    Lane: 1
+    EndTime: 0
+  - StartTime: 124270
+    Lane: 3
+    EndTime: 0
+  - StartTime: 124481
+    Lane: 4
+    EndTime: 0
+  - StartTime: 124481
+    Lane: 2
+    EndTime: 0
+  - StartTime: 124692
+    Lane: 1
+    EndTime: 0
+  - StartTime: 124692
+    Lane: 3
+    EndTime: 0
+  - StartTime: 124904
+    Lane: 1
+    EndTime: 0
+  - StartTime: 124904
+    Lane: 4
+    EndTime: 0
+  - StartTime: 125009
+    Lane: 3
+    EndTime: 0
+  - StartTime: 125115
+    Lane: 1
+    EndTime: 0
+  - StartTime: 125220
+    Lane: 3
+    EndTime: 0
+  - StartTime: 125326
+    Lane: 4
+    EndTime: 0
+  - StartTime: 125326
+    Lane: 1
+    EndTime: 0
+  - StartTime: 125432
+    Lane: 2
+    EndTime: 0
+  - StartTime: 125537
+    Lane: 4
+    EndTime: 0
+  - StartTime: 125643
+    Lane: 2
+    EndTime: 0
+  - StartTime: 125749
+    Lane: 4
+    EndTime: 0
+  - StartTime: 125749
+    Lane: 1
+    EndTime: 0
+  - StartTime: 125749
+    Lane: 3
+    EndTime: 0
+  - StartTime: 125854
+    Lane: 1
+    EndTime: 0
+  - StartTime: 126065
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126065
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126065
+    Lane: 3
+    EndTime: 0
+  - StartTime: 126277
+    Lane: 1
+    EndTime: 0
+  - StartTime: 126277
+    Lane: 3
+    EndTime: 0
+  - StartTime: 126277
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126488
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126488
+    Lane: 3
+    EndTime: 0
+  - StartTime: 126488
+    Lane: 1
+    EndTime: 0
+  - StartTime: 126699
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126699
+    Lane: 3
+    EndTime: 0
+  - StartTime: 126805
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126805
+    Lane: 1
+    EndTime: 0
+  - StartTime: 126910
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126910
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127122
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127122
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127122
+    Lane: 4
+    EndTime: 0
+  - StartTime: 127333
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127333
+    Lane: 2
+    EndTime: 0
+  - StartTime: 127439
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127439
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127544
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127544
+    Lane: 2
+    EndTime: 0
+  - StartTime: 127756
+    Lane: 4
+    EndTime: 0
+  - StartTime: 127756
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127756
+    Lane: 2
+    EndTime: 0
+  - StartTime: 127967
+    Lane: 2
+    EndTime: 0
+  - StartTime: 127967
+    Lane: 4
+    EndTime: 0
+  - StartTime: 127967
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128178
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128178
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128178
+    Lane: 4
+    EndTime: 0
+  - StartTime: 128389
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128389
+    Lane: 2
+    EndTime: 0
+  - StartTime: 128495
+    Lane: 4
+    EndTime: 0
+  - StartTime: 128495
+    Lane: 2
+    EndTime: 0
+  - StartTime: 128601
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128601
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128706
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128706
+    Lane: 2
+    EndTime: 0
+  - StartTime: 128812
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128812
+    Lane: 4
+    EndTime: 0
+  - StartTime: 128918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129023
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129023
+    Lane: 3
+    EndTime: 0
+  - StartTime: 129129
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129129
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129234
+    Lane: 1
+    EndTime: 0
+  - StartTime: 129234
+    Lane: 3
+    EndTime: 0
+  - StartTime: 129446
+    Lane: 1
+    EndTime: 0
+  - StartTime: 129446
+    Lane: 3
+    EndTime: 0
+  - StartTime: 129446
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129657
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129657
+    Lane: 1
+    EndTime: 0
+  - StartTime: 129657
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129868
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129868
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129868
+    Lane: 3
+    EndTime: 0
+  - StartTime: 130079
+    Lane: 4
+    EndTime: 0
+  - StartTime: 130079
+    Lane: 1
+    EndTime: 0
+  - StartTime: 130185
+    Lane: 1
+    EndTime: 0
+  - StartTime: 130185
+    Lane: 3
+    EndTime: 0
+  - StartTime: 130291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 130291
+    Lane: 3
+    EndTime: 0
+  - StartTime: 130502
+    Lane: 1
+    EndTime: 0
+  - StartTime: 130502
+    Lane: 2
+    EndTime: 0
+  - StartTime: 130502
+    Lane: 4
+    EndTime: 0
+  - StartTime: 130713
+    Lane: 2
+    EndTime: 0
+  - StartTime: 130713
+    Lane: 3
+    EndTime: 0
+  - StartTime: 130819
+    Lane: 4
+    EndTime: 0
+  - StartTime: 130819
+    Lane: 2
+    EndTime: 0
+  - StartTime: 130925
+    Lane: 1
+    EndTime: 0
+  - StartTime: 130925
+    Lane: 4
+    EndTime: 0
+  - StartTime: 131136
+    Lane: 1
+    EndTime: 0
+  - StartTime: 131136
+    Lane: 2
+    EndTime: 0
+  - StartTime: 131136
+    Lane: 3
+    EndTime: 0
+  - StartTime: 131347
+    Lane: 4
+    EndTime: 0
+  - StartTime: 131347
+    Lane: 3
+    EndTime: 0
+  - StartTime: 131347
+    Lane: 2
+    EndTime: 0
+  - StartTime: 131558
+    Lane: 1
+    EndTime: 0
+  - StartTime: 131558
+    Lane: 2
+    EndTime: 0
+  - StartTime: 131558
+    Lane: 4
+    EndTime: 0
+  - StartTime: 131770
+    Lane: 1
+    EndTime: 0
+  - StartTime: 131770
+    Lane: 4
+    EndTime: 0
+  - StartTime: 131875
+    Lane: 4
+    EndTime: 0
+  - StartTime: 131875
+    Lane: 2
+    EndTime: 0
+  - StartTime: 131981
+    Lane: 1
+    EndTime: 0
+  - StartTime: 131981
+    Lane: 3
+    EndTime: 0
+  - StartTime: 132087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 132087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 132192
+    Lane: 2
+    EndTime: 0
+  - StartTime: 132192
+    Lane: 1
+    EndTime: 0
+  - StartTime: 132298
+    Lane: 2
+    EndTime: 0
+  - StartTime: 132298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 132403
+    Lane: 1
+    EndTime: 0
+  - StartTime: 132403
+    Lane: 3
+    EndTime: 0
+  - StartTime: 132509
+    Lane: 1
+    EndTime: 0
+  - StartTime: 132509
+    Lane: 4
+    EndTime: 0
+  - StartTime: 132615
+    Lane: 2
+    EndTime: 0
+  - StartTime: 132615
+    Lane: 4
+    EndTime: 0
+  - StartTime: 132826
+    Lane: 4
+    EndTime: 0
+  - StartTime: 132826
+    Lane: 1
+    EndTime: 0
+  - StartTime: 132826
+    Lane: 2
+    EndTime: 0
+  - StartTime: 133037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 133037
+    Lane: 3
+    EndTime: 0
+  - StartTime: 133037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 133249
+    Lane: 2
+    EndTime: 0
+  - StartTime: 133249
+    Lane: 4
+    EndTime: 0
+  - StartTime: 133249
+    Lane: 3
+    EndTime: 0
+  - StartTime: 133460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 133460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 133565
+    Lane: 4
+    EndTime: 0
+  - StartTime: 133565
+    Lane: 2
+    EndTime: 0
+  - StartTime: 133671
+    Lane: 3
+    EndTime: 0
+  - StartTime: 133671
+    Lane: 2
+    EndTime: 0
+  - StartTime: 133882
+    Lane: 1
+    EndTime: 0
+  - StartTime: 133882
+    Lane: 2
+    EndTime: 0
+  - StartTime: 133882
+    Lane: 4
+    EndTime: 0
+  - StartTime: 134094
+    Lane: 4
+    EndTime: 0
+  - StartTime: 134094
+    Lane: 1
+    EndTime: 0
+  - StartTime: 134199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 134199
+    Lane: 3
+    EndTime: 0
+  - StartTime: 134305
+    Lane: 2
+    EndTime: 0
+  - StartTime: 134305
+    Lane: 3
+    EndTime: 0
+  - StartTime: 134516
+    Lane: 3
+    EndTime: 0
+  - StartTime: 134516
+    Lane: 2
+    EndTime: 0
+  - StartTime: 134516
+    Lane: 1
+    EndTime: 0
+  - StartTime: 134727
+    Lane: 4
+    EndTime: 0
+  - StartTime: 134727
+    Lane: 2
+    EndTime: 0
+  - StartTime: 134727
+    Lane: 3
+    EndTime: 0
+  - StartTime: 134939
+    Lane: 2
+    EndTime: 0
+  - StartTime: 134939
+    Lane: 4
+    EndTime: 0
+  - StartTime: 134939
+    Lane: 1
+    EndTime: 0
+  - StartTime: 135150
+    Lane: 1
+    EndTime: 0
+  - StartTime: 135150
+    Lane: 3
+    EndTime: 0
+  - StartTime: 135256
+    Lane: 3
+    EndTime: 0
+  - StartTime: 135256
+    Lane: 2
+    EndTime: 0
+  - StartTime: 135361
+    Lane: 4
+    EndTime: 0
+  - StartTime: 135361
+    Lane: 1
+    EndTime: 0
+  - StartTime: 135467
+    Lane: 1
+    EndTime: 0
+  - StartTime: 135467
+    Lane: 3
+    EndTime: 0
+  - StartTime: 135572
+    Lane: 2
+    EndTime: 0
+  - StartTime: 135572
+    Lane: 4
+    EndTime: 0
+  - StartTime: 135678
+    Lane: 4
+    EndTime: 0
+  - StartTime: 135678
+    Lane: 3
+    EndTime: 0
+  - StartTime: 135784
+    Lane: 1
+    EndTime: 0
+  - StartTime: 135784
+    Lane: 2
+    EndTime: 0
+  - StartTime: 135889
+    Lane: 4
+    EndTime: 138425
+  - StartTime: 135889
+    Lane: 1
+    EndTime: 0
+  - StartTime: 135995
+    Lane: 2
+    EndTime: 0
+  - StartTime: 135995
+    Lane: 3
+    EndTime: 0
+  - StartTime: 136206
+    Lane: 3
+    EndTime: 0
+  - StartTime: 136206
+    Lane: 1
+    EndTime: 0
+  - StartTime: 136418
+    Lane: 2
+    EndTime: 0
+  - StartTime: 136418
+    Lane: 3
+    EndTime: 0
+  - StartTime: 136629
+    Lane: 2
+    EndTime: 0
+  - StartTime: 136629
+    Lane: 1
+    EndTime: 0
+  - StartTime: 136840
+    Lane: 3
+    EndTime: 0
+  - StartTime: 136946
+    Lane: 1
+    EndTime: 0
+  - StartTime: 136946
+    Lane: 3
+    EndTime: 0
+  - StartTime: 137051
+    Lane: 1
+    EndTime: 0
+  - StartTime: 137263
+    Lane: 2
+    EndTime: 0
+  - StartTime: 137263
+    Lane: 3
+    EndTime: 0
+  - StartTime: 137474
+    Lane: 1
+    EndTime: 0
+  - StartTime: 137579
+    Lane: 1
+    EndTime: 0
+  - StartTime: 137579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 137685
+    Lane: 3
+    EndTime: 0
+  - StartTime: 137896
+    Lane: 1
+    EndTime: 0
+  - StartTime: 138108
+    Lane: 2
+    EndTime: 0
+  - StartTime: 138319
+    Lane: 3
+    EndTime: 0
+  - StartTime: 138530
+    Lane: 2
+    EndTime: 0
+  - StartTime: 138530
+    Lane: 3
+    EndTime: 0
+  - StartTime: 138636
+    Lane: 1
+    EndTime: 0
+  - StartTime: 138636
+    Lane: 4
+    EndTime: 0
+  - StartTime: 138741
+    Lane: 2
+    EndTime: 0
+  - StartTime: 138741
+    Lane: 3
+    EndTime: 0
+  - StartTime: 138953
+    Lane: 1
+    EndTime: 0
+  - StartTime: 138953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 139058
+    Lane: 3
+    EndTime: 0
+  - StartTime: 139058
+    Lane: 4
+    EndTime: 0
+  - StartTime: 139164
+    Lane: 1
+    EndTime: 0
+  - StartTime: 139164
+    Lane: 4
+    EndTime: 0
+  - StartTime: 139164
+    Lane: 2
+    EndTime: 0
+  - StartTime: 139481
+    Lane: 4
+    EndTime: 0
+  - StartTime: 139587
+    Lane: 3
+    EndTime: 0
+  - StartTime: 139692
+    Lane: 4
+    EndTime: 0
+  - StartTime: 139692
+    Lane: 1
+    EndTime: 0
+  - StartTime: 139692
+    Lane: 2
+    EndTime: 0
+  - StartTime: 139798
+    Lane: 3
+    EndTime: 0
+  - StartTime: 139903
+    Lane: 2
+    EndTime: 0
+  - StartTime: 140115
+    Lane: 3
+    EndTime: 0
+  - StartTime: 140115
+    Lane: 1
+    EndTime: 0
+  - StartTime: 140326
+    Lane: 4
+    EndTime: 0
+  - StartTime: 140537
+    Lane: 1
+    EndTime: 0
+  - StartTime: 140537
+    Lane: 2
+    EndTime: 0
+  - StartTime: 140960
+    Lane: 2
+    EndTime: 0
+  - StartTime: 140960
+    Lane: 3
+    EndTime: 0
+  - StartTime: 141065
+    Lane: 1
+    EndTime: 0
+  - StartTime: 141171
+    Lane: 2
+    EndTime: 0
+  - StartTime: 141277
+    Lane: 3
+    EndTime: 0
+  - StartTime: 141277
+    Lane: 4
+    EndTime: 0
+  - StartTime: 141382
+    Lane: 2
+    EndTime: 0
+  - StartTime: 141594
+    Lane: 3
+    EndTime: 0
+  - StartTime: 141805
+    Lane: 1
+    EndTime: 142650
+  - StartTime: 141805
+    Lane: 4
+    EndTime: 142650
+  - StartTime: 142650
+    Lane: 3
+    EndTime: 0
+  - StartTime: 142966
+    Lane: 2
+    EndTime: 0
+  - StartTime: 143072
+    Lane: 1
+    EndTime: 0
+  - StartTime: 143072
+    Lane: 4
+    EndTime: 0
+  - StartTime: 143178
+    Lane: 3
+    EndTime: 0
+  - StartTime: 143283
+    Lane: 4
+    EndTime: 0
+  - StartTime: 143389
+    Lane: 1
+    EndTime: 0
+  - StartTime: 143442
+    Lane: 2
+    EndTime: 0
+  - StartTime: 143495
+    Lane: 3
+    EndTime: 0
+  - StartTime: 143600
+    Lane: 2
+    EndTime: 0
+  - StartTime: 143706
+    Lane: 1
+    EndTime: 0
+  - StartTime: 143776
+    Lane: 3
+    EndTime: 0
+  - StartTime: 143847
+    Lane: 4
+    EndTime: 0
+  - StartTime: 143917
+    Lane: 1
+    EndTime: 0
+  - StartTime: 144023
+    Lane: 2
+    EndTime: 0
+  - StartTime: 144128
+    Lane: 3
+    EndTime: 0
+  - StartTime: 144234
+    Lane: 1
+    EndTime: 0
+  - StartTime: 144340
+    Lane: 4
+    EndTime: 0
+  - StartTime: 144445
+    Lane: 3
+    EndTime: 0
+  - StartTime: 144551
+    Lane: 2
+    EndTime: 0
+  - StartTime: 144657
+    Lane: 1
+    EndTime: 0
+  - StartTime: 144762
+    Lane: 1
+    EndTime: 0
+  - StartTime: 144868
+    Lane: 2
+    EndTime: 0
+  - StartTime: 145026
+    Lane: 3
+    EndTime: 0
+  - StartTime: 145185
+    Lane: 1
+    EndTime: 146030
+  - StartTime: 145185
+    Lane: 4
+    EndTime: 146030
+  - StartTime: 146030
+    Lane: 3
+    EndTime: 0
+  - StartTime: 146135
+    Lane: 2
+    EndTime: 0
+  - StartTime: 146241
+    Lane: 4
+    EndTime: 0
+  - StartTime: 146346
+    Lane: 1
+    EndTime: 0
+  - StartTime: 146875
+    Lane: 4
+    EndTime: 0
+  - StartTime: 147086
+    Lane: 2
+    EndTime: 0
+  - StartTime: 147720
+    Lane: 1
+    EndTime: 0
+  - StartTime: 147931
+    Lane: 2
+    EndTime: 0
+  - StartTime: 148565
+    Lane: 2
+    EndTime: 0
+  - StartTime: 148776
+    Lane: 4
+    EndTime: 0
+  - StartTime: 149410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 149515
+    Lane: 2
+    EndTime: 0
+  - StartTime: 149621
+    Lane: 3
+    EndTime: 0
+  - StartTime: 149727
+    Lane: 2
+    EndTime: 0
+  - StartTime: 149832
+    Lane: 4
+    EndTime: 0
+  - StartTime: 150044
+    Lane: 3
+    EndTime: 0
+  - StartTime: 150149
+    Lane: 1
+    EndTime: 0
+  - StartTime: 150202
+    Lane: 2
+    EndTime: 0
+  - StartTime: 150308
+    Lane: 4
+    EndTime: 0
+  - StartTime: 150360
+    Lane: 3
+    EndTime: 0
+  - StartTime: 150572
+    Lane: 3
+    EndTime: 0
+  - StartTime: 151100
+    Lane: 4
+    EndTime: 151312
+  - StartTime: 151101
+    Lane: 1
+    EndTime: 151312
+  - StartTime: 151945
+    Lane: 1
+    EndTime: 0
+  - StartTime: 152367
+    Lane: 1
+    EndTime: 0
+  - StartTime: 152790
+    Lane: 1
+    EndTime: 0
+  - StartTime: 153212
+    Lane: 1
+    EndTime: 0
+  - StartTime: 153635
+    Lane: 4
+    EndTime: 0
+  - StartTime: 153635
+    Lane: 3
+    EndTime: 0
+  - StartTime: 153846
+    Lane: 1
+    EndTime: 0
+  - StartTime: 154058
+    Lane: 2
+    EndTime: 0
+  - StartTime: 154058
+    Lane: 3
+    EndTime: 0
+  - StartTime: 154269
+    Lane: 4
+    EndTime: 0
+  - StartTime: 154481
+    Lane: 1
+    EndTime: 0
+  - StartTime: 154481
+    Lane: 2
+    EndTime: 0
+  - StartTime: 154692
+    Lane: 3
+    EndTime: 0
+  - StartTime: 154904
+    Lane: 4
+    EndTime: 0
+  - StartTime: 154904
+    Lane: 2
+    EndTime: 0
+  - StartTime: 155115
+    Lane: 1
+    EndTime: 0
+  - StartTime: 155327
+    Lane: 4
+    EndTime: 0
+  - StartTime: 155327
+    Lane: 3
+    EndTime: 0
+  - StartTime: 155538
+    Lane: 2
+    EndTime: 0
+  - StartTime: 155750
+    Lane: 1
+    EndTime: 0
+  - StartTime: 155750
+    Lane: 4
+    EndTime: 0
+  - StartTime: 155961
+    Lane: 2
+    EndTime: 0
+  - StartTime: 156173
+    Lane: 3
+    EndTime: 0
+  - StartTime: 156173
+    Lane: 4
+    EndTime: 0
+  - StartTime: 156384
+    Lane: 2
+    EndTime: 0
+  - StartTime: 156596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 156596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 156807
+    Lane: 1
+    EndTime: 0
+  - StartTime: 157019
+    Lane: 4
+    EndTime: 0
+  - StartTime: 157019
+    Lane: 2
+    EndTime: 0
+  - StartTime: 157230
+    Lane: 3
+    EndTime: 0
+  - StartTime: 157442
+    Lane: 1
+    EndTime: 0
+  - StartTime: 157442
+    Lane: 4
+    EndTime: 0
+  - StartTime: 157653
+    Lane: 2
+    EndTime: 0
+  - StartTime: 157865
+    Lane: 3
+    EndTime: 0
+  - StartTime: 157865
+    Lane: 1
+    EndTime: 0
+  - StartTime: 158076
+    Lane: 2
+    EndTime: 0
+  - StartTime: 158288
+    Lane: 4
+    EndTime: 0
+  - StartTime: 158288
+    Lane: 3
+    EndTime: 0
+  - StartTime: 158499
+    Lane: 2
+    EndTime: 0
+  - StartTime: 158711
+    Lane: 1
+    EndTime: 0
+  - StartTime: 158711
+    Lane: 4
+    EndTime: 0
+  - StartTime: 158922
+    Lane: 3
+    EndTime: 0
+  - StartTime: 159134
+    Lane: 1
+    EndTime: 0
+  - StartTime: 159134
+    Lane: 2
+    EndTime: 0
+  - StartTime: 159345
+    Lane: 3
+    EndTime: 0
+  - StartTime: 159557
+    Lane: 4
+    EndTime: 0
+  - StartTime: 159557
+    Lane: 1
+    EndTime: 0
+  - StartTime: 159768
+    Lane: 2
+    EndTime: 0
+  - StartTime: 159980
+    Lane: 4
+    EndTime: 0
+  - StartTime: 159980
+    Lane: 3
+    EndTime: 0
+  - StartTime: 160191
+    Lane: 1
+    EndTime: 0
+  - StartTime: 160403
+    Lane: 4
+    EndTime: 0
+  - StartTime: 160403
+    Lane: 3
+    EndTime: 0
+  - StartTime: 160614
+    Lane: 2
+    EndTime: 0
+  - StartTime: 160826
+    Lane: 1
+    EndTime: 0
+  - StartTime: 160826
+    Lane: 3
+    EndTime: 0
+  - StartTime: 161037
+    Lane: 2
+    EndTime: 0
+  - StartTime: 161249
+    Lane: 4
+    EndTime: 0
+  - StartTime: 161249
+    Lane: 1
+    EndTime: 0
+  - StartTime: 161460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 161672
+    Lane: 2
+    EndTime: 0
+  - StartTime: 161672
+    Lane: 1
+    EndTime: 0
+  - StartTime: 161883
+    Lane: 4
+    EndTime: 0
+  - StartTime: 162095
+    Lane: 1
+    EndTime: 0
+  - StartTime: 162095
+    Lane: 3
+    EndTime: 0
+  - StartTime: 162306
+    Lane: 4
+    EndTime: 0
+  - StartTime: 162518
+    Lane: 2
+    EndTime: 0
+  - StartTime: 162518
+    Lane: 1
+    EndTime: 0
+  - StartTime: 162729
+    Lane: 3
+    EndTime: 0
+  - StartTime: 162941
+    Lane: 1
+    EndTime: 0
+  - StartTime: 162941
+    Lane: 4
+    EndTime: 0
+  - StartTime: 163152
+    Lane: 2
+    EndTime: 0
+  - StartTime: 163364
+    Lane: 3
+    EndTime: 0
+  - StartTime: 163364
+    Lane: 1
+    EndTime: 0
+  - StartTime: 163575
+    Lane: 2
+    EndTime: 0
+  - StartTime: 163787
+    Lane: 3
+    EndTime: 0
+  - StartTime: 163787
+    Lane: 4
+    EndTime: 0
+  - StartTime: 163998
+    Lane: 2
+    EndTime: 0
+  - StartTime: 164210
+    Lane: 1
+    EndTime: 0
+  - StartTime: 164210
+    Lane: 4
+    EndTime: 0
+  - StartTime: 164421
+    Lane: 3
+    EndTime: 0
+  - StartTime: 164633
+    Lane: 4
+    EndTime: 0
+  - StartTime: 164633
+    Lane: 1
+    EndTime: 0
+  - StartTime: 164844
+    Lane: 2
+    EndTime: 0
+  - StartTime: 165055
+    Lane: 1
+    EndTime: 0
+  - StartTime: 165055
+    Lane: 4
+    EndTime: 0
+  - StartTime: 165266
+    Lane: 3
+    EndTime: 0
+  - StartTime: 165466
+    Lane: 1
+    EndTime: 0
+  - StartTime: 165888
+    Lane: 1
+    EndTime: 0
+  - StartTime: 166311
+    Lane: 1
+    EndTime: 0
+  - StartTime: 166733
+    Lane: 1
+    EndTime: 0
+  - StartTime: 167157
+    Lane: 4
+    EndTime: 0
+  - StartTime: 167368
+    Lane: 2
+    EndTime: 0
+  - StartTime: 167368
+    Lane: 3
+    EndTime: 0
+  - StartTime: 167579
+    Lane: 1
+    EndTime: 0
+  - StartTime: 167790
+    Lane: 2
+    EndTime: 0
+  - StartTime: 167790
+    Lane: 4
+    EndTime: 0
+  - StartTime: 168002
+    Lane: 3
+    EndTime: 0
+  - StartTime: 168213
+    Lane: 1
+    EndTime: 0
+  - StartTime: 168213
+    Lane: 2
+    EndTime: 0
+  - StartTime: 168424
+    Lane: 3
+    EndTime: 0
+  - StartTime: 168635
+    Lane: 2
+    EndTime: 0
+  - StartTime: 168635
+    Lane: 1
+    EndTime: 0
+  - StartTime: 168847
+    Lane: 4
+    EndTime: 0
+  - StartTime: 169058
+    Lane: 3
+    EndTime: 0
+  - StartTime: 169058
+    Lane: 4
+    EndTime: 0
+  - StartTime: 169269
+    Lane: 2
+    EndTime: 0
+  - StartTime: 169481
+    Lane: 1
+    EndTime: 0
+  - StartTime: 169481
+    Lane: 2
+    EndTime: 0
+  - StartTime: 169692
+    Lane: 1
+    EndTime: 0
+  - StartTime: 169692
+    Lane: 4
+    EndTime: 0
+  - StartTime: 169903
+    Lane: 3
+    EndTime: 0
+  - StartTime: 170114
+    Lane: 1
+    EndTime: 0
+  - StartTime: 170114
+    Lane: 3
+    EndTime: 0
+  - StartTime: 170326
+    Lane: 4
+    EndTime: 0
+  - StartTime: 170537
+    Lane: 2
+    EndTime: 0
+  - StartTime: 170748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 170748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 170959
+    Lane: 3
+    EndTime: 0
+  - StartTime: 171170
+    Lane: 2
+    EndTime: 0
+  - StartTime: 171170
+    Lane: 3
+    EndTime: 0
+  - StartTime: 171382
+    Lane: 4
+    EndTime: 0
+  - StartTime: 171593
+    Lane: 4
+    EndTime: 0
+  - StartTime: 171593
+    Lane: 3
+    EndTime: 0
+  - StartTime: 171804
+    Lane: 2
+    EndTime: 0
+  - StartTime: 172015
+    Lane: 1
+    EndTime: 0
+  - StartTime: 172015
+    Lane: 4
+    EndTime: 0
+  - StartTime: 172227
+    Lane: 3
+    EndTime: 0
+  - StartTime: 172438
+    Lane: 3
+    EndTime: 0
+  - StartTime: 172649
+    Lane: 2
+    EndTime: 0
+  - StartTime: 172860
+    Lane: 2
+    EndTime: 0
+  - StartTime: 173072
+    Lane: 1
+    EndTime: 0
+  - StartTime: 173283
+    Lane: 4
+    EndTime: 0
+  - StartTime: 173494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 173494
+    Lane: 1
+    EndTime: 0
+  - StartTime: 173706
+    Lane: 1
+    EndTime: 0
+  - StartTime: 173706
+    Lane: 3
+    EndTime: 0
+  - StartTime: 173917
+    Lane: 4
+    EndTime: 0
+  - StartTime: 173917
+    Lane: 2
+    EndTime: 0
+  - StartTime: 174128
+    Lane: 3
+    EndTime: 0
+  - StartTime: 174339
+    Lane: 1
+    EndTime: 0
+  - StartTime: 174339
+    Lane: 3
+    EndTime: 0
+  - StartTime: 174550
+    Lane: 2
+    EndTime: 0
+  - StartTime: 174762
+    Lane: 4
+    EndTime: 0
+  - StartTime: 174762
+    Lane: 3
+    EndTime: 0
+  - StartTime: 174973
+    Lane: 2
+    EndTime: 0
+  - StartTime: 175184
+    Lane: 4
+    EndTime: 0
+  - StartTime: 175184
+    Lane: 3
+    EndTime: 0
+  - StartTime: 175395
+    Lane: 1
+    EndTime: 0
+  - StartTime: 175607
+    Lane: 3
+    EndTime: 0
+  - StartTime: 175607
+    Lane: 2
+    EndTime: 0
+  - StartTime: 175607
+    Lane: 1
+    EndTime: 0
+  - StartTime: 176030
+    Lane: 3
+    EndTime: 0
+  - StartTime: 176030
+    Lane: 2
+    EndTime: 0
+  - StartTime: 176030
+    Lane: 4
+    EndTime: 0
+  - StartTime: 176452
+    Lane: 2
+    EndTime: 0
+  - StartTime: 176452
+    Lane: 1
+    EndTime: 0
+  - StartTime: 176664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 176664
+    Lane: 4
+    EndTime: 0
+  - StartTime: 176875
+    Lane: 1
+    EndTime: 0
+  - StartTime: 176875
+    Lane: 4
+    EndTime: 0
+  - StartTime: 177086
+    Lane: 3
+    EndTime: 0
+  - StartTime: 177086
+    Lane: 1
+    EndTime: 0
+  - StartTime: 177297
+    Lane: 4
+    EndTime: 0
+  - StartTime: 177297
+    Lane: 2
+    EndTime: 0
+  - StartTime: 177720
+    Lane: 2
+    EndTime: 0
+  - StartTime: 177720
+    Lane: 3
+    EndTime: 0
+  - StartTime: 178143
+    Lane: 4
+    EndTime: 0
+  - StartTime: 178565
+    Lane: 1
+    EndTime: 0
+  - StartTime: 178988
+    Lane: 2
+    EndTime: 180678
+  - StartTime: 178988
+    Lane: 3
+    EndTime: 180678
+  - StartTime: 180678
+    Lane: 4
+    EndTime: 0
+  - StartTime: 180678
+    Lane: 1
+    EndTime: 0
+  - StartTime: 180889
+    Lane: 4
+    EndTime: 0
+  - StartTime: 181100
+    Lane: 2
+    EndTime: 0
+  - StartTime: 181311
+    Lane: 3
+    EndTime: 0
+  - StartTime: 181523
+    Lane: 1
+    EndTime: 0
+  - StartTime: 181523
+    Lane: 4
+    EndTime: 0
+  - StartTime: 181734
+    Lane: 2
+    EndTime: 0
+  - StartTime: 181839
+    Lane: 4
+    EndTime: 0
+  - StartTime: 182156
+    Lane: 2
+    EndTime: 0
+  - StartTime: 182156
+    Lane: 3
+    EndTime: 0
+  - StartTime: 182156
+    Lane: 1
+    EndTime: 0
+  - StartTime: 182368
+    Lane: 2
+    EndTime: 0
+  - StartTime: 182368
+    Lane: 3
+    EndTime: 0
+  - StartTime: 182368
+    Lane: 4
+    EndTime: 0
+  - StartTime: 182579
+    Lane: 1
+    EndTime: 0
+  - StartTime: 182790
+    Lane: 2
+    EndTime: 0
+  - StartTime: 183001
+    Lane: 3
+    EndTime: 0
+  - StartTime: 183001
+    Lane: 1
+    EndTime: 0
+  - StartTime: 183213
+    Lane: 4
+    EndTime: 0
+  - StartTime: 183213
+    Lane: 2
+    EndTime: 0
+  - StartTime: 183424
+    Lane: 3
+    EndTime: 0
+  - StartTime: 183530
+    Lane: 4
+    EndTime: 0
+  - StartTime: 183635
+    Lane: 1
+    EndTime: 0
+  - StartTime: 183635
+    Lane: 2
+    EndTime: 0
+  - StartTime: 183635
+    Lane: 3
+    EndTime: 0
+  - StartTime: 183847
+    Lane: 4
+    EndTime: 0
+  - StartTime: 183847
+    Lane: 1
+    EndTime: 0
+  - StartTime: 183847
+    Lane: 2
+    EndTime: 0
+  - StartTime: 184058
+    Lane: 1
+    EndTime: 0
+  - StartTime: 184058
+    Lane: 3
+    EndTime: 0
+  - StartTime: 184058
+    Lane: 4
+    EndTime: 0
+  - StartTime: 184269
+    Lane: 2
+    EndTime: 0
+  - StartTime: 184480
+    Lane: 3
+    EndTime: 0
+  - StartTime: 184692
+    Lane: 2
+    EndTime: 0
+  - StartTime: 184903
+    Lane: 1
+    EndTime: 0
+  - StartTime: 184903
+    Lane: 3
+    EndTime: 0
+  - StartTime: 185114
+    Lane: 4
+    EndTime: 0
+  - StartTime: 185220
+    Lane: 2
+    EndTime: 0
+  - StartTime: 185325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 185325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 185325
+    Lane: 4
+    EndTime: 0
+  - StartTime: 185537
+    Lane: 4
+    EndTime: 0
+  - StartTime: 185537
+    Lane: 1
+    EndTime: 0
+  - StartTime: 185537
+    Lane: 2
+    EndTime: 0
+  - StartTime: 185642
+    Lane: 3
+    EndTime: 0
+  - StartTime: 185748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 185748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 185748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 185959
+    Lane: 3
+    EndTime: 0
+  - StartTime: 186170
+    Lane: 2
+    EndTime: 0
+  - StartTime: 186170
+    Lane: 4
+    EndTime: 0
+  - StartTime: 186382
+    Lane: 1
+    EndTime: 0
+  - StartTime: 186593
+    Lane: 4
+    EndTime: 0
+  - StartTime: 186804
+    Lane: 2
+    EndTime: 0
+  - StartTime: 186910
+    Lane: 1
+    EndTime: 0
+  - StartTime: 187016
+    Lane: 4
+    EndTime: 0
+  - StartTime: 187068
+    Lane: 3
+    EndTime: 0
+  - StartTime: 187121
+    Lane: 1
+    EndTime: 0
+  - StartTime: 187174
+    Lane: 2
+    EndTime: 0
+  - StartTime: 187227
+    Lane: 4
+    EndTime: 0
+  - StartTime: 187280
+    Lane: 3
+    EndTime: 0
+  - StartTime: 187332
+    Lane: 1
+    EndTime: 0
+  - StartTime: 187385
+    Lane: 2
+    EndTime: 0
+  - StartTime: 187438
+    Lane: 4
+    EndTime: 0
+  - StartTime: 187438
+    Lane: 3
+    EndTime: 0
+  - StartTime: 187544
+    Lane: 2
+    EndTime: 0
+  - StartTime: 187649
+    Lane: 1
+    EndTime: 0
+  - StartTime: 187649
+    Lane: 3
+    EndTime: 0
+  - StartTime: 187755
+    Lane: 2
+    EndTime: 0
+  - StartTime: 187861
+    Lane: 4
+    EndTime: 0
+  - StartTime: 187861
+    Lane: 3
+    EndTime: 0
+  - StartTime: 187966
+    Lane: 2
+    EndTime: 0
+  - StartTime: 188072
+    Lane: 4
+    EndTime: 0
+  - StartTime: 188072
+    Lane: 1
+    EndTime: 0
+  - StartTime: 188178
+    Lane: 3
+    EndTime: 0
+  - StartTime: 188283
+    Lane: 2
+    EndTime: 0
+  - StartTime: 188283
+    Lane: 4
+    EndTime: 0
+  - StartTime: 188389
+    Lane: 1
+    EndTime: 0
+  - StartTime: 188494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 188494
+    Lane: 2
+    EndTime: 0
+  - StartTime: 188600
+    Lane: 1
+    EndTime: 0
+  - StartTime: 188600
+    Lane: 3
+    EndTime: 0
+  - StartTime: 188706
+    Lane: 2
+    EndTime: 0
+  - StartTime: 188706
+    Lane: 1
+    EndTime: 0
+  - StartTime: 188706
+    Lane: 4
+    EndTime: 0
+  - StartTime: 188917
+    Lane: 2
+    EndTime: 0
+  - StartTime: 188917
+    Lane: 3
+    EndTime: 0
+  - StartTime: 188917
+    Lane: 1
+    EndTime: 0
+  - StartTime: 189128
+    Lane: 2
+    EndTime: 0
+  - StartTime: 189128
+    Lane: 4
+    EndTime: 0
+  - StartTime: 189128
+    Lane: 3
+    EndTime: 0
+  - StartTime: 189234
+    Lane: 1
+    EndTime: 0
+  - StartTime: 189339
+    Lane: 3
+    EndTime: 0
+  - StartTime: 189339
+    Lane: 4
+    EndTime: 0
+  - StartTime: 189445
+    Lane: 2
+    EndTime: 0
+  - StartTime: 189551
+    Lane: 4
+    EndTime: 0
+  - StartTime: 189551
+    Lane: 1
+    EndTime: 0
+  - StartTime: 189656
+    Lane: 3
+    EndTime: 0
+  - StartTime: 189762
+    Lane: 4
+    EndTime: 0
+  - StartTime: 189762
+    Lane: 1
+    EndTime: 0
+  - StartTime: 189868
+    Lane: 2
+    EndTime: 0
+  - StartTime: 189973
+    Lane: 3
+    EndTime: 0
+  - StartTime: 189973
+    Lane: 1
+    EndTime: 0
+  - StartTime: 190079
+    Lane: 4
+    EndTime: 0
+  - StartTime: 190185
+    Lane: 1
+    EndTime: 0
+  - StartTime: 190185
+    Lane: 3
+    EndTime: 0
+  - StartTime: 190290
+    Lane: 4
+    EndTime: 0
+  - StartTime: 190290
+    Lane: 2
+    EndTime: 0
+  - StartTime: 190396
+    Lane: 1
+    EndTime: 0
+  - StartTime: 190396
+    Lane: 3
+    EndTime: 0
+  - StartTime: 190396
+    Lane: 4
+    EndTime: 0
+  - StartTime: 190607
+    Lane: 1
+    EndTime: 0
+  - StartTime: 190607
+    Lane: 4
+    EndTime: 0
+  - StartTime: 190607
+    Lane: 2
+    EndTime: 0
+  - StartTime: 190818
+    Lane: 3
+    EndTime: 0
+  - StartTime: 190818
+    Lane: 2
+    EndTime: 0
+  - StartTime: 190818
+    Lane: 4
+    EndTime: 0
+  - StartTime: 190924
+    Lane: 1
+    EndTime: 0
+  - StartTime: 191030
+    Lane: 3
+    EndTime: 0
+  - StartTime: 191030
+    Lane: 4
+    EndTime: 0
+  - StartTime: 191135
+    Lane: 2
+    EndTime: 0
+  - StartTime: 191241
+    Lane: 1
+    EndTime: 0
+  - StartTime: 191241
+    Lane: 3
+    EndTime: 0
+  - StartTime: 191347
+    Lane: 4
+    EndTime: 0
+  - StartTime: 191452
+    Lane: 2
+    EndTime: 0
+  - StartTime: 191452
+    Lane: 3
+    EndTime: 0
+  - StartTime: 191558
+    Lane: 1
+    EndTime: 0
+  - StartTime: 191663
+    Lane: 2
+    EndTime: 0
+  - StartTime: 191663
+    Lane: 3
+    EndTime: 0
+  - StartTime: 191769
+    Lane: 4
+    EndTime: 0
+  - StartTime: 191875
+    Lane: 1
+    EndTime: 0
+  - StartTime: 191875
+    Lane: 3
+    EndTime: 0
+  - StartTime: 191980
+    Lane: 2
+    EndTime: 0
+  - StartTime: 192086
+    Lane: 1
+    EndTime: 0
+  - StartTime: 192086
+    Lane: 3
+    EndTime: 0
+  - StartTime: 192192
+    Lane: 4
+    EndTime: 0
+  - StartTime: 192297
+    Lane: 1
+    EndTime: 0
+  - StartTime: 192297
+    Lane: 3
+    EndTime: 0
+  - StartTime: 192508
+    Lane: 1
+    EndTime: 0
+  - StartTime: 192508
+    Lane: 2
+    EndTime: 0
+  - StartTime: 192508
+    Lane: 3
+    EndTime: 0
+  - StartTime: 192720
+    Lane: 4
+    EndTime: 0
+  - StartTime: 192720
+    Lane: 3
+    EndTime: 0
+  - StartTime: 192720
+    Lane: 2
+    EndTime: 0
+  - StartTime: 192931
+    Lane: 1
+    EndTime: 0
+  - StartTime: 192931
+    Lane: 2
+    EndTime: 0
+  - StartTime: 192931
+    Lane: 4
+    EndTime: 0
+  - StartTime: 193142
+    Lane: 4
+    EndTime: 0
+  - StartTime: 193142
+    Lane: 3
+    EndTime: 0
+  - StartTime: 193142
+    Lane: 1
+    EndTime: 0
+  - StartTime: 193354
+    Lane: 1
+    EndTime: 0
+  - StartTime: 193354
+    Lane: 4
+    EndTime: 0
+  - StartTime: 193459
+    Lane: 3
+    EndTime: 0
+  - StartTime: 193459
+    Lane: 2
+    EndTime: 0
+  - StartTime: 193565
+    Lane: 1
+    EndTime: 0
+  - StartTime: 193565
+    Lane: 4
+    EndTime: 0
+  - StartTime: 193670
+    Lane: 2
+    EndTime: 0
+  - StartTime: 193670
+    Lane: 3
+    EndTime: 0
+  - StartTime: 193776
+    Lane: 4
+    EndTime: 0
+  - StartTime: 193776
+    Lane: 1
+    EndTime: 0
+  - StartTime: 193882
+    Lane: 3
+    EndTime: 0
+  - StartTime: 193882
+    Lane: 2
+    EndTime: 0
+  - StartTime: 193987
+    Lane: 1
+    EndTime: 0
+  - StartTime: 193987
+    Lane: 4
+    EndTime: 0
+  - StartTime: 194093
+    Lane: 2
+    EndTime: 0
+  - StartTime: 194093
+    Lane: 3
+    EndTime: 0
+  - StartTime: 194199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 194199
+    Lane: 4
+    EndTime: 0
+  - StartTime: 194304
+    Lane: 3
+    EndTime: 0
+  - StartTime: 194410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 194410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 194515
+    Lane: 1
+    EndTime: 0
+  - StartTime: 194621
+    Lane: 2
+    EndTime: 0
+  - StartTime: 194621
+    Lane: 3
+    EndTime: 0
+  - StartTime: 194621
+    Lane: 4
+    EndTime: 0
+  - StartTime: 194727
+    Lane: 1
+    EndTime: 0
+  - StartTime: 194832
+    Lane: 2
+    EndTime: 0
+  - StartTime: 194832
+    Lane: 4
+    EndTime: 0
+  - StartTime: 194938
+    Lane: 3
+    EndTime: 0
+  - StartTime: 195044
+    Lane: 2
+    EndTime: 0
+  - StartTime: 195044
+    Lane: 4
+    EndTime: 0
+  - StartTime: 195149
+    Lane: 1
+    EndTime: 0
+  - StartTime: 195255
+    Lane: 3
+    EndTime: 0
+  - StartTime: 195255
+    Lane: 4
+    EndTime: 0
+  - StartTime: 195360
+    Lane: 1
+    EndTime: 0
+  - StartTime: 195360
+    Lane: 2
+    EndTime: 0
+  - StartTime: 195466
+    Lane: 3
+    EndTime: 0
+  - StartTime: 195466
+    Lane: 1
+    EndTime: 0
+  - StartTime: 195466
+    Lane: 4
+    EndTime: 0
+  - StartTime: 195572
+    Lane: 2
+    EndTime: 0
+  - StartTime: 195677
+    Lane: 1
+    EndTime: 0
+  - StartTime: 195677
+    Lane: 4
+    EndTime: 0
+  - StartTime: 195783
+    Lane: 3
+    EndTime: 0
+  - StartTime: 195889
+    Lane: 2
+    EndTime: 0
+  - StartTime: 195889
+    Lane: 4
+    EndTime: 0
+  - StartTime: 195994
+    Lane: 1
+    EndTime: 0
+  - StartTime: 196100
+    Lane: 2
+    EndTime: 0
+  - StartTime: 196100
+    Lane: 3
+    EndTime: 0
+  - StartTime: 196206
+    Lane: 4
+    EndTime: 0
+  - StartTime: 196311
+    Lane: 1
+    EndTime: 0
+  - StartTime: 196311
+    Lane: 2
+    EndTime: 0
+  - StartTime: 196311
+    Lane: 3
+    EndTime: 0
+  - StartTime: 196417
+    Lane: 4
+    EndTime: 0
+  - StartTime: 196522
+    Lane: 2
+    EndTime: 0
+  - StartTime: 196522
+    Lane: 1
+    EndTime: 0
+  - StartTime: 196628
+    Lane: 3
+    EndTime: 0
+  - StartTime: 196734
+    Lane: 4
+    EndTime: 0
+  - StartTime: 196734
+    Lane: 1
+    EndTime: 0
+  - StartTime: 196839
+    Lane: 3
+    EndTime: 0
+  - StartTime: 196945
+    Lane: 1
+    EndTime: 0
+  - StartTime: 196945
+    Lane: 2
+    EndTime: 0
+  - StartTime: 197051
+    Lane: 3
+    EndTime: 0
+  - StartTime: 197051
+    Lane: 4
+    EndTime: 0
+  - StartTime: 197156
+    Lane: 2
+    EndTime: 0
+  - StartTime: 197156
+    Lane: 4
+    EndTime: 0
+  - StartTime: 197156
+    Lane: 1
+    EndTime: 0
+  - StartTime: 197262
+    Lane: 3
+    EndTime: 0
+  - StartTime: 197368
+    Lane: 1
+    EndTime: 0
+  - StartTime: 197368
+    Lane: 2
+    EndTime: 0
+  - StartTime: 197473
+    Lane: 4
+    EndTime: 0
+  - StartTime: 197579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 197579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 197684
+    Lane: 4
+    EndTime: 0
+  - StartTime: 197790
+    Lane: 1
+    EndTime: 0
+  - StartTime: 197790
+    Lane: 2
+    EndTime: 0
+  - StartTime: 197896
+    Lane: 3
+    EndTime: 0
+  - StartTime: 198001
+    Lane: 4
+    EndTime: 0
+  - StartTime: 198001
+    Lane: 1
+    EndTime: 0
+  - StartTime: 198001
+    Lane: 2
+    EndTime: 0
+  - StartTime: 198107
+    Lane: 3
+    EndTime: 0
+  - StartTime: 198213
+    Lane: 1
+    EndTime: 0
+  - StartTime: 198213
+    Lane: 2
+    EndTime: 0
+  - StartTime: 198318
+    Lane: 4
+    EndTime: 0
+  - StartTime: 198424
+    Lane: 1
+    EndTime: 0
+  - StartTime: 198424
+    Lane: 3
+    EndTime: 0
+  - StartTime: 198529
+    Lane: 2
+    EndTime: 0
+  - StartTime: 198635
+    Lane: 1
+    EndTime: 0
+  - StartTime: 198635
+    Lane: 3
+    EndTime: 0
+  - StartTime: 198741
+    Lane: 2
+    EndTime: 0
+  - StartTime: 198741
+    Lane: 4
+    EndTime: 0
+  - StartTime: 198846
+    Lane: 3
+    EndTime: 0
+  - StartTime: 198846
+    Lane: 1
+    EndTime: 0
+  - StartTime: 198846
+    Lane: 4
+    EndTime: 0
+  - StartTime: 198952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 199058
+    Lane: 3
+    EndTime: 0
+  - StartTime: 199058
+    Lane: 4
+    EndTime: 0
+  - StartTime: 199163
+    Lane: 1
+    EndTime: 0
+  - StartTime: 199269
+    Lane: 2
+    EndTime: 0
+  - StartTime: 199269
+    Lane: 4
+    EndTime: 0
+  - StartTime: 199375
+    Lane: 3
+    EndTime: 0
+  - StartTime: 199480
+    Lane: 1
+    EndTime: 0
+  - StartTime: 199480
+    Lane: 4
+    EndTime: 0
+  - StartTime: 199586
+    Lane: 3
+    EndTime: 0
+  - StartTime: 199691
+    Lane: 1
+    EndTime: 0
+  - StartTime: 199691
+    Lane: 2
+    EndTime: 0
+  - StartTime: 199797
+    Lane: 4
+    EndTime: 0
+  - StartTime: 199903
+    Lane: 1
+    EndTime: 0
+  - StartTime: 199903
+    Lane: 3
+    EndTime: 0
+  - StartTime: 200008
+    Lane: 2
+    EndTime: 0
+  - StartTime: 200114
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200114
+    Lane: 3
+    EndTime: 0
+  - StartTime: 200220
+    Lane: 2
+    EndTime: 0
+  - StartTime: 200325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 200325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 200431
+    Lane: 2
+    EndTime: 0
+  - StartTime: 200431
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200537
+    Lane: 1
+    EndTime: 0
+  - StartTime: 200537
+    Lane: 3
+    EndTime: 0
+  - StartTime: 200537
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200642
+    Lane: 2
+    EndTime: 0
+  - StartTime: 200748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 200748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200853
+    Lane: 1
+    EndTime: 0
+  - StartTime: 200959
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200959
+    Lane: 2
+    EndTime: 0
+  - StartTime: 200959
+    Lane: 3
+    EndTime: 0
+  - StartTime: 201065
+    Lane: 1
+    EndTime: 0
+  - StartTime: 201170
+    Lane: 2
+    EndTime: 0
+  - StartTime: 201170
+    Lane: 3
+    EndTime: 0
+  - StartTime: 201276
+    Lane: 4
+    EndTime: 0
+  - StartTime: 201382
+    Lane: 1
+    EndTime: 0
+  - StartTime: 201382
+    Lane: 2
+    EndTime: 0
+  - StartTime: 201487
+    Lane: 3
+    EndTime: 0
+  - StartTime: 201593
+    Lane: 4
+    EndTime: 0
+  - StartTime: 201593
+    Lane: 2
+    EndTime: 0
+  - StartTime: 201699
+    Lane: 3
+    EndTime: 0
+  - StartTime: 201804
+    Lane: 1
+    EndTime: 0
+  - StartTime: 201804
+    Lane: 4
+    EndTime: 0
+  - StartTime: 201910
+    Lane: 2
+    EndTime: 0
+  - StartTime: 202015
+    Lane: 3
+    EndTime: 0
+  - StartTime: 202015
+    Lane: 4
+    EndTime: 0
+  - StartTime: 202121
+    Lane: 1
+    EndTime: 0
+  - StartTime: 202121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 202227
+    Lane: 4
+    EndTime: 0
+  - StartTime: 202227
+    Lane: 1
+    EndTime: 0
+  - StartTime: 202227
+    Lane: 3
+    EndTime: 0
+  - StartTime: 202332
+    Lane: 2
+    EndTime: 0
+  - StartTime: 202438
+    Lane: 1
+    EndTime: 0
+  - StartTime: 202438
+    Lane: 4
+    EndTime: 0
+  - StartTime: 202544
+    Lane: 3
+    EndTime: 0
+  - StartTime: 202649
+    Lane: 2
+    EndTime: 0
+  - StartTime: 202649
+    Lane: 4
+    EndTime: 0
+  - StartTime: 202755
+    Lane: 1
+    EndTime: 0
+  - StartTime: 202860
+    Lane: 2
+    EndTime: 0
+  - StartTime: 202860
+    Lane: 4
+    EndTime: 0
+  - StartTime: 202966
+    Lane: 3
+    EndTime: 0
+  - StartTime: 203072
+    Lane: 1
+    EndTime: 0
+  - StartTime: 203072
+    Lane: 2
+    EndTime: 0
+  - StartTime: 203177
+    Lane: 4
+    EndTime: 0
+  - StartTime: 203283
+    Lane: 1
+    EndTime: 0
+  - StartTime: 203283
+    Lane: 3
+    EndTime: 0
+  - StartTime: 203389
+    Lane: 2
+    EndTime: 0
+  - StartTime: 203494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 203494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 203600
+    Lane: 1
+    EndTime: 0
+  - StartTime: 203600
+    Lane: 2
+    EndTime: 0
+  - StartTime: 203706
+    Lane: 3
+    EndTime: 0
+  - StartTime: 203706
+    Lane: 4
+    EndTime: 0
+  - StartTime: 203811
+    Lane: 1
+    EndTime: 0
+  - StartTime: 203811
+    Lane: 4
+    EndTime: 0
+  - StartTime: 203811
+    Lane: 2
+    EndTime: 0
+  - StartTime: 203917
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204022
+    Lane: 2
+    EndTime: 0
+  - StartTime: 204128
+    Lane: 1
+    EndTime: 0
+  - StartTime: 204128
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204234
+    Lane: 4
+    EndTime: 0
+  - StartTime: 204339
+    Lane: 2
+    EndTime: 0
+  - StartTime: 204445
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204551
+    Lane: 1
+    EndTime: 0
+  - StartTime: 204551
+    Lane: 2
+    EndTime: 0
+  - StartTime: 204656
+    Lane: 4
+    EndTime: 0
+  - StartTime: 204762
+    Lane: 2
+    EndTime: 0
+  - StartTime: 204762
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204762
+    Lane: 1
+    EndTime: 0
+  - StartTime: 204868
+    Lane: 4
+    EndTime: 0
+  - StartTime: 204973
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204973
+    Lane: 1
+    EndTime: 0
+  - StartTime: 205079
+    Lane: 2
+    EndTime: 0
+  - StartTime: 205184
+    Lane: 3
+    EndTime: 0
+  - StartTime: 205184
+    Lane: 4
+    EndTime: 0
+  - StartTime: 205290
+    Lane: 2
+    EndTime: 0
+  - StartTime: 205396
+    Lane: 3
+    EndTime: 0
+  - StartTime: 205396
+    Lane: 4
+    EndTime: 0
+  - StartTime: 205501
+    Lane: 2
+    EndTime: 0
+  - StartTime: 205501
+    Lane: 1
+    EndTime: 0
+  - StartTime: 205607
+    Lane: 1
+    EndTime: 0
+  - StartTime: 205607
+    Lane: 3
+    EndTime: 0
+  - StartTime: 205607
+    Lane: 4
+    EndTime: 0
+  - StartTime: 205713
+    Lane: 2
+    EndTime: 0
+  - StartTime: 205818
+    Lane: 1
+    EndTime: 0
+  - StartTime: 205818
+    Lane: 4
+    EndTime: 0
+  - StartTime: 205924
+    Lane: 3
+    EndTime: 0
+  - StartTime: 206029
+    Lane: 1
+    EndTime: 0
+  - StartTime: 206029
+    Lane: 2
+    EndTime: 0
+  - StartTime: 206029
+    Lane: 4
+    EndTime: 0
+  - StartTime: 206241
+    Lane: 4
+    EndTime: 0
+  - StartTime: 206241
+    Lane: 3
+    EndTime: 0
+  - StartTime: 206241
+    Lane: 1
+    EndTime: 0
+  - StartTime: 206452
+    Lane: 2
+    EndTime: 0
+  - StartTime: 206452
+    Lane: 3
+    EndTime: 0
+  - StartTime: 206452
+    Lane: 4
+    EndTime: 0
+  - StartTime: 206663
+    Lane: 1
+    EndTime: 0
+  - StartTime: 206663
+    Lane: 2
+    EndTime: 0
+  - StartTime: 206663
+    Lane: 4
+    EndTime: 0
+  - StartTime: 206875
+    Lane: 1
+    EndTime: 0
+  - StartTime: 206875
+    Lane: 2
+    EndTime: 0
+  - StartTime: 206980
+    Lane: 3
+    EndTime: 0
+  - StartTime: 206980
+    Lane: 1
+    EndTime: 0
+  - StartTime: 207086
+    Lane: 3
+    EndTime: 0
+  - StartTime: 207086
+    Lane: 4
+    EndTime: 0
+  - StartTime: 207191
+    Lane: 1
+    EndTime: 0
+  - StartTime: 207191
+    Lane: 2
+    EndTime: 0
+  - StartTime: 207297
+    Lane: 2
+    EndTime: 0
+  - StartTime: 207403
+    Lane: 3
+    EndTime: 0
+  - StartTime: 207403
+    Lane: 4
+    EndTime: 0
+  - StartTime: 207508
+    Lane: 1
+    EndTime: 0
+  - StartTime: 207508
+    Lane: 2
+    EndTime: 0
+  - StartTime: 207508
+    Lane: 4
+    EndTime: 0
+  - StartTime: 207614
+    Lane: 1
+    EndTime: 0
+  - StartTime: 207720
+    Lane: 4
+    EndTime: 0
+  - StartTime: 208143
+    Lane: 2
+    EndTime: 0
+  - StartTime: 208565
+    Lane: 3
+    EndTime: 0
+  - StartTime: 208988
+    Lane: 4
+    EndTime: 0
+  - StartTime: 209410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 209833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 210255
+    Lane: 4
+    EndTime: 0
+  - StartTime: 210678
+    Lane: 4
+    EndTime: 0
+  - StartTime: 211100
+    Lane: 3
+    EndTime: 0
+  - StartTime: 211523
+    Lane: 3
+    EndTime: 0
+  - StartTime: 211945
+    Lane: 2
+    EndTime: 0
+  - StartTime: 212368
+    Lane: 2
+    EndTime: 0
+  - StartTime: 212790
+    Lane: 1
+    EndTime: 0
+  - StartTime: 213213
+    Lane: 4
+    EndTime: 0
+  - StartTime: 213636
+    Lane: 1
+    EndTime: 0
+  - StartTime: 214058
+    Lane: 4
+    EndTime: 0
+  - StartTime: 214481
+    Lane: 4
+    EndTime: 0
+  - StartTime: 214903
+    Lane: 2
+    EndTime: 0
+  - StartTime: 215326
+    Lane: 3
+    EndTime: 0
+  - StartTime: 215748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 216171
+    Lane: 4
+    EndTime: 0
+  - StartTime: 216593
+    Lane: 2
+    EndTime: 0
+  - StartTime: 217016
+    Lane: 4
+    EndTime: 0
+  - StartTime: 217438
+    Lane: 4
+    EndTime: 0
+  - StartTime: 217861
+    Lane: 3
+    EndTime: 0
+  - StartTime: 218283
+    Lane: 3
+    EndTime: 0
+  - StartTime: 218706
+    Lane: 2
+    EndTime: 0
+  - StartTime: 219128
+    Lane: 2
+    EndTime: 0
+  - StartTime: 219551
+    Lane: 1
+    EndTime: 0
+  - StartTime: 219974
+    Lane: 4
+    EndTime: 0
+  - StartTime: 220396
+    Lane: 1
+    EndTime: 0
+  - StartTime: 220819
+    Lane: 4
+    EndTime: 0
+  - StartTime: 221241
+    Lane: 4
+    EndTime: 221927
+  - StartTime: 221241
+    Lane: 2
+    EndTime: 222033
+  - StartTime: 221241
+    Lane: 3
+    EndTime: 221980
+  - StartTime: 221241
+    Lane: 1
+    EndTime: 222086

--- a/Quaver.API.Tests/Quaver/Resources/regression-1-normalized.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-1-normalized.qua
@@ -1,0 +1,15 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: true
+InitialScrollVelocity: 1.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 0
+SliderVelocities: []
+HitObjects: []

--- a/Quaver.API.Tests/Quaver/Resources/regression-1.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-1.qua
@@ -1,0 +1,15 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: false
+InitialScrollVelocity: 0.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 0
+SliderVelocities: []
+HitObjects: []

--- a/Quaver.API.Tests/Quaver/Resources/regression-2-normalized.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-2-normalized.qua
@@ -1,0 +1,15 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: true
+InitialScrollVelocity: -8.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 0
+SliderVelocities: []
+HitObjects: []

--- a/Quaver.API.Tests/Quaver/Resources/regression-2.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-2.qua
@@ -1,0 +1,17 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: false
+InitialScrollVelocity: 0.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 0
+SliderVelocities:
+  - StartTime: 0.0
+    Multiplier: -8.0
+HitObjects: []

--- a/Quaver.API.Tests/Quaver/Resources/regression-3-normalized.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-3-normalized.qua
@@ -1,0 +1,17 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: true
+InitialScrollVelocity: -8.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 0
+SliderVelocities:
+  - StartTime: 0.0
+    Multiplier: 1.0
+HitObjects: []

--- a/Quaver.API.Tests/Quaver/Resources/regression-3.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-3.qua
@@ -1,0 +1,17 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: false
+InitialScrollVelocity: 0.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 0
+SliderVelocities:
+  - StartTime: -12057820.0
+    Multiplier: -8.0
+HitObjects: []

--- a/Quaver.API.Tests/Quaver/Resources/regression-4-normalized.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-4-normalized.qua
@@ -1,0 +1,19 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: true
+InitialScrollVelocity: -8.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 0
+SliderVelocities:
+  - StartTime: -12057820.0
+    Multiplier: -4.0
+  - StartTime: 0.0
+    Multiplier: -8.0
+HitObjects: []

--- a/Quaver.API.Tests/Quaver/Resources/regression-4.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-4.qua
@@ -1,0 +1,21 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: false
+InitialScrollVelocity: 0.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 0
+SliderVelocities:
+  - StartTime: 0.0
+    Multiplier: -8.0
+  - StartTime: -15698166.0
+    Multiplier: -8.0
+  - StartTime: -12057820.0
+    Multiplier: -4.0
+HitObjects: []

--- a/Quaver.API.Tests/Quaver/Resources/regression-5-normalized.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-5-normalized.qua
@@ -1,0 +1,25 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: true
+InitialScrollVelocity: -0.125
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 1
+  - StartTime: 0.0
+    Bpm: 2.0
+    Signature: 1
+SliderVelocities:
+  - StartTime: 0.0
+    Multiplier: 0.5
+  - StartTime: 0.0
+    Multiplier: 1.0
+HitObjects:
+  - StartTime: 0
+    Lane: 1
+    EndTime: 0

--- a/Quaver.API.Tests/Quaver/Resources/regression-5.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-5.qua
@@ -1,0 +1,23 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: false
+InitialScrollVelocity: 0.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 1
+  - StartTime: 0.0
+    Bpm: 2.0
+    Signature: 1
+SliderVelocities:
+  - StartTime: -100.0
+    Multiplier: -0.25
+HitObjects:
+  - StartTime: 0
+    Lane: 1
+    EndTime: 0

--- a/Quaver.API.Tests/Quaver/Resources/regression-6-normalized.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-6-normalized.qua
@@ -1,0 +1,25 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: true
+InitialScrollVelocity: 1.0
+TimingPoints:
+  - StartTime: -37700.0
+    Bpm: 64.0
+    Signature: 1
+  - StartTime: 0.0
+    Bpm: 128.0
+    Signature: 1
+SliderVelocities:
+  - StartTime: -37700.0
+    Multiplier: 0.5
+  - StartTime: 0.0
+    Multiplier: 1.0
+HitObjects:
+  - StartTime: 37920
+    Lane: 1
+    EndTime: 0

--- a/Quaver.API.Tests/Quaver/Resources/regression-6.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-6.qua
@@ -1,0 +1,23 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: false
+InitialScrollVelocity: 0.0
+TimingPoints:
+  - StartTime: -37700.0
+    Bpm: 64.0
+    Signature: 1
+  - StartTime: 0.0
+    Bpm: 128.0
+    Signature: 1
+SliderVelocities:
+  - StartTime: -37800.0
+    Multiplier: 2.0
+HitObjects:
+  - StartTime: 37920
+    Lane: 1
+    EndTime: 0

--- a/Quaver.API.Tests/Quaver/Resources/regression-7-normalized.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-7-normalized.qua
@@ -1,0 +1,23 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: true
+InitialScrollVelocity: 0.5
+TimingPoints:
+  - StartTime: -83000.0
+    Bpm: 64.0
+    Signature: 1
+  - StartTime: 0.0
+    Bpm: 128.0
+    Signature: 1
+SliderVelocities:
+  - StartTime: 0.0
+    Multiplier: 1.0
+HitObjects:
+  - StartTime: 0
+    Lane: 1
+    EndTime: 201025

--- a/Quaver.API.Tests/Quaver/Resources/regression-7.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-7.qua
@@ -1,0 +1,21 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: false
+InitialScrollVelocity: 0.0
+TimingPoints:
+  - StartTime: -83000.0
+    Bpm: 64.0
+    Signature: 1
+  - StartTime: 0.0
+    Bpm: 128.0
+    Signature: 1
+SliderVelocities: []
+HitObjects:
+  - StartTime: 0
+    Lane: 1
+    EndTime: 201025

--- a/Quaver.API.Tests/Quaver/Resources/regression-8-normalized.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-8-normalized.qua
@@ -1,0 +1,199 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: true
+InitialScrollVelocity: 2.0
+TimingPoints:
+  - StartTime: -98800.0
+    Bpm: 128.0
+    Signature: 227
+  - StartTime: -91100.0
+    Bpm: 128.0
+    Signature: 179
+  - StartTime: -88500.0
+    Bpm: 128.0
+    Signature: 198
+  - StartTime: -79000.0
+    Bpm: 64.0
+    Signature: 70
+  - StartTime: -70700.0
+    Bpm: 128.0
+    Signature: 68
+  - StartTime: -62600.0
+    Bpm: 128.0
+    Signature: 75
+  - StartTime: -60000.0
+    Bpm: 128.0
+    Signature: 82
+  - StartTime: -58300.0
+    Bpm: 64.0
+    Signature: 180
+  - StartTime: -50400.0
+    Bpm: 64.0
+    Signature: 137
+  - StartTime: -45400.0
+    Bpm: 64.0
+    Signature: 99
+  - StartTime: -45300.0
+    Bpm: 64.0
+    Signature: 89
+  - StartTime: -43500.0
+    Bpm: 64.0
+    Signature: 1
+  - StartTime: -40900.0
+    Bpm: 64.0
+    Signature: 33
+  - StartTime: -39000.0
+    Bpm: 64.0
+    Signature: 32
+  - StartTime: -38800.0
+    Bpm: 128.0
+    Signature: 104
+  - StartTime: -36300.0
+    Bpm: 64.0
+    Signature: 173
+  - StartTime: -32800.0
+    Bpm: 64.0
+    Signature: 71
+  - StartTime: -29800.0
+    Bpm: 64.0
+    Signature: 202
+  - StartTime: -28400.0
+    Bpm: 64.0
+    Signature: 240
+  - StartTime: -18700.0
+    Bpm: 64.0
+    Signature: 115
+  - StartTime: -17700.0
+    Bpm: 64.0
+    Signature: 36
+  - StartTime: 4700.0
+    Bpm: 64.0
+    Signature: 199
+  - StartTime: 6300.0
+    Bpm: 128.0
+    Signature: 231
+  - StartTime: 6900.0
+    Bpm: 128.0
+    Signature: 106
+  - StartTime: 14400.0
+    Bpm: 128.0
+    Signature: 131
+  - StartTime: 16200.0
+    Bpm: 64.0
+    Signature: 3
+  - StartTime: 16700.0
+    Bpm: 128.0
+    Signature: 29
+  - StartTime: 39300.0
+    Bpm: 64.0
+    Signature: 157
+  - StartTime: 39400.0
+    Bpm: 128.0
+    Signature: 18
+  - StartTime: 46000.0
+    Bpm: 64.0
+    Signature: 112
+  - StartTime: 55900.0
+    Bpm: 64.0
+    Signature: 168
+  - StartTime: 62600.0
+    Bpm: 64.0
+    Signature: 53
+  - StartTime: 66900.0
+    Bpm: 64.0
+    Signature: 206
+  - StartTime: 84800.0
+    Bpm: 64.0
+    Signature: 167
+  - StartTime: 89300.0
+    Bpm: 128.0
+    Signature: 129
+  - StartTime: 92500.0
+    Bpm: 128.0
+    Signature: 16
+  - StartTime: 94500.0
+    Bpm: 64.0
+    Signature: 92
+  - StartTime: 98400.0
+    Bpm: 64.0
+    Signature: 211
+SliderVelocities:
+  - StartTime: -79000.0
+    Multiplier: 1.0
+  - StartTime: -70700.0
+    Multiplier: 2.0
+  - StartTime: -58300.0
+    Multiplier: 1.0
+  - StartTime: -38800.0
+    Multiplier: 2.0
+  - StartTime: -36300.0
+    Multiplier: 1.0
+  - StartTime: 6300.0
+    Multiplier: 2.0
+  - StartTime: 16200.0
+    Multiplier: 1.0
+  - StartTime: 16700.0
+    Multiplier: 2.0
+  - StartTime: 39300.0
+    Multiplier: 1.0
+  - StartTime: 39400.0
+    Multiplier: 2.0
+  - StartTime: 46000.0
+    Multiplier: -8.0
+  - StartTime: 55900.0
+    Multiplier: 1.0
+  - StartTime: 89300.0
+    Multiplier: 2.0
+  - StartTime: 94500.0
+    Multiplier: 1.0
+HitObjects:
+  - StartTime: 202462
+    Lane: 1
+    EndTime: 0
+  - StartTime: 970163
+    Lane: 1
+    EndTime: 15680283
+  - StartTime: 2506236
+    Lane: 3
+    EndTime: 19481258
+  - StartTime: 2852464
+    Lane: 1
+    EndTime: 20351517
+  - StartTime: 3544150
+    Lane: 3
+    EndTime: 20464567
+  - StartTime: 7072036
+    Lane: 1
+    EndTime: 0
+  - StartTime: 8092560
+    Lane: 2
+    EndTime: 0
+  - StartTime: 8228738
+    Lane: 4
+    EndTime: 12197545
+  - StartTime: 8636771
+    Lane: 3
+    EndTime: 9902122
+  - StartTime: 9678597
+    Lane: 4
+    EndTime: 12003914
+  - StartTime: 11177954
+    Lane: 4
+    EndTime: 0
+  - StartTime: 17004952
+    Lane: 2
+    EndTime: 19753175
+  - StartTime: 19669830
+    Lane: 1
+    EndTime: 0
+  - StartTime: 20457648
+    Lane: 1
+    EndTime: 0
+  - StartTime: 21287804
+    Lane: 3
+    EndTime: 21458135

--- a/Quaver.API.Tests/Quaver/Resources/regression-8.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-8.qua
@@ -1,0 +1,175 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: false
+InitialScrollVelocity: 0.0
+TimingPoints:
+  - StartTime: -98800.0
+    Bpm: 128.0
+    Signature: 227
+  - StartTime: -91100.0
+    Bpm: 128.0
+    Signature: 179
+  - StartTime: -88500.0
+    Bpm: 128.0
+    Signature: 198
+  - StartTime: -79000.0
+    Bpm: 64.0
+    Signature: 70
+  - StartTime: -70700.0
+    Bpm: 128.0
+    Signature: 68
+  - StartTime: -62600.0
+    Bpm: 128.0
+    Signature: 75
+  - StartTime: -60000.0
+    Bpm: 128.0
+    Signature: 82
+  - StartTime: -58300.0
+    Bpm: 64.0
+    Signature: 180
+  - StartTime: -50400.0
+    Bpm: 64.0
+    Signature: 137
+  - StartTime: -45400.0
+    Bpm: 64.0
+    Signature: 99
+  - StartTime: -45300.0
+    Bpm: 64.0
+    Signature: 89
+  - StartTime: -43500.0
+    Bpm: 64.0
+    Signature: 1
+  - StartTime: -40900.0
+    Bpm: 64.0
+    Signature: 33
+  - StartTime: -39000.0
+    Bpm: 64.0
+    Signature: 32
+  - StartTime: -38800.0
+    Bpm: 128.0
+    Signature: 104
+  - StartTime: -36300.0
+    Bpm: 64.0
+    Signature: 173
+  - StartTime: -32800.0
+    Bpm: 64.0
+    Signature: 71
+  - StartTime: -29800.0
+    Bpm: 64.0
+    Signature: 202
+  - StartTime: -28400.0
+    Bpm: 64.0
+    Signature: 240
+  - StartTime: -18700.0
+    Bpm: 64.0
+    Signature: 115
+  - StartTime: -17700.0
+    Bpm: 64.0
+    Signature: 36
+  - StartTime: 4700.0
+    Bpm: 64.0
+    Signature: 199
+  - StartTime: 6300.0
+    Bpm: 128.0
+    Signature: 231
+  - StartTime: 6900.0
+    Bpm: 128.0
+    Signature: 106
+  - StartTime: 14400.0
+    Bpm: 128.0
+    Signature: 131
+  - StartTime: 16200.0
+    Bpm: 64.0
+    Signature: 3
+  - StartTime: 16700.0
+    Bpm: 128.0
+    Signature: 29
+  - StartTime: 39300.0
+    Bpm: 64.0
+    Signature: 157
+  - StartTime: 39400.0
+    Bpm: 128.0
+    Signature: 18
+  - StartTime: 46000.0
+    Bpm: 64.0
+    Signature: 112
+  - StartTime: 55900.0
+    Bpm: 64.0
+    Signature: 168
+  - StartTime: 62600.0
+    Bpm: 64.0
+    Signature: 53
+  - StartTime: 66900.0
+    Bpm: 64.0
+    Signature: 206
+  - StartTime: 84800.0
+    Bpm: 64.0
+    Signature: 167
+  - StartTime: 89300.0
+    Bpm: 128.0
+    Signature: 129
+  - StartTime: 92500.0
+    Bpm: 128.0
+    Signature: 16
+  - StartTime: 94500.0
+    Bpm: 64.0
+    Signature: 92
+  - StartTime: 98400.0
+    Bpm: 64.0
+    Signature: 211
+SliderVelocities:
+  - StartTime: 46000.0
+    Multiplier: -8.0
+  - StartTime: 55900.0
+    Multiplier: 1.0
+HitObjects:
+  - StartTime: 202462
+    Lane: 1
+    EndTime: 0
+  - StartTime: 970163
+    Lane: 1
+    EndTime: 15680283
+  - StartTime: 2506236
+    Lane: 3
+    EndTime: 19481258
+  - StartTime: 2852464
+    Lane: 1
+    EndTime: 20351517
+  - StartTime: 3544150
+    Lane: 3
+    EndTime: 20464567
+  - StartTime: 7072036
+    Lane: 1
+    EndTime: 0
+  - StartTime: 8092560
+    Lane: 2
+    EndTime: 0
+  - StartTime: 8228738
+    Lane: 4
+    EndTime: 12197545
+  - StartTime: 8636771
+    Lane: 3
+    EndTime: 9902122
+  - StartTime: 9678597
+    Lane: 4
+    EndTime: 12003914
+  - StartTime: 11177954
+    Lane: 4
+    EndTime: 0
+  - StartTime: 17004952
+    Lane: 2
+    EndTime: 19753175
+  - StartTime: 19669830
+    Lane: 1
+    EndTime: 0
+  - StartTime: 20457648
+    Lane: 1
+    EndTime: 0
+  - StartTime: 21287804
+    Lane: 3
+    EndTime: 21458135

--- a/Quaver.API.Tests/Quaver/Resources/sample-normalized.qua
+++ b/Quaver.API.Tests/Quaver/Resources/sample-normalized.qua
@@ -1,0 +1,62 @@
+---
+Mode: Keys4
+Title: Sample Map
+Artist: Unknown
+Creator: YaLTeR
+DifficultyName: Easy
+AudioFile: song.mp3
+BPMDoesNotAffectScrollVelocity: true
+InitialScrollVelocity: 0.5
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 100.0
+    Signature: 4
+  - StartTime: 200.0
+    Bpm: 200.0
+    Signature: 3
+  - StartTime: 400.0
+    Bpm: 200.0
+    Signature: 4
+  - StartTime: 500.0
+    Bpm: 200.0
+    Signature: 3
+  - StartTime: 10000.0
+    Bpm: 0.0
+    Signature: 4
+SliderVelocities:
+  - StartTime: 200.0
+    Multiplier: 1.0
+  - StartTime: 300.0
+    Multiplier: 2.0
+  - StartTime: 400.0
+    Multiplier: 1.0
+  - StartTime: 600.0
+    Multiplier: 0.0
+HitObjects:
+  - StartTime: 0
+    Lane: 4
+    EndTime: 0
+  - StartTime: 601
+    Lane: 2
+    EndTime: 0
+  - StartTime: 601
+    Lane: 1
+    EndTime: 0
+  - StartTime: 601
+    Lane: 4
+    EndTime: 939
+  - StartTime: 601
+    Lane: 3
+    EndTime: 939
+  - StartTime: 939
+    Lane: 2
+    EndTime: 1278
+  - StartTime: 939
+    Lane: 1
+    EndTime: 0
+  - StartTime: 1194
+    Lane: 4
+    EndTime: 1363
+  - StartTime: 1278
+    Lane: 3
+    EndTime: 0

--- a/Quaver.API.Tests/Quaver/Resources/sample.qua
+++ b/Quaver.API.Tests/Quaver/Resources/sample.qua
@@ -1,0 +1,58 @@
+---
+Mode: Keys4
+Title: Sample Map
+Artist: Unknown
+Creator: YaLTeR
+DifficultyName: Easy
+AudioFile: song.mp3
+BPMDoesNotAffectScrollVelocity: false
+InitialScrollVelocity: 0.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 100.0
+    Signature: 4
+  - StartTime: 200.0
+    Bpm: 200.0
+    Signature: 3
+  - StartTime: 400.0
+    Bpm: 200.0
+    Signature: 4
+  - StartTime: 500.0
+    Bpm: 200.0
+    Signature: 3
+  - StartTime: 10000.0
+    Bpm: 0.0
+    Signature: 4
+SliderVelocities:
+  - StartTime: 300.0
+    Multiplier: 2.0
+  - StartTime: 600.0
+    Multiplier: 0.0
+HitObjects:
+  - StartTime: 0
+    Lane: 4
+    EndTime: 0
+  - StartTime: 601
+    Lane: 2
+    EndTime: 0
+  - StartTime: 601
+    Lane: 1
+    EndTime: 0
+  - StartTime: 601
+    Lane: 4
+    EndTime: 939
+  - StartTime: 601
+    Lane: 3
+    EndTime: 939
+  - StartTime: 939
+    Lane: 2
+    EndTime: 1278
+  - StartTime: 939
+    Lane: 1
+    EndTime: 0
+  - StartTime: 1194
+    Lane: 4
+    EndTime: 1363
+  - StartTime: 1278
+    Lane: 3
+    EndTime: 0

--- a/Quaver.API.Tests/Quaver/Resources/sv-at-first-timing-point-normalized.qua
+++ b/Quaver.API.Tests/Quaver/Resources/sv-at-first-timing-point-normalized.qua
@@ -1,0 +1,15 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: true
+InitialScrollVelocity: 10.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 4
+SliderVelocities: []
+HitObjects: []

--- a/Quaver.API.Tests/Quaver/Resources/sv-at-first-timing-point.qua
+++ b/Quaver.API.Tests/Quaver/Resources/sv-at-first-timing-point.qua
@@ -1,0 +1,17 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: false
+InitialScrollVelocity: 0.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 4
+SliderVelocities:
+  - StartTime: 0.0
+    Multiplier: 10.0
+HitObjects: []

--- a/Quaver.API.Tests/Quaver/Resources/sv-before-first-timing-point-normalized.qua
+++ b/Quaver.API.Tests/Quaver/Resources/sv-before-first-timing-point-normalized.qua
@@ -1,0 +1,17 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: true
+InitialScrollVelocity: 10.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 4
+SliderVelocities:
+  - StartTime: 0.0
+    Multiplier: 1.0
+HitObjects: []

--- a/Quaver.API.Tests/Quaver/Resources/sv-before-first-timing-point.qua
+++ b/Quaver.API.Tests/Quaver/Resources/sv-before-first-timing-point.qua
@@ -1,0 +1,17 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: false
+InitialScrollVelocity: 0.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 4
+SliderVelocities:
+  - StartTime: -10.0
+    Multiplier: 10.0
+HitObjects: []

--- a/Quaver.API.Tests/Quaver/Resources/symphony-normalized.qua
+++ b/Quaver.API.Tests/Quaver/Resources/symphony-normalized.qua
@@ -1,0 +1,11267 @@
+---
+Mode: Keys4
+Title: Symphony of the Night
+Artist: DragonForce
+Creator: ArXXX
+DifficultyName: Melody of the Darkness  - Extreme
+AudioFile: audio.mp3
+BPMDoesNotAffectScrollVelocity: true
+InitialScrollVelocity: 1.0
+TimingPoints:
+  - StartTime: 410.0
+    Bpm: 177.0
+    Signature: 4
+  - StartTime: 144436.0
+    Bpm: 145.0
+    Signature: 4
+  - StartTime: 243742.0
+    Bpm: 177.0
+    Signature: 4
+  - StartTime: 304758.0
+    Bpm: 112.0
+    Signature: 4
+  - StartTime: 306869.0
+    Bpm: 106.0
+    Signature: 4
+  - StartTime: 308969.0
+    Bpm: 49.000003814697269
+    Signature: 4
+  - StartTime: 310193.0
+    Bpm: 49.75
+    Signature: 4
+  - StartTime: 315017.0
+    Bpm: 57.0
+    Signature: 4
+SliderVelocities:
+  - StartTime: 53291.0
+    Multiplier: 10.0
+  - StartTime: 53347.0
+    Multiplier: 5.0
+  - StartTime: 53404.0
+    Multiplier: 3.0
+  - StartTime: 53460.0
+    Multiplier: 1.0
+  - StartTime: 53517.0
+    Multiplier: 0.10000000149011612
+  - StartTime: 54393.0
+    Multiplier: 1.1999999284744263
+  - StartTime: 54647.0
+    Multiplier: 1.0
+  - StartTime: 107528.0
+    Multiplier: 10.0
+  - StartTime: 108037.0
+    Multiplier: 0.10000000149011612
+  - StartTime: 108715.0
+    Multiplier: 1.5
+  - StartTime: 108884.0
+    Multiplier: 1.0
+  - StartTime: 144436.0
+    Multiplier: 0.9180791974067688
+  - StartTime: 174229.0
+    Multiplier: 1.0
+  - StartTime: 274928.0
+    Multiplier: 1.600000023841858
+  - StartTime: 275097.0
+    Multiplier: 0.4000000059604645
+  - StartTime: 275267.0
+    Multiplier: 1.600000023841858
+  - StartTime: 275436.0
+    Multiplier: 0.4000000059604645
+  - StartTime: 275606.0
+    Multiplier: 1.600000023841858
+  - StartTime: 275775.0
+    Multiplier: 0.4000000059604645
+  - StartTime: 275945.0
+    Multiplier: 1.600000023841858
+  - StartTime: 276114.0
+    Multiplier: 0.4000000059604645
+  - StartTime: 276284.0
+    Multiplier: 1.0
+  - StartTime: 277640.0
+    Multiplier: -1.0
+  - StartTime: 277979.0
+    Multiplier: -0.6700000166893005
+  - StartTime: 278318.0
+    Multiplier: 1.0
+  - StartTime: 308969.0
+    Multiplier: 1.0000001192092896
+  - StartTime: 310193.0
+    Multiplier: 1.0
+  - StartTime: 315017.0
+    Multiplier: 1.0000001192092896
+HitObjects:
+  - StartTime: 410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 1087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 1257
+    Lane: 1
+    EndTime: 0
+  - StartTime: 1426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 1483
+    Lane: 4
+    EndTime: 0
+  - StartTime: 1568
+    Lane: 3
+    EndTime: 0
+  - StartTime: 1652
+    Lane: 2
+    EndTime: 0
+  - StartTime: 1765
+    Lane: 4
+    EndTime: 0
+  - StartTime: 1935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 2104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 2274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 2443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 2613
+    Lane: 1
+    EndTime: 0
+  - StartTime: 2782
+    Lane: 2
+    EndTime: 0
+  - StartTime: 2867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 2952
+    Lane: 4
+    EndTime: 0
+  - StartTime: 3037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 3121
+    Lane: 4
+    EndTime: 0
+  - StartTime: 3291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 3460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 3630
+    Lane: 4
+    EndTime: 0
+  - StartTime: 3799
+    Lane: 2
+    EndTime: 0
+  - StartTime: 3969
+    Lane: 1
+    EndTime: 0
+  - StartTime: 4138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 4223
+    Lane: 3
+    EndTime: 0
+  - StartTime: 4308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 4393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 4477
+    Lane: 4
+    EndTime: 4816
+  - StartTime: 4647
+    Lane: 2
+    EndTime: 0
+  - StartTime: 4816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 4986
+    Lane: 3
+    EndTime: 0
+  - StartTime: 5155
+    Lane: 1
+    EndTime: 5494
+  - StartTime: 5325
+    Lane: 2
+    EndTime: 0
+  - StartTime: 5494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 5579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 5664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 5748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 5833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 6003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 6172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 6342
+    Lane: 3
+    EndTime: 0
+  - StartTime: 6511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 6681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 6850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 6935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 7020
+    Lane: 2
+    EndTime: 0
+  - StartTime: 7104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 7189
+    Lane: 3
+    EndTime: 0
+  - StartTime: 7359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 7528
+    Lane: 3
+    EndTime: 0
+  - StartTime: 7698
+    Lane: 4
+    EndTime: 0
+  - StartTime: 7867
+    Lane: 2
+    EndTime: 8206
+  - StartTime: 8037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 8206
+    Lane: 3
+    EndTime: 0
+  - StartTime: 8291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 8376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 8460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 8545
+    Lane: 1
+    EndTime: 0
+  - StartTime: 8715
+    Lane: 2
+    EndTime: 0
+  - StartTime: 8884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 9054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 9223
+    Lane: 2
+    EndTime: 0
+  - StartTime: 9393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 9562
+    Lane: 4
+    EndTime: 0
+  - StartTime: 9647
+    Lane: 2
+    EndTime: 0
+  - StartTime: 9732
+    Lane: 3
+    EndTime: 0
+  - StartTime: 9816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 9901
+    Lane: 2
+    EndTime: 10918
+  - StartTime: 10071
+    Lane: 4
+    EndTime: 0
+  - StartTime: 10240
+    Lane: 1
+    EndTime: 0
+  - StartTime: 10410
+    Lane: 3
+    EndTime: 0
+  - StartTime: 10579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 10748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 10918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 11003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 11087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 11257
+    Lane: 1
+    EndTime: 11765
+  - StartTime: 11257
+    Lane: 4
+    EndTime: 0
+  - StartTime: 11257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 11596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 11765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 11765
+    Lane: 3
+    EndTime: 12274
+  - StartTime: 11935
+    Lane: 4
+    EndTime: 0
+  - StartTime: 12274
+    Lane: 2
+    EndTime: 0
+  - StartTime: 12274
+    Lane: 1
+    EndTime: 12613
+  - StartTime: 12359
+    Lane: 4
+    EndTime: 0
+  - StartTime: 12443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 12528
+    Lane: 2
+    EndTime: 0
+  - StartTime: 12613
+    Lane: 3
+    EndTime: 0
+  - StartTime: 12613
+    Lane: 4
+    EndTime: 13121
+  - StartTime: 12952
+    Lane: 1
+    EndTime: 0
+  - StartTime: 13121
+    Lane: 2
+    EndTime: 13630
+  - StartTime: 13121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 13291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 13460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 13630
+    Lane: 4
+    EndTime: 13969
+  - StartTime: 13630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 13799
+    Lane: 1
+    EndTime: 0
+  - StartTime: 13969
+    Lane: 1
+    EndTime: 0
+  - StartTime: 13969
+    Lane: 2
+    EndTime: 14477
+  - StartTime: 14308
+    Lane: 4
+    EndTime: 0
+  - StartTime: 14477
+    Lane: 3
+    EndTime: 14986
+  - StartTime: 14477
+    Lane: 1
+    EndTime: 0
+  - StartTime: 14647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 14986
+    Lane: 4
+    EndTime: 15325
+  - StartTime: 14986
+    Lane: 1
+    EndTime: 0
+  - StartTime: 15071
+    Lane: 2
+    EndTime: 0
+  - StartTime: 15155
+    Lane: 3
+    EndTime: 0
+  - StartTime: 15240
+    Lane: 1
+    EndTime: 0
+  - StartTime: 15325
+    Lane: 3
+    EndTime: 15833
+  - StartTime: 15325
+    Lane: 2
+    EndTime: 0
+  - StartTime: 15664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 15833
+    Lane: 2
+    EndTime: 16342
+  - StartTime: 15833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 16003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 16003
+    Lane: 4
+    EndTime: 0
+  - StartTime: 16172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 16342
+    Lane: 1
+    EndTime: 16681
+  - StartTime: 16342
+    Lane: 4
+    EndTime: 0
+  - StartTime: 16511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 16681
+    Lane: 4
+    EndTime: 17189
+  - StartTime: 16681
+    Lane: 3
+    EndTime: 0
+  - StartTime: 17020
+    Lane: 2
+    EndTime: 0
+  - StartTime: 17189
+    Lane: 3
+    EndTime: 18037
+  - StartTime: 17189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 17359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 17528
+    Lane: 1
+    EndTime: 0
+  - StartTime: 17698
+    Lane: 4
+    EndTime: 18037
+  - StartTime: 17698
+    Lane: 2
+    EndTime: 0
+  - StartTime: 17867
+    Lane: 1
+    EndTime: 0
+  - StartTime: 18037
+    Lane: 2
+    EndTime: 18545
+  - StartTime: 18037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 18376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 18545
+    Lane: 1
+    EndTime: 19308
+  - StartTime: 18545
+    Lane: 3
+    EndTime: 0
+  - StartTime: 18715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 18884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 18969
+    Lane: 3
+    EndTime: 0
+  - StartTime: 19054
+    Lane: 4
+    EndTime: 19308
+  - StartTime: 19138
+    Lane: 3
+    EndTime: 0
+  - StartTime: 19223
+    Lane: 2
+    EndTime: 0
+  - StartTime: 19308
+    Lane: 3
+    EndTime: 0
+  - StartTime: 19393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 19393
+    Lane: 2
+    EndTime: 0
+  - StartTime: 19393
+    Lane: 4
+    EndTime: 20748
+  - StartTime: 19732
+    Lane: 2
+    EndTime: 21003
+  - StartTime: 20071
+    Lane: 3
+    EndTime: 20664
+  - StartTime: 20410
+    Lane: 1
+    EndTime: 20918
+  - StartTime: 20748
+    Lane: 3
+    EndTime: 20833
+  - StartTime: 20833
+    Lane: 4
+    EndTime: 21172
+  - StartTime: 20918
+    Lane: 3
+    EndTime: 21342
+  - StartTime: 21003
+    Lane: 1
+    EndTime: 21681
+  - StartTime: 21087
+    Lane: 2
+    EndTime: 21511
+  - StartTime: 21257
+    Lane: 4
+    EndTime: 21426
+  - StartTime: 21426
+    Lane: 3
+    EndTime: 21596
+  - StartTime: 21596
+    Lane: 2
+    EndTime: 21765
+  - StartTime: 21765
+    Lane: 1
+    EndTime: 21935
+  - StartTime: 21935
+    Lane: 4
+    EndTime: 22104
+  - StartTime: 22104
+    Lane: 2
+    EndTime: 0
+  - StartTime: 22104
+    Lane: 3
+    EndTime: 0
+  - StartTime: 22104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 22274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 22274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 22359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 22359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 22443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 22528
+    Lane: 3
+    EndTime: 0
+  - StartTime: 22613
+    Lane: 1
+    EndTime: 0
+  - StartTime: 22613
+    Lane: 2
+    EndTime: 0
+  - StartTime: 22698
+    Lane: 3
+    EndTime: 0
+  - StartTime: 22782
+    Lane: 1
+    EndTime: 0
+  - StartTime: 22782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 22867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 22952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 22952
+    Lane: 4
+    EndTime: 0
+  - StartTime: 23037
+    Lane: 3
+    EndTime: 0
+  - StartTime: 23037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 23121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 23206
+    Lane: 1
+    EndTime: 0
+  - StartTime: 23291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 23291
+    Lane: 4
+    EndTime: 0
+  - StartTime: 23376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 23460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 23460
+    Lane: 4
+    EndTime: 0
+  - StartTime: 23630
+    Lane: 2
+    EndTime: 0
+  - StartTime: 23630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 23715
+    Lane: 1
+    EndTime: 0
+  - StartTime: 23715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 23799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 23884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 23969
+    Lane: 1
+    EndTime: 0
+  - StartTime: 23969
+    Lane: 4
+    EndTime: 0
+  - StartTime: 24054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 24138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 24138
+    Lane: 4
+    EndTime: 0
+  - StartTime: 24308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 24308
+    Lane: 3
+    EndTime: 0
+  - StartTime: 24393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 24393
+    Lane: 4
+    EndTime: 0
+  - StartTime: 24477
+    Lane: 2
+    EndTime: 0
+  - StartTime: 24562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 24647
+    Lane: 1
+    EndTime: 0
+  - StartTime: 24647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 24816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 24816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 24901
+    Lane: 4
+    EndTime: 0
+  - StartTime: 24986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 24986
+    Lane: 3
+    EndTime: 0
+  - StartTime: 25071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 25155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 25155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 25240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 25325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 25325
+    Lane: 4
+    EndTime: 0
+  - StartTime: 25410
+    Lane: 3
+    EndTime: 0
+  - StartTime: 25494
+    Lane: 2
+    EndTime: 0
+  - StartTime: 25494
+    Lane: 1
+    EndTime: 0
+  - StartTime: 25579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 25664
+    Lane: 4
+    EndTime: 0
+  - StartTime: 25664
+    Lane: 2
+    EndTime: 0
+  - StartTime: 25748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 25833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 25833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 25918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 26003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 26003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 26087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 26172
+    Lane: 2
+    EndTime: 0
+  - StartTime: 26172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 26257
+    Lane: 1
+    EndTime: 0
+  - StartTime: 26342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 26342
+    Lane: 3
+    EndTime: 0
+  - StartTime: 26426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 26511
+    Lane: 1
+    EndTime: 0
+  - StartTime: 26511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 26596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 26681
+    Lane: 4
+    EndTime: 0
+  - StartTime: 26681
+    Lane: 2
+    EndTime: 0
+  - StartTime: 26765
+    Lane: 1
+    EndTime: 0
+  - StartTime: 26850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 26850
+    Lane: 3
+    EndTime: 0
+  - StartTime: 26935
+    Lane: 2
+    EndTime: 0
+  - StartTime: 26935
+    Lane: 1
+    EndTime: 0
+  - StartTime: 27020
+    Lane: 4
+    EndTime: 0
+  - StartTime: 27104
+    Lane: 3
+    EndTime: 0
+  - StartTime: 27189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 27189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 27274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 27274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 27359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 27359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 27443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 27443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 27528
+    Lane: 1
+    EndTime: 0
+  - StartTime: 27528
+    Lane: 2
+    EndTime: 0
+  - StartTime: 27528
+    Lane: 4
+    EndTime: 27782
+  - StartTime: 27698
+    Lane: 3
+    EndTime: 0
+  - StartTime: 27782
+    Lane: 1
+    EndTime: 28037
+  - StartTime: 27782
+    Lane: 2
+    EndTime: 0
+  - StartTime: 27952
+    Lane: 3
+    EndTime: 0
+  - StartTime: 28037
+    Lane: 2
+    EndTime: 0
+  - StartTime: 28037
+    Lane: 4
+    EndTime: 28206
+  - StartTime: 28206
+    Lane: 3
+    EndTime: 28460
+  - StartTime: 28206
+    Lane: 2
+    EndTime: 0
+  - StartTime: 28376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 28460
+    Lane: 1
+    EndTime: 28715
+  - StartTime: 28460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 28630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 28715
+    Lane: 2
+    EndTime: 28884
+  - StartTime: 28715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 28884
+    Lane: 4
+    EndTime: 29138
+  - StartTime: 28884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 29054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 29138
+    Lane: 2
+    EndTime: 29393
+  - StartTime: 29138
+    Lane: 1
+    EndTime: 0
+  - StartTime: 29308
+    Lane: 3
+    EndTime: 0
+  - StartTime: 29393
+    Lane: 1
+    EndTime: 29562
+  - StartTime: 29393
+    Lane: 4
+    EndTime: 0
+  - StartTime: 29562
+    Lane: 3
+    EndTime: 29816
+  - StartTime: 29562
+    Lane: 4
+    EndTime: 0
+  - StartTime: 29732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 29816
+    Lane: 1
+    EndTime: 30071
+  - StartTime: 29816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 29986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 30071
+    Lane: 4
+    EndTime: 30240
+  - StartTime: 30071
+    Lane: 3
+    EndTime: 0
+  - StartTime: 30240
+    Lane: 1
+    EndTime: 30325
+  - StartTime: 30325
+    Lane: 2
+    EndTime: 30410
+  - StartTime: 30410
+    Lane: 3
+    EndTime: 30494
+  - StartTime: 30410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 30494
+    Lane: 1
+    EndTime: 30579
+  - StartTime: 30579
+    Lane: 3
+    EndTime: 30664
+  - StartTime: 30579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 30664
+    Lane: 2
+    EndTime: 30748
+  - StartTime: 30748
+    Lane: 1
+    EndTime: 30833
+  - StartTime: 30833
+    Lane: 4
+    EndTime: 30918
+  - StartTime: 30918
+    Lane: 3
+    EndTime: 31003
+  - StartTime: 30918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 31003
+    Lane: 1
+    EndTime: 31087
+  - StartTime: 31087
+    Lane: 4
+    EndTime: 31172
+  - StartTime: 31087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 31172
+    Lane: 2
+    EndTime: 31257
+  - StartTime: 31257
+    Lane: 1
+    EndTime: 31342
+  - StartTime: 31342
+    Lane: 2
+    EndTime: 31426
+  - StartTime: 31426
+    Lane: 3
+    EndTime: 31511
+  - StartTime: 31426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 31511
+    Lane: 1
+    EndTime: 31596
+  - StartTime: 31596
+    Lane: 2
+    EndTime: 31681
+  - StartTime: 31681
+    Lane: 4
+    EndTime: 31765
+  - StartTime: 31765
+    Lane: 1
+    EndTime: 31850
+  - StartTime: 31765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 31850
+    Lane: 3
+    EndTime: 31935
+  - StartTime: 31935
+    Lane: 2
+    EndTime: 32020
+  - StartTime: 31935
+    Lane: 1
+    EndTime: 0
+  - StartTime: 32020
+    Lane: 4
+    EndTime: 32104
+  - StartTime: 32104
+    Lane: 3
+    EndTime: 32189
+  - StartTime: 32189
+    Lane: 2
+    EndTime: 32274
+  - StartTime: 32274
+    Lane: 1
+    EndTime: 32359
+  - StartTime: 32359
+    Lane: 4
+    EndTime: 32443
+  - StartTime: 32443
+    Lane: 2
+    EndTime: 32528
+  - StartTime: 32528
+    Lane: 3
+    EndTime: 32613
+  - StartTime: 32613
+    Lane: 1
+    EndTime: 32698
+  - StartTime: 32698
+    Lane: 4
+    EndTime: 32782
+  - StartTime: 32782
+    Lane: 2
+    EndTime: 32867
+  - StartTime: 32867
+    Lane: 3
+    EndTime: 32952
+  - StartTime: 32952
+    Lane: 1
+    EndTime: 0
+  - StartTime: 32952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 32952
+    Lane: 4
+    EndTime: 34308
+  - StartTime: 33121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 33121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 33206
+    Lane: 1
+    EndTime: 0
+  - StartTime: 33376
+    Lane: 1
+    EndTime: 0
+  - StartTime: 33460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 33460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 33630
+    Lane: 1
+    EndTime: 0
+  - StartTime: 33799
+    Lane: 2
+    EndTime: 0
+  - StartTime: 33799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 33884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 34054
+    Lane: 1
+    EndTime: 0
+  - StartTime: 34138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 34138
+    Lane: 3
+    EndTime: 0
+  - StartTime: 34308
+    Lane: 1
+    EndTime: 0
+  - StartTime: 34477
+    Lane: 2
+    EndTime: 0
+  - StartTime: 34477
+    Lane: 4
+    EndTime: 0
+  - StartTime: 34562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 34732
+    Lane: 2
+    EndTime: 0
+  - StartTime: 34816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 34816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 34986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 35155
+    Lane: 3
+    EndTime: 0
+  - StartTime: 35155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 35240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 35410
+    Lane: 1
+    EndTime: 0
+  - StartTime: 35494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 35494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 35664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 35664
+    Lane: 2
+    EndTime: 0
+  - StartTime: 35748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 35833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 35833
+    Lane: 1
+    EndTime: 0
+  - StartTime: 35918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 36003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 36003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 36087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 36172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 36172
+    Lane: 2
+    EndTime: 0
+  - StartTime: 36257
+    Lane: 4
+    EndTime: 0
+  - StartTime: 36342
+    Lane: 1
+    EndTime: 0
+  - StartTime: 36342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 36426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 36511
+    Lane: 1
+    EndTime: 0
+  - StartTime: 36511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 36596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 36681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 36681
+    Lane: 2
+    EndTime: 0
+  - StartTime: 36765
+    Lane: 3
+    EndTime: 0
+  - StartTime: 36850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 36850
+    Lane: 2
+    EndTime: 0
+  - StartTime: 36935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 37020
+    Lane: 1
+    EndTime: 0
+  - StartTime: 37020
+    Lane: 4
+    EndTime: 0
+  - StartTime: 37104
+    Lane: 2
+    EndTime: 0
+  - StartTime: 37189
+    Lane: 3
+    EndTime: 0
+  - StartTime: 37189
+    Lane: 4
+    EndTime: 0
+  - StartTime: 37274
+    Lane: 1
+    EndTime: 0
+  - StartTime: 37359
+    Lane: 4
+    EndTime: 0
+  - StartTime: 37359
+    Lane: 3
+    EndTime: 0
+  - StartTime: 37443
+    Lane: 2
+    EndTime: 0
+  - StartTime: 37528
+    Lane: 4
+    EndTime: 0
+  - StartTime: 37528
+    Lane: 3
+    EndTime: 0
+  - StartTime: 37613
+    Lane: 1
+    EndTime: 0
+  - StartTime: 37698
+    Lane: 3
+    EndTime: 0
+  - StartTime: 37698
+    Lane: 2
+    EndTime: 37867
+  - StartTime: 37782
+    Lane: 1
+    EndTime: 0
+  - StartTime: 37867
+    Lane: 4
+    EndTime: 0
+  - StartTime: 37867
+    Lane: 3
+    EndTime: 38037
+  - StartTime: 37952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 38037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 38037
+    Lane: 4
+    EndTime: 38206
+  - StartTime: 38121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 38206
+    Lane: 2
+    EndTime: 0
+  - StartTime: 38206
+    Lane: 1
+    EndTime: 38376
+  - StartTime: 38291
+    Lane: 4
+    EndTime: 0
+  - StartTime: 38376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 38376
+    Lane: 2
+    EndTime: 38884
+  - StartTime: 38545
+    Lane: 4
+    EndTime: 0
+  - StartTime: 38545
+    Lane: 1
+    EndTime: 0
+  - StartTime: 38630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 38799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 38884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 38884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 39054
+    Lane: 3
+    EndTime: 39562
+  - StartTime: 39054
+    Lane: 2
+    EndTime: 0
+  - StartTime: 39223
+    Lane: 4
+    EndTime: 0
+  - StartTime: 39223
+    Lane: 2
+    EndTime: 0
+  - StartTime: 39308
+    Lane: 1
+    EndTime: 0
+  - StartTime: 39477
+    Lane: 1
+    EndTime: 0
+  - StartTime: 39562
+    Lane: 2
+    EndTime: 0
+  - StartTime: 39562
+    Lane: 4
+    EndTime: 0
+  - StartTime: 39732
+    Lane: 1
+    EndTime: 40240
+  - StartTime: 39732
+    Lane: 3
+    EndTime: 0
+  - StartTime: 39901
+    Lane: 4
+    EndTime: 0
+  - StartTime: 39901
+    Lane: 3
+    EndTime: 0
+  - StartTime: 39986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 40155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 40240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 40240
+    Lane: 4
+    EndTime: 0
+  - StartTime: 40410
+    Lane: 3
+    EndTime: 40918
+  - StartTime: 40410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 40579
+    Lane: 1
+    EndTime: 0
+  - StartTime: 40579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 40664
+    Lane: 2
+    EndTime: 0
+  - StartTime: 40833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 40918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 40918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 41087
+    Lane: 4
+    EndTime: 41596
+  - StartTime: 41087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 41172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 41257
+    Lane: 3
+    EndTime: 0
+  - StartTime: 41257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 41342
+    Lane: 1
+    EndTime: 0
+  - StartTime: 41426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 41511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 41596
+    Lane: 1
+    EndTime: 41765
+  - StartTime: 41596
+    Lane: 2
+    EndTime: 0
+  - StartTime: 41681
+    Lane: 3
+    EndTime: 0
+  - StartTime: 41765
+    Lane: 4
+    EndTime: 41935
+  - StartTime: 41765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 41850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 41935
+    Lane: 2
+    EndTime: 42104
+  - StartTime: 41935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 42020
+    Lane: 4
+    EndTime: 0
+  - StartTime: 42104
+    Lane: 3
+    EndTime: 42274
+  - StartTime: 42104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 42189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 42274
+    Lane: 1
+    EndTime: 42443
+  - StartTime: 42274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 42359
+    Lane: 3
+    EndTime: 0
+  - StartTime: 42443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 42443
+    Lane: 2
+    EndTime: 0
+  - StartTime: 42613
+    Lane: 4
+    EndTime: 0
+  - StartTime: 42613
+    Lane: 2
+    EndTime: 0
+  - StartTime: 42782
+    Lane: 1
+    EndTime: 0
+  - StartTime: 42782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 42867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 42867
+    Lane: 2
+    EndTime: 0
+  - StartTime: 42952
+    Lane: 1
+    EndTime: 0
+  - StartTime: 42952
+    Lane: 4
+    EndTime: 0
+  - StartTime: 43121
+    Lane: 4
+    EndTime: 0
+  - StartTime: 43121
+    Lane: 1
+    EndTime: 0
+  - StartTime: 43291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 43291
+    Lane: 3
+    EndTime: 0
+  - StartTime: 43376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 43460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 43460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 43545
+    Lane: 2
+    EndTime: 0
+  - StartTime: 43630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 43630
+    Lane: 4
+    EndTime: 0
+  - StartTime: 43715
+    Lane: 2
+    EndTime: 0
+  - StartTime: 43799
+    Lane: 1
+    EndTime: 0
+  - StartTime: 43799
+    Lane: 4
+    EndTime: 0
+  - StartTime: 43799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 45155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 45155
+    Lane: 3
+    EndTime: 0
+  - StartTime: 45155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 45325
+    Lane: 2
+    EndTime: 0
+  - StartTime: 45325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 45494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 45494
+    Lane: 2
+    EndTime: 0
+  - StartTime: 45664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 45664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 45664
+    Lane: 4
+    EndTime: 46003
+  - StartTime: 46003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 46087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 46172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 46172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 46342
+    Lane: 3
+    EndTime: 0
+  - StartTime: 46342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 46511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 46511
+    Lane: 1
+    EndTime: 0
+  - StartTime: 46511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 47189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 47189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 47189
+    Lane: 4
+    EndTime: 0
+  - StartTime: 47867
+    Lane: 1
+    EndTime: 0
+  - StartTime: 47867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 47867
+    Lane: 4
+    EndTime: 0
+  - StartTime: 48545
+    Lane: 1
+    EndTime: 0
+  - StartTime: 48545
+    Lane: 2
+    EndTime: 0
+  - StartTime: 48545
+    Lane: 3
+    EndTime: 0
+  - StartTime: 48545
+    Lane: 4
+    EndTime: 0
+  - StartTime: 48715
+    Lane: 3
+    EndTime: 0
+  - StartTime: 48715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 48799
+    Lane: 2
+    EndTime: 0
+  - StartTime: 48799
+    Lane: 1
+    EndTime: 0
+  - StartTime: 48884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 48884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 48969
+    Lane: 2
+    EndTime: 0
+  - StartTime: 48969
+    Lane: 1
+    EndTime: 0
+  - StartTime: 49054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 49054
+    Lane: 4
+    EndTime: 0
+  - StartTime: 49138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 49223
+    Lane: 3
+    EndTime: 0
+  - StartTime: 49223
+    Lane: 4
+    EndTime: 0
+  - StartTime: 49223
+    Lane: 1
+    EndTime: 0
+  - StartTime: 49308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 49393
+    Lane: 4
+    EndTime: 0
+  - StartTime: 49393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 49477
+    Lane: 1
+    EndTime: 0
+  - StartTime: 49562
+    Lane: 2
+    EndTime: 0
+  - StartTime: 49647
+    Lane: 3
+    EndTime: 0
+  - StartTime: 49732
+    Lane: 1
+    EndTime: 0
+  - StartTime: 49732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 49816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 49901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 49986
+    Lane: 4
+    EndTime: 0
+  - StartTime: 50071
+    Lane: 3
+    EndTime: 0
+  - StartTime: 50071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 50155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 50240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 50325
+    Lane: 4
+    EndTime: 0
+  - StartTime: 50410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 50410
+    Lane: 3
+    EndTime: 0
+  - StartTime: 50494
+    Lane: 1
+    EndTime: 0
+  - StartTime: 50579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 50579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 50664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 50748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 50748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 50833
+    Lane: 3
+    EndTime: 0
+  - StartTime: 50918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 51003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 51087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 51087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 51172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 51257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 51342
+    Lane: 1
+    EndTime: 0
+  - StartTime: 51426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 51426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 51511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 51596
+    Lane: 1
+    EndTime: 0
+  - StartTime: 51681
+    Lane: 2
+    EndTime: 0
+  - StartTime: 51765
+    Lane: 4
+    EndTime: 0
+  - StartTime: 51765
+    Lane: 1
+    EndTime: 0
+  - StartTime: 51850
+    Lane: 3
+    EndTime: 0
+  - StartTime: 51935
+    Lane: 2
+    EndTime: 0
+  - StartTime: 51935
+    Lane: 1
+    EndTime: 0
+  - StartTime: 51935
+    Lane: 4
+    EndTime: 0
+  - StartTime: 52020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 52104
+    Lane: 2
+    EndTime: 0
+  - StartTime: 52189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 52189
+    Lane: 3
+    EndTime: 0
+  - StartTime: 52189
+    Lane: 4
+    EndTime: 0
+  - StartTime: 52274
+    Lane: 2
+    EndTime: 0
+  - StartTime: 52359
+    Lane: 3
+    EndTime: 0
+  - StartTime: 52443
+    Lane: 2
+    EndTime: 0
+  - StartTime: 52443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 52443
+    Lane: 1
+    EndTime: 0
+  - StartTime: 52528
+    Lane: 3
+    EndTime: 0
+  - StartTime: 52613
+    Lane: 4
+    EndTime: 0
+  - StartTime: 52613
+    Lane: 1
+    EndTime: 0
+  - StartTime: 52698
+    Lane: 2
+    EndTime: 0
+  - StartTime: 52698
+    Lane: 3
+    EndTime: 0
+  - StartTime: 52782
+    Lane: 1
+    EndTime: 0
+  - StartTime: 52782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 52867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 52952
+    Lane: 1
+    EndTime: 0
+  - StartTime: 52952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 53037
+    Lane: 3
+    EndTime: 0
+  - StartTime: 53037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 53121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 53121
+    Lane: 1
+    EndTime: 0
+  - StartTime: 53206
+    Lane: 3
+    EndTime: 0
+  - StartTime: 53291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 53291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 53291
+    Lane: 4
+    EndTime: 0
+  - StartTime: 54647
+    Lane: 1
+    EndTime: 0
+  - StartTime: 54647
+    Lane: 3
+    EndTime: 0
+  - StartTime: 54647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 54732
+    Lane: 2
+    EndTime: 0
+  - StartTime: 54816
+    Lane: 4
+    EndTime: 0
+  - StartTime: 54816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 54901
+    Lane: 3
+    EndTime: 0
+  - StartTime: 54986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 55071
+    Lane: 3
+    EndTime: 0
+  - StartTime: 55155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 55155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 55240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 55325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 55410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 55494
+    Lane: 1
+    EndTime: 0
+  - StartTime: 55494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 55579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 55664
+    Lane: 2
+    EndTime: 0
+  - StartTime: 55748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 55833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 55833
+    Lane: 1
+    EndTime: 0
+  - StartTime: 55918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 56003
+    Lane: 4
+    EndTime: 0
+  - StartTime: 56003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 56087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 56172
+    Lane: 2
+    EndTime: 0
+  - StartTime: 56172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 56257
+    Lane: 3
+    EndTime: 0
+  - StartTime: 56342
+    Lane: 4
+    EndTime: 0
+  - StartTime: 56342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 56426
+    Lane: 1
+    EndTime: 0
+  - StartTime: 56511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 56511
+    Lane: 4
+    EndTime: 0
+  - StartTime: 56596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 56681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 56681
+    Lane: 4
+    EndTime: 0
+  - StartTime: 56765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 56850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 56850
+    Lane: 3
+    EndTime: 0
+  - StartTime: 56935
+    Lane: 2
+    EndTime: 0
+  - StartTime: 57020
+    Lane: 1
+    EndTime: 0
+  - StartTime: 57020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 57104
+    Lane: 4
+    EndTime: 0
+  - StartTime: 57189
+    Lane: 3
+    EndTime: 0
+  - StartTime: 57189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 57274
+    Lane: 2
+    EndTime: 0
+  - StartTime: 57359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 57359
+    Lane: 4
+    EndTime: 0
+  - StartTime: 57443
+    Lane: 2
+    EndTime: 0
+  - StartTime: 57528
+    Lane: 3
+    EndTime: 0
+  - StartTime: 57528
+    Lane: 4
+    EndTime: 0
+  - StartTime: 57613
+    Lane: 2
+    EndTime: 0
+  - StartTime: 57698
+    Lane: 1
+    EndTime: 0
+  - StartTime: 57782
+    Lane: 3
+    EndTime: 0
+  - StartTime: 57867
+    Lane: 4
+    EndTime: 0
+  - StartTime: 57867
+    Lane: 2
+    EndTime: 0
+  - StartTime: 57952
+    Lane: 3
+    EndTime: 0
+  - StartTime: 58037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 58121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 58206
+    Lane: 3
+    EndTime: 0
+  - StartTime: 58206
+    Lane: 4
+    EndTime: 0
+  - StartTime: 58291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 58376
+    Lane: 1
+    EndTime: 0
+  - StartTime: 58460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 58545
+    Lane: 2
+    EndTime: 0
+  - StartTime: 58545
+    Lane: 4
+    EndTime: 0
+  - StartTime: 58630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 58715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 58715
+    Lane: 1
+    EndTime: 0
+  - StartTime: 58799
+    Lane: 2
+    EndTime: 0
+  - StartTime: 58884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 58884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 58969
+    Lane: 2
+    EndTime: 0
+  - StartTime: 59054
+    Lane: 1
+    EndTime: 0
+  - StartTime: 59054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 59138
+    Lane: 4
+    EndTime: 0
+  - StartTime: 59223
+    Lane: 3
+    EndTime: 0
+  - StartTime: 59223
+    Lane: 1
+    EndTime: 0
+  - StartTime: 59308
+    Lane: 4
+    EndTime: 0
+  - StartTime: 59393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 59393
+    Lane: 2
+    EndTime: 0
+  - StartTime: 59477
+    Lane: 1
+    EndTime: 0
+  - StartTime: 59562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 59562
+    Lane: 2
+    EndTime: 0
+  - StartTime: 59647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 59732
+    Lane: 1
+    EndTime: 0
+  - StartTime: 59732
+    Lane: 2
+    EndTime: 0
+  - StartTime: 59816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 59816
+    Lane: 4
+    EndTime: 0
+  - StartTime: 59901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 59901
+    Lane: 1
+    EndTime: 0
+  - StartTime: 59986
+    Lane: 4
+    EndTime: 0
+  - StartTime: 60071
+    Lane: 2
+    EndTime: 0
+  - StartTime: 60071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 60071
+    Lane: 3
+    EndTime: 0
+  - StartTime: 60155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 60240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 60240
+    Lane: 1
+    EndTime: 0
+  - StartTime: 60325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 60410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 60410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 60494
+    Lane: 1
+    EndTime: 0
+  - StartTime: 60579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 60579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 60664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 60748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 60748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 60833
+    Lane: 3
+    EndTime: 0
+  - StartTime: 60918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 60918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 61003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 61087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 61087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 61172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 61257
+    Lane: 3
+    EndTime: 0
+  - StartTime: 61257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 61342
+    Lane: 1
+    EndTime: 0
+  - StartTime: 61426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 61426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 61511
+    Lane: 1
+    EndTime: 0
+  - StartTime: 61596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 61596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 61681
+    Lane: 2
+    EndTime: 0
+  - StartTime: 61765
+    Lane: 3
+    EndTime: 0
+  - StartTime: 61765
+    Lane: 1
+    EndTime: 0
+  - StartTime: 61850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 61935
+    Lane: 1
+    EndTime: 0
+  - StartTime: 61935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 62020
+    Lane: 2
+    EndTime: 0
+  - StartTime: 62104
+    Lane: 4
+    EndTime: 0
+  - StartTime: 62104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 62189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 62274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 62274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 62359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 62443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 62443
+    Lane: 1
+    EndTime: 0
+  - StartTime: 62528
+    Lane: 4
+    EndTime: 0
+  - StartTime: 62613
+    Lane: 3
+    EndTime: 0
+  - StartTime: 62613
+    Lane: 2
+    EndTime: 0
+  - StartTime: 62698
+    Lane: 1
+    EndTime: 0
+  - StartTime: 62782
+    Lane: 2
+    EndTime: 0
+  - StartTime: 62782
+    Lane: 3
+    EndTime: 0
+  - StartTime: 62782
+    Lane: 4
+    EndTime: 63121
+  - StartTime: 63121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 63121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 63121
+    Lane: 1
+    EndTime: 63460
+  - StartTime: 63460
+    Lane: 4
+    EndTime: 0
+  - StartTime: 63460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 63460
+    Lane: 3
+    EndTime: 63799
+  - StartTime: 63799
+    Lane: 4
+    EndTime: 0
+  - StartTime: 63799
+    Lane: 1
+    EndTime: 0
+  - StartTime: 63799
+    Lane: 2
+    EndTime: 64138
+  - StartTime: 64138
+    Lane: 1
+    EndTime: 0
+  - StartTime: 64138
+    Lane: 3
+    EndTime: 0
+  - StartTime: 64138
+    Lane: 4
+    EndTime: 0
+  - StartTime: 64308
+    Lane: 1
+    EndTime: 0
+  - StartTime: 64308
+    Lane: 3
+    EndTime: 0
+  - StartTime: 64308
+    Lane: 4
+    EndTime: 0
+  - StartTime: 64647
+    Lane: 1
+    EndTime: 0
+  - StartTime: 64647
+    Lane: 2
+    EndTime: 0
+  - StartTime: 64647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 64816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 64816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 64816
+    Lane: 4
+    EndTime: 0
+  - StartTime: 64986
+    Lane: 1
+    EndTime: 0
+  - StartTime: 64986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 65071
+    Lane: 3
+    EndTime: 0
+  - StartTime: 65071
+    Lane: 4
+    EndTime: 0
+  - StartTime: 65155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 65155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 65240
+    Lane: 4
+    EndTime: 0
+  - StartTime: 65240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 65325
+    Lane: 2
+    EndTime: 0
+  - StartTime: 65325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 65410
+    Lane: 3
+    EndTime: 0
+  - StartTime: 65494
+    Lane: 1
+    EndTime: 0
+  - StartTime: 65494
+    Lane: 2
+    EndTime: 0
+  - StartTime: 65494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 65664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 65664
+    Lane: 4
+    EndTime: 0
+  - StartTime: 65748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 65918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 66003
+    Lane: 4
+    EndTime: 0
+  - StartTime: 66003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 66172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 66342
+    Lane: 3
+    EndTime: 0
+  - StartTime: 66342
+    Lane: 4
+    EndTime: 0
+  - StartTime: 66426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 66511
+    Lane: 1
+    EndTime: 0
+  - StartTime: 66596
+    Lane: 2
+    EndTime: 0
+  - StartTime: 66681
+    Lane: 3
+    EndTime: 0
+  - StartTime: 66681
+    Lane: 4
+    EndTime: 0
+  - StartTime: 66850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 67020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 67020
+    Lane: 4
+    EndTime: 0
+  - StartTime: 67189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 67274
+    Lane: 2
+    EndTime: 0
+  - StartTime: 67359
+    Lane: 3
+    EndTime: 0
+  - StartTime: 67359
+    Lane: 4
+    EndTime: 0
+  - StartTime: 67528
+    Lane: 1
+    EndTime: 0
+  - StartTime: 67698
+    Lane: 3
+    EndTime: 0
+  - StartTime: 67698
+    Lane: 4
+    EndTime: 0
+  - StartTime: 67782
+    Lane: 2
+    EndTime: 0
+  - StartTime: 67867
+    Lane: 1
+    EndTime: 0
+  - StartTime: 67952
+    Lane: 3
+    EndTime: 0
+  - StartTime: 68037
+    Lane: 2
+    EndTime: 0
+  - StartTime: 68037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 68206
+    Lane: 3
+    EndTime: 0
+  - StartTime: 68206
+    Lane: 1
+    EndTime: 68545
+  - StartTime: 68376
+    Lane: 2
+    EndTime: 0
+  - StartTime: 68376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 68545
+    Lane: 3
+    EndTime: 0
+  - StartTime: 68630
+    Lane: 2
+    EndTime: 0
+  - StartTime: 68715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 68715
+    Lane: 3
+    EndTime: 0
+  - StartTime: 68884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 69054
+    Lane: 4
+    EndTime: 0
+  - StartTime: 69054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 69138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 69223
+    Lane: 1
+    EndTime: 0
+  - StartTime: 69308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 69393
+    Lane: 4
+    EndTime: 0
+  - StartTime: 69393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 69562
+    Lane: 1
+    EndTime: 0
+  - StartTime: 69562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 69647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 69732
+    Lane: 3
+    EndTime: 0
+  - StartTime: 69732
+    Lane: 1
+    EndTime: 0
+  - StartTime: 69816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 69901
+    Lane: 4
+    EndTime: 0
+  - StartTime: 69901
+    Lane: 1
+    EndTime: 0
+  - StartTime: 69986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 70071
+    Lane: 4
+    EndTime: 0
+  - StartTime: 70071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 70155
+    Lane: 3
+    EndTime: 0
+  - StartTime: 70240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 70240
+    Lane: 4
+    EndTime: 0
+  - StartTime: 70410
+    Lane: 3
+    EndTime: 0
+  - StartTime: 70410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 70494
+    Lane: 1
+    EndTime: 0
+  - StartTime: 70579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 70579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 70664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 70748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 70748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 70833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 70918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 70918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 70918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 71003
+    Lane: 4
+    EndTime: 0
+  - StartTime: 71087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 71087
+    Lane: 1
+    EndTime: 0
+  - StartTime: 71172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 71257
+    Lane: 4
+    EndTime: 0
+  - StartTime: 71342
+    Lane: 3
+    EndTime: 0
+  - StartTime: 71426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 71426
+    Lane: 1
+    EndTime: 0
+  - StartTime: 71511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 71596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 71681
+    Lane: 3
+    EndTime: 0
+  - StartTime: 71765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 71765
+    Lane: 1
+    EndTime: 0
+  - StartTime: 71850
+    Lane: 3
+    EndTime: 0
+  - StartTime: 71935
+    Lane: 4
+    EndTime: 0
+  - StartTime: 72020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 72104
+    Lane: 2
+    EndTime: 0
+  - StartTime: 72104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 72189
+    Lane: 3
+    EndTime: 0
+  - StartTime: 72274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 72274
+    Lane: 1
+    EndTime: 0
+  - StartTime: 72359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 72443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 72443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 72528
+    Lane: 2
+    EndTime: 0
+  - StartTime: 72613
+    Lane: 1
+    EndTime: 0
+  - StartTime: 72698
+    Lane: 2
+    EndTime: 0
+  - StartTime: 72782
+    Lane: 3
+    EndTime: 0
+  - StartTime: 72782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 72867
+    Lane: 2
+    EndTime: 0
+  - StartTime: 72952
+    Lane: 1
+    EndTime: 0
+  - StartTime: 73037
+    Lane: 2
+    EndTime: 0
+  - StartTime: 73121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 73121
+    Lane: 4
+    EndTime: 0
+  - StartTime: 73206
+    Lane: 2
+    EndTime: 0
+  - StartTime: 73291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 73376
+    Lane: 2
+    EndTime: 0
+  - StartTime: 73460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 73460
+    Lane: 4
+    EndTime: 0
+  - StartTime: 73545
+    Lane: 2
+    EndTime: 0
+  - StartTime: 73630
+    Lane: 1
+    EndTime: 0
+  - StartTime: 73630
+    Lane: 4
+    EndTime: 0
+  - StartTime: 73630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 73799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 73884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 73884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 73884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 74054
+    Lane: 2
+    EndTime: 0
+  - StartTime: 74138
+    Lane: 1
+    EndTime: 0
+  - StartTime: 74138
+    Lane: 3
+    EndTime: 0
+  - StartTime: 74138
+    Lane: 4
+    EndTime: 0
+  - StartTime: 74308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 74308
+    Lane: 4
+    EndTime: 0
+  - StartTime: 74393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 74477
+    Lane: 4
+    EndTime: 0
+  - StartTime: 74477
+    Lane: 2
+    EndTime: 0
+  - StartTime: 74562
+    Lane: 1
+    EndTime: 0
+  - StartTime: 74647
+    Lane: 3
+    EndTime: 0
+  - StartTime: 74647
+    Lane: 2
+    EndTime: 0
+  - StartTime: 74732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 74816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 74816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 74901
+    Lane: 3
+    EndTime: 0
+  - StartTime: 74986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 74986
+    Lane: 4
+    EndTime: 0
+  - StartTime: 75071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 75155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 75155
+    Lane: 3
+    EndTime: 0
+  - StartTime: 75240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 75325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 75325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 75410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 75410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 75494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 75494
+    Lane: 1
+    EndTime: 0
+  - StartTime: 75579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 75664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 75664
+    Lane: 4
+    EndTime: 0
+  - StartTime: 75748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 75833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 75918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 76003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 76003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 76087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 76172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 76257
+    Lane: 1
+    EndTime: 0
+  - StartTime: 76342
+    Lane: 3
+    EndTime: 0
+  - StartTime: 76342
+    Lane: 4
+    EndTime: 0
+  - StartTime: 76342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 76426
+    Lane: 1
+    EndTime: 0
+  - StartTime: 76511
+    Lane: 4
+    EndTime: 0
+  - StartTime: 76511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 76596
+    Lane: 2
+    EndTime: 0
+  - StartTime: 76681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 76681
+    Lane: 4
+    EndTime: 0
+  - StartTime: 76765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 76850
+    Lane: 3
+    EndTime: 0
+  - StartTime: 76850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 76935
+    Lane: 1
+    EndTime: 0
+  - StartTime: 77020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 77020
+    Lane: 2
+    EndTime: 0
+  - StartTime: 77104
+    Lane: 4
+    EndTime: 0
+  - StartTime: 77189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 77189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 77274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 77359
+    Lane: 4
+    EndTime: 0
+  - StartTime: 77359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 77443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 77528
+    Lane: 2
+    EndTime: 0
+  - StartTime: 77528
+    Lane: 1
+    EndTime: 0
+  - StartTime: 77613
+    Lane: 4
+    EndTime: 0
+  - StartTime: 77698
+    Lane: 3
+    EndTime: 0
+  - StartTime: 77698
+    Lane: 2
+    EndTime: 0
+  - StartTime: 77698
+    Lane: 1
+    EndTime: 0
+  - StartTime: 77782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 77867
+    Lane: 2
+    EndTime: 0
+  - StartTime: 77867
+    Lane: 1
+    EndTime: 0
+  - StartTime: 77952
+    Lane: 3
+    EndTime: 0
+  - StartTime: 78037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 78037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 78121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 78206
+    Lane: 4
+    EndTime: 0
+  - StartTime: 78206
+    Lane: 2
+    EndTime: 0
+  - StartTime: 78291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 78376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 78376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 78460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 78545
+    Lane: 4
+    EndTime: 0
+  - StartTime: 78545
+    Lane: 3
+    EndTime: 0
+  - StartTime: 78630
+    Lane: 2
+    EndTime: 0
+  - StartTime: 78715
+    Lane: 1
+    EndTime: 0
+  - StartTime: 78715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 78799
+    Lane: 2
+    EndTime: 0
+  - StartTime: 78884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 78884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 78969
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79054
+    Lane: 1
+    EndTime: 0
+  - StartTime: 79054
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 79138
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79223
+    Lane: 3
+    EndTime: 0
+  - StartTime: 79223
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79308
+    Lane: 1
+    EndTime: 0
+  - StartTime: 79393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 79393
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79477
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79562
+    Lane: 1
+    EndTime: 0
+  - StartTime: 79562
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79647
+    Lane: 3
+    EndTime: 0
+  - StartTime: 79732
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79732
+    Lane: 1
+    EndTime: 0
+  - StartTime: 79816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 79901
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79986
+    Lane: 1
+    EndTime: 0
+  - StartTime: 80071
+    Lane: 2
+    EndTime: 0
+  - StartTime: 80071
+    Lane: 3
+    EndTime: 0
+  - StartTime: 80155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 80240
+    Lane: 1
+    EndTime: 0
+  - StartTime: 80240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 80325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 80410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 80410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 80410
+    Lane: 1
+    EndTime: 0
+  - StartTime: 80494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 80579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 80579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 80664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 80748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 80748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 80833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 80918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 80918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 81003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 81087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 81087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 81172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 81172
+    Lane: 2
+    EndTime: 0
+  - StartTime: 81257
+    Lane: 3
+    EndTime: 0
+  - StartTime: 81257
+    Lane: 4
+    EndTime: 0
+  - StartTime: 81342
+    Lane: 1
+    EndTime: 0
+  - StartTime: 81342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 81426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 81426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 81511
+    Lane: 1
+    EndTime: 0
+  - StartTime: 81511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 81596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 81596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 81681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 81765
+    Lane: 3
+    EndTime: 0
+  - StartTime: 81765
+    Lane: 4
+    EndTime: 0
+  - StartTime: 81765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 81850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 81935
+    Lane: 2
+    EndTime: 0
+  - StartTime: 81935
+    Lane: 4
+    EndTime: 0
+  - StartTime: 82020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 82104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 82104
+    Lane: 4
+    EndTime: 0
+  - StartTime: 82189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 82274
+    Lane: 1
+    EndTime: 0
+  - StartTime: 82274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 82359
+    Lane: 4
+    EndTime: 0
+  - StartTime: 82443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 82443
+    Lane: 2
+    EndTime: 0
+  - StartTime: 82528
+    Lane: 4
+    EndTime: 0
+  - StartTime: 82613
+    Lane: 3
+    EndTime: 0
+  - StartTime: 82613
+    Lane: 1
+    EndTime: 0
+  - StartTime: 82698
+    Lane: 2
+    EndTime: 0
+  - StartTime: 82782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 82782
+    Lane: 1
+    EndTime: 0
+  - StartTime: 82867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 82952
+    Lane: 4
+    EndTime: 0
+  - StartTime: 82952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 83037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 83121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 83121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 83121
+    Lane: 4
+    EndTime: 0
+  - StartTime: 83206
+    Lane: 1
+    EndTime: 0
+  - StartTime: 83291
+    Lane: 4
+    EndTime: 0
+  - StartTime: 83291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 83376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 83460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 83460
+    Lane: 4
+    EndTime: 0
+  - StartTime: 83545
+    Lane: 2
+    EndTime: 0
+  - StartTime: 83630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 83630
+    Lane: 4
+    EndTime: 0
+  - StartTime: 83715
+    Lane: 1
+    EndTime: 0
+  - StartTime: 83799
+    Lane: 2
+    EndTime: 0
+  - StartTime: 83799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 83884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 83969
+    Lane: 1
+    EndTime: 0
+  - StartTime: 83969
+    Lane: 3
+    EndTime: 0
+  - StartTime: 84054
+    Lane: 2
+    EndTime: 0
+  - StartTime: 84138
+    Lane: 4
+    EndTime: 0
+  - StartTime: 84138
+    Lane: 1
+    EndTime: 0
+  - StartTime: 84223
+    Lane: 3
+    EndTime: 0
+  - StartTime: 84308
+    Lane: 1
+    EndTime: 0
+  - StartTime: 84308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 84393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 84477
+    Lane: 4
+    EndTime: 0
+  - StartTime: 84477
+    Lane: 1
+    EndTime: 0
+  - StartTime: 84562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 84562
+    Lane: 2
+    EndTime: 0
+  - StartTime: 84647
+    Lane: 1
+    EndTime: 0
+  - StartTime: 84647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 84732
+    Lane: 3
+    EndTime: 0
+  - StartTime: 84816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 84901
+    Lane: 1
+    EndTime: 0
+  - StartTime: 84986
+    Lane: 3
+    EndTime: 0
+  - StartTime: 84986
+    Lane: 4
+    EndTime: 0
+  - StartTime: 85071
+    Lane: 2
+    EndTime: 0
+  - StartTime: 85155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 85240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 85325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 85325
+    Lane: 4
+    EndTime: 0
+  - StartTime: 85410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 85410
+    Lane: 1
+    EndTime: 0
+  - StartTime: 85494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 85494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 85579
+    Lane: 1
+    EndTime: 0
+  - StartTime: 85664
+    Lane: 2
+    EndTime: 0
+  - StartTime: 85748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 85833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 85833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 85833
+    Lane: 1
+    EndTime: 0
+  - StartTime: 86003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 86172
+    Lane: 2
+    EndTime: 0
+  - StartTime: 86342
+    Lane: 1
+    EndTime: 0
+  - StartTime: 86511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 86511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 86511
+    Lane: 4
+    EndTime: 0
+  - StartTime: 86681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 86850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 87020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 87189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 87189
+    Lane: 4
+    EndTime: 0
+  - StartTime: 87189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 87359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 87359
+    Lane: 3
+    EndTime: 0
+  - StartTime: 87443
+    Lane: 2
+    EndTime: 0
+  - StartTime: 87613
+    Lane: 3
+    EndTime: 0
+  - StartTime: 87698
+    Lane: 2
+    EndTime: 0
+  - StartTime: 87698
+    Lane: 4
+    EndTime: 0
+  - StartTime: 87867
+    Lane: 1
+    EndTime: 0
+  - StartTime: 88037
+    Lane: 3
+    EndTime: 0
+  - StartTime: 88037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 88121
+    Lane: 1
+    EndTime: 0
+  - StartTime: 88291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 88376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 88376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 88545
+    Lane: 1
+    EndTime: 0
+  - StartTime: 88715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 88715
+    Lane: 3
+    EndTime: 0
+  - StartTime: 88799
+    Lane: 2
+    EndTime: 0
+  - StartTime: 88969
+    Lane: 3
+    EndTime: 0
+  - StartTime: 89054
+    Lane: 2
+    EndTime: 0
+  - StartTime: 89054
+    Lane: 4
+    EndTime: 0
+  - StartTime: 89223
+    Lane: 1
+    EndTime: 0
+  - StartTime: 89393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 89393
+    Lane: 2
+    EndTime: 0
+  - StartTime: 89477
+    Lane: 1
+    EndTime: 0
+  - StartTime: 89647
+    Lane: 2
+    EndTime: 0
+  - StartTime: 89732
+    Lane: 1
+    EndTime: 0
+  - StartTime: 89732
+    Lane: 3
+    EndTime: 0
+  - StartTime: 89901
+    Lane: 4
+    EndTime: 0
+  - StartTime: 89901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 89986
+    Lane: 3
+    EndTime: 0
+  - StartTime: 90071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 90071
+    Lane: 4
+    EndTime: 0
+  - StartTime: 90155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 90240
+    Lane: 1
+    EndTime: 0
+  - StartTime: 90240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 90325
+    Lane: 4
+    EndTime: 0
+  - StartTime: 90410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 90410
+    Lane: 1
+    EndTime: 0
+  - StartTime: 90494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 90579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 90579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 90664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 90748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 90748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 90833
+    Lane: 3
+    EndTime: 0
+  - StartTime: 90918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 90918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 91003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 91087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 91087
+    Lane: 1
+    EndTime: 0
+  - StartTime: 91172
+    Lane: 2
+    EndTime: 0
+  - StartTime: 91257
+    Lane: 1
+    EndTime: 0
+  - StartTime: 91257
+    Lane: 3
+    EndTime: 0
+  - StartTime: 91342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 91426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 91426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 91511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 91596
+    Lane: 1
+    EndTime: 0
+  - StartTime: 91596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 91681
+    Lane: 2
+    EndTime: 0
+  - StartTime: 91765
+    Lane: 1
+    EndTime: 0
+  - StartTime: 91765
+    Lane: 3
+    EndTime: 0
+  - StartTime: 91850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 91935
+    Lane: 2
+    EndTime: 92020
+  - StartTime: 92020
+    Lane: 3
+    EndTime: 92104
+  - StartTime: 92104
+    Lane: 4
+    EndTime: 92189
+  - StartTime: 92104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 92189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 92274
+    Lane: 3
+    EndTime: 92359
+  - StartTime: 92359
+    Lane: 2
+    EndTime: 92443
+  - StartTime: 92443
+    Lane: 1
+    EndTime: 92528
+  - StartTime: 92443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 92528
+    Lane: 3
+    EndTime: 0
+  - StartTime: 92613
+    Lane: 2
+    EndTime: 0
+  - StartTime: 92613
+    Lane: 1
+    EndTime: 92952
+  - StartTime: 92782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 92782
+    Lane: 3
+    EndTime: 0
+  - StartTime: 92867
+    Lane: 2
+    EndTime: 0
+  - StartTime: 93037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 93121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 93121
+    Lane: 4
+    EndTime: 0
+  - StartTime: 93291
+    Lane: 4
+    EndTime: 93630
+  - StartTime: 93291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 93460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 93460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 93545
+    Lane: 2
+    EndTime: 0
+  - StartTime: 93715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 93799
+    Lane: 1
+    EndTime: 0
+  - StartTime: 93799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 93969
+    Lane: 1
+    EndTime: 94308
+  - StartTime: 93969
+    Lane: 4
+    EndTime: 0
+  - StartTime: 94138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 94138
+    Lane: 3
+    EndTime: 0
+  - StartTime: 94223
+    Lane: 4
+    EndTime: 0
+  - StartTime: 94393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 94477
+    Lane: 3
+    EndTime: 0
+  - StartTime: 94477
+    Lane: 2
+    EndTime: 0
+  - StartTime: 94647
+    Lane: 4
+    EndTime: 94986
+  - StartTime: 94647
+    Lane: 3
+    EndTime: 0
+  - StartTime: 94816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 94816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 94901
+    Lane: 3
+    EndTime: 0
+  - StartTime: 95071
+    Lane: 4
+    EndTime: 0
+  - StartTime: 95155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 95155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 95325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 95325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 95410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 95494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 95494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 95579
+    Lane: 1
+    EndTime: 0
+  - StartTime: 95664
+    Lane: 2
+    EndTime: 0
+  - StartTime: 95748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 95833
+    Lane: 1
+    EndTime: 0
+  - StartTime: 95833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 95918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 96003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 96003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 96087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 96172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 96172
+    Lane: 2
+    EndTime: 0
+  - StartTime: 96257
+    Lane: 1
+    EndTime: 0
+  - StartTime: 96342
+    Lane: 4
+    EndTime: 0
+  - StartTime: 96342
+    Lane: 3
+    EndTime: 0
+  - StartTime: 96426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 96511
+    Lane: 4
+    EndTime: 0
+  - StartTime: 96511
+    Lane: 1
+    EndTime: 0
+  - StartTime: 96596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 96681
+    Lane: 2
+    EndTime: 0
+  - StartTime: 96681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 96765
+    Lane: 3
+    EndTime: 0
+  - StartTime: 96850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 96850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 96935
+    Lane: 2
+    EndTime: 0
+  - StartTime: 97020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 97104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 97189
+    Lane: 4
+    EndTime: 0
+  - StartTime: 97189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 97274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 97359
+    Lane: 1
+    EndTime: 97528
+  - StartTime: 97359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 97443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 97528
+    Lane: 3
+    EndTime: 0
+  - StartTime: 97528
+    Lane: 2
+    EndTime: 97698
+  - StartTime: 97613
+    Lane: 1
+    EndTime: 0
+  - StartTime: 97698
+    Lane: 3
+    EndTime: 97867
+  - StartTime: 97698
+    Lane: 4
+    EndTime: 0
+  - StartTime: 97782
+    Lane: 2
+    EndTime: 0
+  - StartTime: 97867
+    Lane: 4
+    EndTime: 98037
+  - StartTime: 97867
+    Lane: 1
+    EndTime: 0
+  - StartTime: 97952
+    Lane: 3
+    EndTime: 0
+  - StartTime: 98037
+    Lane: 2
+    EndTime: 0
+  - StartTime: 98037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 98206
+    Lane: 3
+    EndTime: 0
+  - StartTime: 98206
+    Lane: 4
+    EndTime: 0
+  - StartTime: 98291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 98376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 98460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 98460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 98545
+    Lane: 3
+    EndTime: 0
+  - StartTime: 98545
+    Lane: 4
+    EndTime: 0
+  - StartTime: 98630
+    Lane: 2
+    EndTime: 0
+  - StartTime: 98715
+    Lane: 1
+    EndTime: 0
+  - StartTime: 98884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 98884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 98969
+    Lane: 1
+    EndTime: 0
+  - StartTime: 99054
+    Lane: 4
+    EndTime: 0
+  - StartTime: 99138
+    Lane: 1
+    EndTime: 0
+  - StartTime: 99138
+    Lane: 3
+    EndTime: 0
+  - StartTime: 99223
+    Lane: 4
+    EndTime: 0
+  - StartTime: 99223
+    Lane: 2
+    EndTime: 0
+  - StartTime: 99308
+    Lane: 3
+    EndTime: 0
+  - StartTime: 99393
+    Lane: 2
+    EndTime: 0
+  - StartTime: 99393
+    Lane: 1
+    EndTime: 99562
+  - StartTime: 99562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 99562
+    Lane: 2
+    EndTime: 99732
+  - StartTime: 99732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 99732
+    Lane: 3
+    EndTime: 99901
+  - StartTime: 99901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 99901
+    Lane: 1
+    EndTime: 100071
+  - StartTime: 100071
+    Lane: 3
+    EndTime: 0
+  - StartTime: 100071
+    Lane: 2
+    EndTime: 100240
+  - StartTime: 100240
+    Lane: 4
+    EndTime: 0
+  - StartTime: 100240
+    Lane: 3
+    EndTime: 100410
+  - StartTime: 100410
+    Lane: 1
+    EndTime: 0
+  - StartTime: 100410
+    Lane: 4
+    EndTime: 100579
+  - StartTime: 100579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 100579
+    Lane: 1
+    EndTime: 100748
+  - StartTime: 100748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 100748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 100918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 100918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 101003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 101003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 101172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 101172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 101257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 101257
+    Lane: 4
+    EndTime: 0
+  - StartTime: 101426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 101426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 101596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 101596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 101681
+    Lane: 2
+    EndTime: 0
+  - StartTime: 101681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 101850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 101850
+    Lane: 2
+    EndTime: 0
+  - StartTime: 101935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 101935
+    Lane: 4
+    EndTime: 0
+  - StartTime: 102104
+    Lane: 3
+    EndTime: 0
+  - StartTime: 102104
+    Lane: 1
+    EndTime: 102443
+  - StartTime: 102274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 102443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 102443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 102443
+    Lane: 2
+    EndTime: 102782
+  - StartTime: 102613
+    Lane: 4
+    EndTime: 0
+  - StartTime: 102782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 102782
+    Lane: 3
+    EndTime: 0
+  - StartTime: 102782
+    Lane: 1
+    EndTime: 0
+  - StartTime: 102867
+    Lane: 2
+    EndTime: 0
+  - StartTime: 102952
+    Lane: 3
+    EndTime: 0
+  - StartTime: 103037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 103037
+    Lane: 2
+    EndTime: 0
+  - StartTime: 103121
+    Lane: 1
+    EndTime: 0
+  - StartTime: 103206
+    Lane: 4
+    EndTime: 0
+  - StartTime: 103291
+    Lane: 3
+    EndTime: 0
+  - StartTime: 103291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 103376
+    Lane: 2
+    EndTime: 0
+  - StartTime: 103460
+    Lane: 4
+    EndTime: 0
+  - StartTime: 103460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 103460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 103545
+    Lane: 2
+    EndTime: 0
+  - StartTime: 103630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 103630
+    Lane: 1
+    EndTime: 0
+  - StartTime: 103715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 103799
+    Lane: 2
+    EndTime: 0
+  - StartTime: 103884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 103969
+    Lane: 4
+    EndTime: 0
+  - StartTime: 103969
+    Lane: 2
+    EndTime: 0
+  - StartTime: 104054
+    Lane: 1
+    EndTime: 0
+  - StartTime: 104138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 104223
+    Lane: 3
+    EndTime: 0
+  - StartTime: 104308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 104308
+    Lane: 4
+    EndTime: 0
+  - StartTime: 104393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 104477
+    Lane: 3
+    EndTime: 0
+  - StartTime: 104562
+    Lane: 2
+    EndTime: 0
+  - StartTime: 104647
+    Lane: 3
+    EndTime: 0
+  - StartTime: 104647
+    Lane: 1
+    EndTime: 0
+  - StartTime: 104732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 104816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 104816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 104901
+    Lane: 3
+    EndTime: 0
+  - StartTime: 104986
+    Lane: 4
+    EndTime: 0
+  - StartTime: 104986
+    Lane: 1
+    EndTime: 0
+  - StartTime: 105071
+    Lane: 2
+    EndTime: 0
+  - StartTime: 105155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 105155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 105240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 105325
+    Lane: 4
+    EndTime: 0
+  - StartTime: 105325
+    Lane: 2
+    EndTime: 0
+  - StartTime: 105410
+    Lane: 1
+    EndTime: 0
+  - StartTime: 105494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 105494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 105579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 105664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 105664
+    Lane: 4
+    EndTime: 0
+  - StartTime: 105748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 105833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 105833
+    Lane: 3
+    EndTime: 0
+  - StartTime: 105918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 106003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 106003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 106087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 106172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 106172
+    Lane: 2
+    EndTime: 0
+  - StartTime: 106257
+    Lane: 1
+    EndTime: 0
+  - StartTime: 106342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 106426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 106426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 106511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 106596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 106681
+    Lane: 4
+    EndTime: 0
+  - StartTime: 106681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 106765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 106850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 106850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 106935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 107020
+    Lane: 2
+    EndTime: 0
+  - StartTime: 107020
+    Lane: 1
+    EndTime: 0
+  - StartTime: 107104
+    Lane: 3
+    EndTime: 0
+  - StartTime: 107104
+    Lane: 4
+    EndTime: 0
+  - StartTime: 107189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 107189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 107274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 107274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 107359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 107359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 107443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 107528
+    Lane: 4
+    EndTime: 0
+  - StartTime: 107528
+    Lane: 1
+    EndTime: 0
+  - StartTime: 107528
+    Lane: 2
+    EndTime: 0
+  - StartTime: 108884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 108884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 108884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 108969
+    Lane: 2
+    EndTime: 0
+  - StartTime: 109054
+    Lane: 4
+    EndTime: 0
+  - StartTime: 109054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 109138
+    Lane: 1
+    EndTime: 0
+  - StartTime: 109223
+    Lane: 2
+    EndTime: 0
+  - StartTime: 109308
+    Lane: 3
+    EndTime: 0
+  - StartTime: 109393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 109393
+    Lane: 4
+    EndTime: 0
+  - StartTime: 109477
+    Lane: 2
+    EndTime: 0
+  - StartTime: 109562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 109647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 109732
+    Lane: 1
+    EndTime: 0
+  - StartTime: 109732
+    Lane: 2
+    EndTime: 0
+  - StartTime: 109816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 109901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 109986
+    Lane: 3
+    EndTime: 0
+  - StartTime: 110071
+    Lane: 4
+    EndTime: 0
+  - StartTime: 110071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 110155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 110240
+    Lane: 4
+    EndTime: 0
+  - StartTime: 110240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 110325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 110410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 110410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 110494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 110579
+    Lane: 1
+    EndTime: 0
+  - StartTime: 110579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 110664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 110748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 110748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 110833
+    Lane: 1
+    EndTime: 0
+  - StartTime: 110918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 110918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 111003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 111087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 111087
+    Lane: 1
+    EndTime: 0
+  - StartTime: 111172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 111257
+    Lane: 4
+    EndTime: 0
+  - StartTime: 111257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 111342
+    Lane: 1
+    EndTime: 0
+  - StartTime: 111426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 111426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 111511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 111596
+    Lane: 2
+    EndTime: 0
+  - StartTime: 111596
+    Lane: 1
+    EndTime: 0
+  - StartTime: 111681
+    Lane: 3
+    EndTime: 0
+  - StartTime: 111765
+    Lane: 4
+    EndTime: 0
+  - StartTime: 111765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 111850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 111935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 112020
+    Lane: 2
+    EndTime: 0
+  - StartTime: 112104
+    Lane: 4
+    EndTime: 0
+  - StartTime: 112104
+    Lane: 3
+    EndTime: 0
+  - StartTime: 112189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 112274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 112359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 112443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 112443
+    Lane: 1
+    EndTime: 0
+  - StartTime: 112528
+    Lane: 2
+    EndTime: 0
+  - StartTime: 112613
+    Lane: 4
+    EndTime: 0
+  - StartTime: 112698
+    Lane: 3
+    EndTime: 0
+  - StartTime: 112782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 112782
+    Lane: 1
+    EndTime: 0
+  - StartTime: 112867
+    Lane: 2
+    EndTime: 0
+  - StartTime: 112952
+    Lane: 3
+    EndTime: 0
+  - StartTime: 112952
+    Lane: 1
+    EndTime: 0
+  - StartTime: 112952
+    Lane: 4
+    EndTime: 0
+  - StartTime: 113121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 113121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 113291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 113291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 113376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 113460
+    Lane: 4
+    EndTime: 0
+  - StartTime: 113460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 113460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 113630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 113630
+    Lane: 2
+    EndTime: 0
+  - StartTime: 113799
+    Lane: 4
+    EndTime: 0
+  - StartTime: 113799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 113884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 113969
+    Lane: 3
+    EndTime: 0
+  - StartTime: 113969
+    Lane: 4
+    EndTime: 0
+  - StartTime: 113969
+    Lane: 1
+    EndTime: 0
+  - StartTime: 114138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 114138
+    Lane: 1
+    EndTime: 0
+  - StartTime: 114223
+    Lane: 3
+    EndTime: 0
+  - StartTime: 114308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 114308
+    Lane: 1
+    EndTime: 0
+  - StartTime: 114308
+    Lane: 4
+    EndTime: 0
+  - StartTime: 114393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 114477
+    Lane: 2
+    EndTime: 0
+  - StartTime: 114477
+    Lane: 1
+    EndTime: 0
+  - StartTime: 114562
+    Lane: 4
+    EndTime: 0
+  - StartTime: 114647
+    Lane: 2
+    EndTime: 0
+  - StartTime: 114647
+    Lane: 3
+    EndTime: 0
+  - StartTime: 114732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 114816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 114816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 114901
+    Lane: 1
+    EndTime: 0
+  - StartTime: 114986
+    Lane: 4
+    EndTime: 0
+  - StartTime: 114986
+    Lane: 3
+    EndTime: 0
+  - StartTime: 115071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 115155
+    Lane: 3
+    EndTime: 0
+  - StartTime: 115155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 115240
+    Lane: 1
+    EndTime: 0
+  - StartTime: 115325
+    Lane: 2
+    EndTime: 0
+  - StartTime: 115325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 115410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 115494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 115494
+    Lane: 2
+    EndTime: 0
+  - StartTime: 115579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 115664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 115664
+    Lane: 2
+    EndTime: 0
+  - StartTime: 115748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 115833
+    Lane: 1
+    EndTime: 0
+  - StartTime: 115833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 115918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 116003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 116003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 116087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 116172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 116172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 116257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 116342
+    Lane: 3
+    EndTime: 0
+  - StartTime: 116342
+    Lane: 4
+    EndTime: 0
+  - StartTime: 116426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 116511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 116511
+    Lane: 4
+    EndTime: 0
+  - StartTime: 116596
+    Lane: 2
+    EndTime: 0
+  - StartTime: 116681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 116681
+    Lane: 3
+    EndTime: 0
+  - StartTime: 116765
+    Lane: 4
+    EndTime: 0
+  - StartTime: 116850
+    Lane: 3
+    EndTime: 0
+  - StartTime: 116850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 116935
+    Lane: 4
+    EndTime: 0
+  - StartTime: 117020
+    Lane: 2
+    EndTime: 0
+  - StartTime: 117020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 117020
+    Lane: 1
+    EndTime: 0
+  - StartTime: 117104
+    Lane: 4
+    EndTime: 0
+  - StartTime: 117189
+    Lane: 3
+    EndTime: 0
+  - StartTime: 117274
+    Lane: 2
+    EndTime: 0
+  - StartTime: 117359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 117443
+    Lane: 2
+    EndTime: 0
+  - StartTime: 117528
+    Lane: 3
+    EndTime: 0
+  - StartTime: 117528
+    Lane: 4
+    EndTime: 0
+  - StartTime: 117528
+    Lane: 1
+    EndTime: 0
+  - StartTime: 117613
+    Lane: 2
+    EndTime: 0
+  - StartTime: 117698
+    Lane: 3
+    EndTime: 0
+  - StartTime: 117782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 117867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 117952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 118037
+    Lane: 3
+    EndTime: 0
+  - StartTime: 118037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 118037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 118121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 118206
+    Lane: 1
+    EndTime: 0
+  - StartTime: 118291
+    Lane: 4
+    EndTime: 0
+  - StartTime: 118376
+    Lane: 1
+    EndTime: 0
+  - StartTime: 118376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 118460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 118545
+    Lane: 1
+    EndTime: 0
+  - StartTime: 118545
+    Lane: 3
+    EndTime: 0
+  - StartTime: 118630
+    Lane: 2
+    EndTime: 0
+  - StartTime: 118715
+    Lane: 3
+    EndTime: 0
+  - StartTime: 118715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 118799
+    Lane: 1
+    EndTime: 0
+  - StartTime: 118884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 118884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 118969
+    Lane: 1
+    EndTime: 0
+  - StartTime: 119054
+    Lane: 4
+    EndTime: 0
+  - StartTime: 119054
+    Lane: 2
+    EndTime: 0
+  - StartTime: 119138
+    Lane: 3
+    EndTime: 0
+  - StartTime: 119223
+    Lane: 4
+    EndTime: 0
+  - StartTime: 119223
+    Lane: 2
+    EndTime: 0
+  - StartTime: 119308
+    Lane: 3
+    EndTime: 0
+  - StartTime: 119393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 119393
+    Lane: 2
+    EndTime: 0
+  - StartTime: 119477
+    Lane: 4
+    EndTime: 0
+  - StartTime: 119562
+    Lane: 2
+    EndTime: 0
+  - StartTime: 119562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 119647
+    Lane: 1
+    EndTime: 0
+  - StartTime: 119732
+    Lane: 2
+    EndTime: 0
+  - StartTime: 119732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 119732
+    Lane: 3
+    EndTime: 0
+  - StartTime: 119901
+    Lane: 4
+    EndTime: 0
+  - StartTime: 119901
+    Lane: 3
+    EndTime: 0
+  - StartTime: 119986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 120155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 120240
+    Lane: 4
+    EndTime: 0
+  - StartTime: 120240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 120410
+    Lane: 1
+    EndTime: 0
+  - StartTime: 120579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 120579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 120664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 120748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 120833
+    Lane: 1
+    EndTime: 0
+  - StartTime: 120918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 120918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 121087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 121257
+    Lane: 1
+    EndTime: 0
+  - StartTime: 121257
+    Lane: 4
+    EndTime: 0
+  - StartTime: 121426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 121511
+    Lane: 1
+    EndTime: 0
+  - StartTime: 121596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 121596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 121765
+    Lane: 1
+    EndTime: 0
+  - StartTime: 121935
+    Lane: 4
+    EndTime: 0
+  - StartTime: 121935
+    Lane: 2
+    EndTime: 0
+  - StartTime: 122020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 122104
+    Lane: 2
+    EndTime: 0
+  - StartTime: 122189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 122274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 122274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 122443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 122443
+    Lane: 2
+    EndTime: 122782
+  - StartTime: 122613
+    Lane: 1
+    EndTime: 0
+  - StartTime: 122613
+    Lane: 3
+    EndTime: 0
+  - StartTime: 122782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 122867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 122952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 122952
+    Lane: 4
+    EndTime: 0
+  - StartTime: 123121
+    Lane: 1
+    EndTime: 0
+  - StartTime: 123291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 123291
+    Lane: 3
+    EndTime: 0
+  - StartTime: 123376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 123460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 123545
+    Lane: 3
+    EndTime: 0
+  - StartTime: 123630
+    Lane: 2
+    EndTime: 0
+  - StartTime: 123630
+    Lane: 4
+    EndTime: 0
+  - StartTime: 123799
+    Lane: 1
+    EndTime: 0
+  - StartTime: 123799
+    Lane: 3
+    EndTime: 124138
+  - StartTime: 123969
+    Lane: 2
+    EndTime: 124138
+  - StartTime: 124138
+    Lane: 4
+    EndTime: 0
+  - StartTime: 124138
+    Lane: 1
+    EndTime: 124477
+  - StartTime: 124308
+    Lane: 3
+    EndTime: 124477
+  - StartTime: 124477
+    Lane: 4
+    EndTime: 0
+  - StartTime: 124477
+    Lane: 2
+    EndTime: 124816
+  - StartTime: 124647
+    Lane: 1
+    EndTime: 124816
+  - StartTime: 124816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 124816
+    Lane: 4
+    EndTime: 125155
+  - StartTime: 124986
+    Lane: 3
+    EndTime: 125155
+  - StartTime: 125155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 125155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 125240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 125325
+    Lane: 4
+    EndTime: 0
+  - StartTime: 125325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 125410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 125494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 125494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 125579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 125664
+    Lane: 4
+    EndTime: 0
+  - StartTime: 125664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 125748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 125833
+    Lane: 3
+    EndTime: 0
+  - StartTime: 125833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 125918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126003
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 126087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 126172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126342
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126342
+    Lane: 1
+    EndTime: 0
+  - StartTime: 126426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126511
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 126596
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 126681
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126765
+    Lane: 3
+    EndTime: 0
+  - StartTime: 126850
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 126935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127020
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127020
+    Lane: 4
+    EndTime: 0
+  - StartTime: 127104
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 127189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127359
+    Lane: 4
+    EndTime: 0
+  - StartTime: 127443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127528
+    Lane: 2
+    EndTime: 0
+  - StartTime: 127528
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127613
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127698
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127698
+    Lane: 4
+    EndTime: 0
+  - StartTime: 127782
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127867
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127867
+    Lane: 4
+    EndTime: 0
+  - StartTime: 127867
+    Lane: 2
+    EndTime: 0
+  - StartTime: 127952
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 128121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 128206
+    Lane: 4
+    EndTime: 0
+  - StartTime: 128206
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 128376
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 128376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 128545
+    Lane: 4
+    EndTime: 0
+  - StartTime: 128545
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128715
+    Lane: 2
+    EndTime: 0
+  - StartTime: 128715
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 128884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 128884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128969
+    Lane: 3
+    EndTime: 0
+  - StartTime: 129054
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129223
+    Lane: 1
+    EndTime: 0
+  - StartTime: 129223
+    Lane: 3
+    EndTime: 0
+  - StartTime: 129223
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 129393
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129477
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129562
+    Lane: 1
+    EndTime: 0
+  - StartTime: 129562
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129647
+    Lane: 3
+    EndTime: 0
+  - StartTime: 129732
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129732
+    Lane: 1
+    EndTime: 0
+  - StartTime: 129732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 129901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129901
+    Lane: 1
+    EndTime: 0
+  - StartTime: 129986
+    Lane: 3
+    EndTime: 0
+  - StartTime: 130071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 130071
+    Lane: 4
+    EndTime: 0
+  - StartTime: 130155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 130240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 130240
+    Lane: 4
+    EndTime: 0
+  - StartTime: 130325
+    Lane: 2
+    EndTime: 0
+  - StartTime: 130325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 130410
+    Lane: 3
+    EndTime: 0
+  - StartTime: 130410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 130494
+    Lane: 2
+    EndTime: 0
+  - StartTime: 130579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 130579
+    Lane: 1
+    EndTime: 0
+  - StartTime: 130579
+    Lane: 4
+    EndTime: 131935
+  - StartTime: 130748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 130918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 131087
+    Lane: 1
+    EndTime: 0
+  - StartTime: 131257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 131426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 131596
+    Lane: 2
+    EndTime: 0
+  - StartTime: 131652
+    Lane: 1
+    EndTime: 0
+  - StartTime: 131737
+    Lane: 3
+    EndTime: 0
+  - StartTime: 131822
+    Lane: 2
+    EndTime: 0
+  - StartTime: 131935
+    Lane: 1
+    EndTime: 0
+  - StartTime: 131935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 132104
+    Lane: 2
+    EndTime: 0
+  - StartTime: 132104
+    Lane: 4
+    EndTime: 0
+  - StartTime: 132104
+    Lane: 1
+    EndTime: 132274
+  - StartTime: 132274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 132443
+    Lane: 1
+    EndTime: 0
+  - StartTime: 132613
+    Lane: 2
+    EndTime: 0
+  - StartTime: 132782
+    Lane: 3
+    EndTime: 0
+  - StartTime: 132952
+    Lane: 4
+    EndTime: 0
+  - StartTime: 133037
+    Lane: 3
+    EndTime: 0
+  - StartTime: 133121
+    Lane: 1
+    EndTime: 0
+  - StartTime: 133206
+    Lane: 2
+    EndTime: 0
+  - StartTime: 133291
+    Lane: 4
+    EndTime: 0
+  - StartTime: 133291
+    Lane: 3
+    EndTime: 134647
+  - StartTime: 133291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 133460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 133630
+    Lane: 4
+    EndTime: 0
+  - StartTime: 133799
+    Lane: 1
+    EndTime: 0
+  - StartTime: 133969
+    Lane: 2
+    EndTime: 0
+  - StartTime: 134138
+    Lane: 4
+    EndTime: 0
+  - StartTime: 134308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 134393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 134477
+    Lane: 4
+    EndTime: 0
+  - StartTime: 134562
+    Lane: 2
+    EndTime: 0
+  - StartTime: 134647
+    Lane: 1
+    EndTime: 0
+  - StartTime: 134647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 134816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 134816
+    Lane: 1
+    EndTime: 134986
+  - StartTime: 134816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 134986
+    Lane: 4
+    EndTime: 0
+  - StartTime: 135155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 135325
+    Lane: 2
+    EndTime: 0
+  - StartTime: 135494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 135664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 135748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 135833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 135918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 136003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 136003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 136003
+    Lane: 4
+    EndTime: 0
+  - StartTime: 136172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 136342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 136426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 136511
+    Lane: 4
+    EndTime: 0
+  - StartTime: 136596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 136681
+    Lane: 2
+    EndTime: 0
+  - StartTime: 136850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 137020
+    Lane: 4
+    EndTime: 0
+  - StartTime: 137104
+    Lane: 3
+    EndTime: 0
+  - StartTime: 137189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 137274
+    Lane: 2
+    EndTime: 0
+  - StartTime: 137359
+    Lane: 4
+    EndTime: 0
+  - StartTime: 137359
+    Lane: 3
+    EndTime: 0
+  - StartTime: 137359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 137528
+    Lane: 2
+    EndTime: 0
+  - StartTime: 137698
+    Lane: 1
+    EndTime: 0
+  - StartTime: 137782
+    Lane: 2
+    EndTime: 0
+  - StartTime: 137867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 137952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 138037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 138206
+    Lane: 4
+    EndTime: 0
+  - StartTime: 138376
+    Lane: 2
+    EndTime: 0
+  - StartTime: 138460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 138545
+    Lane: 1
+    EndTime: 0
+  - StartTime: 138630
+    Lane: 2
+    EndTime: 0
+  - StartTime: 138715
+    Lane: 3
+    EndTime: 0
+  - StartTime: 138715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 138715
+    Lane: 1
+    EndTime: 0
+  - StartTime: 138884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 139054
+    Lane: 2
+    EndTime: 0
+  - StartTime: 139054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 139054
+    Lane: 4
+    EndTime: 0
+  - StartTime: 139223
+    Lane: 2
+    EndTime: 0
+  - StartTime: 139393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 139393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 139393
+    Lane: 4
+    EndTime: 0
+  - StartTime: 139562
+    Lane: 2
+    EndTime: 0
+  - StartTime: 139562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 139732
+    Lane: 1
+    EndTime: 0
+  - StartTime: 139732
+    Lane: 2
+    EndTime: 0
+  - StartTime: 139732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 139816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 139901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 139986
+    Lane: 3
+    EndTime: 0
+  - StartTime: 140071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 140071
+    Lane: 2
+    EndTime: 0
+  - StartTime: 140071
+    Lane: 4
+    EndTime: 0
+  - StartTime: 140240
+    Lane: 1
+    EndTime: 0
+  - StartTime: 140240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 140410
+    Lane: 1
+    EndTime: 0
+  - StartTime: 140410
+    Lane: 3
+    EndTime: 0
+  - StartTime: 140410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 140579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 140579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 140748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 140748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 140748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 140918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 140918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 141087
+    Lane: 1
+    EndTime: 0
+  - StartTime: 141087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 141087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 141257
+    Lane: 3
+    EndTime: 0
+  - StartTime: 141257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 141426
+    Lane: 1
+    EndTime: 0
+  - StartTime: 141426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 141426
+    Lane: 2
+    EndTime: 146918
+  - StartTime: 141426
+    Lane: 4
+    EndTime: 144436
+  - StartTime: 144436
+    Lane: 3
+    EndTime: 147746
+  - StartTime: 144436
+    Lane: 1
+    EndTime: 149401
+  - StartTime: 147746
+    Lane: 4
+    EndTime: 0
+  - StartTime: 147953
+    Lane: 3
+    EndTime: 0
+  - StartTime: 148160
+    Lane: 2
+    EndTime: 0
+  - StartTime: 148367
+    Lane: 4
+    EndTime: 0
+  - StartTime: 148573
+    Lane: 3
+    EndTime: 0
+  - StartTime: 148780
+    Lane: 2
+    EndTime: 0
+  - StartTime: 148987
+    Lane: 4
+    EndTime: 0
+  - StartTime: 149194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 149401
+    Lane: 2
+    EndTime: 0
+  - StartTime: 149815
+    Lane: 3
+    EndTime: 0
+  - StartTime: 150022
+    Lane: 4
+    EndTime: 0
+  - StartTime: 150229
+    Lane: 2
+    EndTime: 0
+  - StartTime: 150436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 150642
+    Lane: 3
+    EndTime: 0
+  - StartTime: 150849
+    Lane: 2
+    EndTime: 0
+  - StartTime: 151056
+    Lane: 4
+    EndTime: 0
+  - StartTime: 151263
+    Lane: 3
+    EndTime: 0
+  - StartTime: 151470
+    Lane: 1
+    EndTime: 0
+  - StartTime: 151677
+    Lane: 3
+    EndTime: 0
+  - StartTime: 151884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 152091
+    Lane: 1
+    EndTime: 0
+  - StartTime: 152298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 152504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 152711
+    Lane: 4
+    EndTime: 0
+  - StartTime: 153125
+    Lane: 2
+    EndTime: 0
+  - StartTime: 153332
+    Lane: 3
+    EndTime: 0
+  - StartTime: 153539
+    Lane: 2
+    EndTime: 0
+  - StartTime: 153746
+    Lane: 1
+    EndTime: 0
+  - StartTime: 153953
+    Lane: 3
+    EndTime: 0
+  - StartTime: 154160
+    Lane: 1
+    EndTime: 0
+  - StartTime: 154367
+    Lane: 4
+    EndTime: 0
+  - StartTime: 154573
+    Lane: 3
+    EndTime: 0
+  - StartTime: 154780
+    Lane: 2
+    EndTime: 0
+  - StartTime: 154987
+    Lane: 4
+    EndTime: 0
+  - StartTime: 155194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 155401
+    Lane: 1
+    EndTime: 0
+  - StartTime: 155608
+    Lane: 4
+    EndTime: 0
+  - StartTime: 155815
+    Lane: 2
+    EndTime: 0
+  - StartTime: 156022
+    Lane: 3
+    EndTime: 0
+  - StartTime: 156436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 156642
+    Lane: 4
+    EndTime: 0
+  - StartTime: 156849
+    Lane: 2
+    EndTime: 0
+  - StartTime: 157056
+    Lane: 1
+    EndTime: 0
+  - StartTime: 157263
+    Lane: 4
+    EndTime: 0
+  - StartTime: 157470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 157677
+    Lane: 4
+    EndTime: 0
+  - StartTime: 157884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 158091
+    Lane: 1
+    EndTime: 0
+  - StartTime: 158298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 158504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 158711
+    Lane: 1
+    EndTime: 0
+  - StartTime: 158918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 159125
+    Lane: 3
+    EndTime: 0
+  - StartTime: 159332
+    Lane: 4
+    EndTime: 0
+  - StartTime: 159539
+    Lane: 2
+    EndTime: 0
+  - StartTime: 159746
+    Lane: 1
+    EndTime: 0
+  - StartTime: 159953
+    Lane: 4
+    EndTime: 0
+  - StartTime: 160160
+    Lane: 2
+    EndTime: 0
+  - StartTime: 160367
+    Lane: 1
+    EndTime: 0
+  - StartTime: 160573
+    Lane: 4
+    EndTime: 0
+  - StartTime: 160780
+    Lane: 3
+    EndTime: 0
+  - StartTime: 160987
+    Lane: 2
+    EndTime: 162642
+  - StartTime: 161194
+    Lane: 4
+    EndTime: 0
+  - StartTime: 161401
+    Lane: 1
+    EndTime: 0
+  - StartTime: 161608
+    Lane: 3
+    EndTime: 0
+  - StartTime: 161815
+    Lane: 4
+    EndTime: 0
+  - StartTime: 162022
+    Lane: 1
+    EndTime: 0
+  - StartTime: 162229
+    Lane: 3
+    EndTime: 0
+  - StartTime: 162436
+    Lane: 4
+    EndTime: 0
+  - StartTime: 162642
+    Lane: 3
+    EndTime: 163470
+  - StartTime: 162849
+    Lane: 2
+    EndTime: 0
+  - StartTime: 163056
+    Lane: 1
+    EndTime: 0
+  - StartTime: 163263
+    Lane: 4
+    EndTime: 0
+  - StartTime: 163470
+    Lane: 2
+    EndTime: 164298
+  - StartTime: 163677
+    Lane: 1
+    EndTime: 0
+  - StartTime: 163884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 164091
+    Lane: 3
+    EndTime: 0
+  - StartTime: 164298
+    Lane: 1
+    EndTime: 167608
+  - StartTime: 164298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 164504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 164711
+    Lane: 2
+    EndTime: 0
+  - StartTime: 164918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 165125
+    Lane: 3
+    EndTime: 0
+  - StartTime: 165332
+    Lane: 2
+    EndTime: 0
+  - StartTime: 165539
+    Lane: 4
+    EndTime: 0
+  - StartTime: 165746
+    Lane: 2
+    EndTime: 0
+  - StartTime: 165953
+    Lane: 4
+    EndTime: 0
+  - StartTime: 166160
+    Lane: 3
+    EndTime: 0
+  - StartTime: 166367
+    Lane: 2
+    EndTime: 0
+  - StartTime: 166573
+    Lane: 4
+    EndTime: 0
+  - StartTime: 166780
+    Lane: 3
+    EndTime: 0
+  - StartTime: 166987
+    Lane: 2
+    EndTime: 0
+  - StartTime: 167194
+    Lane: 4
+    EndTime: 0
+  - StartTime: 167401
+    Lane: 3
+    EndTime: 0
+  - StartTime: 167608
+    Lane: 2
+    EndTime: 0
+  - StartTime: 167608
+    Lane: 4
+    EndTime: 169263
+  - StartTime: 169263
+    Lane: 3
+    EndTime: 169884
+  - StartTime: 169263
+    Lane: 1
+    EndTime: 0
+  - StartTime: 169884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 169987
+    Lane: 3
+    EndTime: 0
+  - StartTime: 170091
+    Lane: 2
+    EndTime: 170918
+  - StartTime: 170918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 170918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 170996
+    Lane: 3
+    EndTime: 174229
+  - StartTime: 172573
+    Lane: 1
+    EndTime: 0
+  - StartTime: 173608
+    Lane: 1
+    EndTime: 0
+  - StartTime: 173815
+    Lane: 1
+    EndTime: 0
+  - StartTime: 173815
+    Lane: 2
+    EndTime: 0
+  - StartTime: 174229
+    Lane: 1
+    EndTime: 0
+  - StartTime: 174229
+    Lane: 2
+    EndTime: 0
+  - StartTime: 174229
+    Lane: 4
+    EndTime: 0
+  - StartTime: 174642
+    Lane: 4
+    EndTime: 0
+  - StartTime: 174642
+    Lane: 2
+    EndTime: 0
+  - StartTime: 174849
+    Lane: 1
+    EndTime: 0
+  - StartTime: 175056
+    Lane: 4
+    EndTime: 0
+  - StartTime: 175263
+    Lane: 1
+    EndTime: 0
+  - StartTime: 175470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 175470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 175884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 175884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 176091
+    Lane: 3
+    EndTime: 0
+  - StartTime: 176298
+    Lane: 2
+    EndTime: 0
+  - StartTime: 176298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 176711
+    Lane: 1
+    EndTime: 0
+  - StartTime: 176711
+    Lane: 2
+    EndTime: 0
+  - StartTime: 176918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 177125
+    Lane: 2
+    EndTime: 0
+  - StartTime: 177125
+    Lane: 4
+    EndTime: 0
+  - StartTime: 177332
+    Lane: 1
+    EndTime: 0
+  - StartTime: 177539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 177539
+    Lane: 4
+    EndTime: 180436
+  - StartTime: 177953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 177953
+    Lane: 3
+    EndTime: 0
+  - StartTime: 178160
+    Lane: 1
+    EndTime: 0
+  - StartTime: 178367
+    Lane: 3
+    EndTime: 0
+  - StartTime: 178573
+    Lane: 1
+    EndTime: 0
+  - StartTime: 178780
+    Lane: 2
+    EndTime: 0
+  - StartTime: 178780
+    Lane: 3
+    EndTime: 0
+  - StartTime: 179194
+    Lane: 1
+    EndTime: 0
+  - StartTime: 179194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 179401
+    Lane: 1
+    EndTime: 0
+  - StartTime: 179608
+    Lane: 2
+    EndTime: 0
+  - StartTime: 179608
+    Lane: 3
+    EndTime: 0
+  - StartTime: 180022
+    Lane: 1
+    EndTime: 0
+  - StartTime: 180022
+    Lane: 3
+    EndTime: 0
+  - StartTime: 180229
+    Lane: 1
+    EndTime: 0
+  - StartTime: 180436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 180436
+    Lane: 3
+    EndTime: 0
+  - StartTime: 180642
+    Lane: 1
+    EndTime: 0
+  - StartTime: 180849
+    Lane: 1
+    EndTime: 0
+  - StartTime: 180849
+    Lane: 3
+    EndTime: 0
+  - StartTime: 180849
+    Lane: 4
+    EndTime: 0
+  - StartTime: 181263
+    Lane: 4
+    EndTime: 0
+  - StartTime: 181263
+    Lane: 3
+    EndTime: 0
+  - StartTime: 181470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 181677
+    Lane: 1
+    EndTime: 0
+  - StartTime: 181884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 182091
+    Lane: 3
+    EndTime: 0
+  - StartTime: 182091
+    Lane: 4
+    EndTime: 0
+  - StartTime: 182504
+    Lane: 1
+    EndTime: 0
+  - StartTime: 182504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 182711
+    Lane: 2
+    EndTime: 0
+  - StartTime: 182918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 182918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 183125
+    Lane: 4
+    EndTime: 183229
+  - StartTime: 183229
+    Lane: 3
+    EndTime: 183332
+  - StartTime: 183332
+    Lane: 2
+    EndTime: 184160
+  - StartTime: 183332
+    Lane: 1
+    EndTime: 0
+  - StartTime: 183539
+    Lane: 1
+    EndTime: 0
+  - StartTime: 183746
+    Lane: 4
+    EndTime: 0
+  - StartTime: 183746
+    Lane: 3
+    EndTime: 0
+  - StartTime: 183953
+    Lane: 1
+    EndTime: 0
+  - StartTime: 184160
+    Lane: 4
+    EndTime: 187470
+  - StartTime: 184160
+    Lane: 1
+    EndTime: 0
+  - StartTime: 184573
+    Lane: 2
+    EndTime: 0
+  - StartTime: 184573
+    Lane: 3
+    EndTime: 0
+  - StartTime: 184780
+    Lane: 1
+    EndTime: 0
+  - StartTime: 184987
+    Lane: 3
+    EndTime: 0
+  - StartTime: 185194
+    Lane: 1
+    EndTime: 0
+  - StartTime: 185401
+    Lane: 1
+    EndTime: 0
+  - StartTime: 185401
+    Lane: 3
+    EndTime: 0
+  - StartTime: 185608
+    Lane: 2
+    EndTime: 0
+  - StartTime: 185815
+    Lane: 1
+    EndTime: 0
+  - StartTime: 186022
+    Lane: 2
+    EndTime: 0
+  - StartTime: 186022
+    Lane: 3
+    EndTime: 0
+  - StartTime: 186229
+    Lane: 2
+    EndTime: 0
+  - StartTime: 186229
+    Lane: 3
+    EndTime: 0
+  - StartTime: 186436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 186642
+    Lane: 1
+    EndTime: 0
+  - StartTime: 186642
+    Lane: 3
+    EndTime: 0
+  - StartTime: 186849
+    Lane: 3
+    EndTime: 0
+  - StartTime: 186953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 187056
+    Lane: 1
+    EndTime: 0
+  - StartTime: 187056
+    Lane: 3
+    EndTime: 0
+  - StartTime: 187263
+    Lane: 3
+    EndTime: 0
+  - StartTime: 187367
+    Lane: 2
+    EndTime: 0
+  - StartTime: 187470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 187470
+    Lane: 1
+    EndTime: 0
+  - StartTime: 187677
+    Lane: 4
+    EndTime: 0
+  - StartTime: 187884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 188091
+    Lane: 2
+    EndTime: 0
+  - StartTime: 188091
+    Lane: 1
+    EndTime: 0
+  - StartTime: 188298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 188298
+    Lane: 3
+    EndTime: 0
+  - StartTime: 188504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 188711
+    Lane: 1
+    EndTime: 0
+  - StartTime: 188918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 188918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 189125
+    Lane: 3
+    EndTime: 0
+  - StartTime: 189125
+    Lane: 1
+    EndTime: 0
+  - StartTime: 189332
+    Lane: 4
+    EndTime: 0
+  - StartTime: 189539
+    Lane: 2
+    EndTime: 0
+  - StartTime: 189746
+    Lane: 3
+    EndTime: 0
+  - StartTime: 189746
+    Lane: 1
+    EndTime: 0
+  - StartTime: 189953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 189953
+    Lane: 4
+    EndTime: 0
+  - StartTime: 190160
+    Lane: 3
+    EndTime: 0
+  - StartTime: 190160
+    Lane: 2
+    EndTime: 0
+  - StartTime: 190367
+    Lane: 1
+    EndTime: 0
+  - StartTime: 190367
+    Lane: 3
+    EndTime: 0
+  - StartTime: 190573
+    Lane: 2
+    EndTime: 0
+  - StartTime: 190573
+    Lane: 1
+    EndTime: 0
+  - StartTime: 190780
+    Lane: 1
+    EndTime: 0
+  - StartTime: 190780
+    Lane: 4
+    EndTime: 191608
+  - StartTime: 190987
+    Lane: 3
+    EndTime: 0
+  - StartTime: 191194
+    Lane: 2
+    EndTime: 0
+  - StartTime: 191194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 191401
+    Lane: 1
+    EndTime: 191504
+  - StartTime: 191504
+    Lane: 2
+    EndTime: 191608
+  - StartTime: 191608
+    Lane: 3
+    EndTime: 192436
+  - StartTime: 191815
+    Lane: 1
+    EndTime: 0
+  - StartTime: 192022
+    Lane: 2
+    EndTime: 0
+  - StartTime: 192022
+    Lane: 4
+    EndTime: 0
+  - StartTime: 192229
+    Lane: 1
+    EndTime: 192332
+  - StartTime: 192332
+    Lane: 2
+    EndTime: 192436
+  - StartTime: 192436
+    Lane: 4
+    EndTime: 193263
+  - StartTime: 192642
+    Lane: 3
+    EndTime: 0
+  - StartTime: 192849
+    Lane: 2
+    EndTime: 0
+  - StartTime: 192849
+    Lane: 1
+    EndTime: 0
+  - StartTime: 193056
+    Lane: 3
+    EndTime: 193160
+  - StartTime: 193160
+    Lane: 2
+    EndTime: 193263
+  - StartTime: 193263
+    Lane: 1
+    EndTime: 193987
+  - StartTime: 193470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 193470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 193677
+    Lane: 4
+    EndTime: 193987
+  - StartTime: 193677
+    Lane: 2
+    EndTime: 0
+  - StartTime: 194091
+    Lane: 1
+    EndTime: 0
+  - StartTime: 194091
+    Lane: 3
+    EndTime: 0
+  - StartTime: 194091
+    Lane: 4
+    EndTime: 0
+  - StartTime: 194298
+    Lane: 2
+    EndTime: 0
+  - StartTime: 194504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 194711
+    Lane: 4
+    EndTime: 0
+  - StartTime: 194711
+    Lane: 3
+    EndTime: 0
+  - StartTime: 194918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 194918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 195125
+    Lane: 1
+    EndTime: 0
+  - StartTime: 195332
+    Lane: 2
+    EndTime: 0
+  - StartTime: 195539
+    Lane: 1
+    EndTime: 0
+  - StartTime: 195539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 195746
+    Lane: 3
+    EndTime: 0
+  - StartTime: 195746
+    Lane: 4
+    EndTime: 0
+  - StartTime: 195953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 196160
+    Lane: 1
+    EndTime: 0
+  - StartTime: 196160
+    Lane: 3
+    EndTime: 0
+  - StartTime: 196367
+    Lane: 4
+    EndTime: 0
+  - StartTime: 196367
+    Lane: 3
+    EndTime: 0
+  - StartTime: 196573
+    Lane: 2
+    EndTime: 0
+  - StartTime: 196573
+    Lane: 1
+    EndTime: 0
+  - StartTime: 196780
+    Lane: 2
+    EndTime: 0
+  - StartTime: 196780
+    Lane: 4
+    EndTime: 0
+  - StartTime: 196987
+    Lane: 3
+    EndTime: 0
+  - StartTime: 196987
+    Lane: 1
+    EndTime: 0
+  - StartTime: 197194
+    Lane: 1
+    EndTime: 0
+  - StartTime: 197194
+    Lane: 4
+    EndTime: 0
+  - StartTime: 197401
+    Lane: 3
+    EndTime: 0
+  - StartTime: 197401
+    Lane: 2
+    EndTime: 197815
+  - StartTime: 197815
+    Lane: 4
+    EndTime: 0
+  - StartTime: 197815
+    Lane: 3
+    EndTime: 198229
+  - StartTime: 198229
+    Lane: 4
+    EndTime: 0
+  - StartTime: 198229
+    Lane: 1
+    EndTime: 198642
+  - StartTime: 198642
+    Lane: 3
+    EndTime: 0
+  - StartTime: 198642
+    Lane: 2
+    EndTime: 199056
+  - StartTime: 198849
+    Lane: 4
+    EndTime: 0
+  - StartTime: 198953
+    Lane: 1
+    EndTime: 0
+  - StartTime: 199056
+    Lane: 3
+    EndTime: 0
+  - StartTime: 199056
+    Lane: 4
+    EndTime: 0
+  - StartTime: 199263
+    Lane: 2
+    EndTime: 0
+  - StartTime: 199263
+    Lane: 4
+    EndTime: 0
+  - StartTime: 199470
+    Lane: 1
+    EndTime: 0
+  - StartTime: 199470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 199677
+    Lane: 1
+    EndTime: 0
+  - StartTime: 199677
+    Lane: 3
+    EndTime: 0
+  - StartTime: 199884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 199884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200091
+    Lane: 2
+    EndTime: 0
+  - StartTime: 200091
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200298
+    Lane: 1
+    EndTime: 0
+  - StartTime: 200298
+    Lane: 3
+    EndTime: 0
+  - StartTime: 200349
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 200711
+    Lane: 1
+    EndTime: 0
+  - StartTime: 200711
+    Lane: 2
+    EndTime: 0
+  - StartTime: 200711
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200815
+    Lane: 3
+    EndTime: 0
+  - StartTime: 200918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 201022
+    Lane: 3
+    EndTime: 0
+  - StartTime: 201125
+    Lane: 1
+    EndTime: 0
+  - StartTime: 201125
+    Lane: 2
+    EndTime: 0
+  - StartTime: 201229
+    Lane: 4
+    EndTime: 0
+  - StartTime: 201332
+    Lane: 3
+    EndTime: 0
+  - StartTime: 201436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 201539
+    Lane: 4
+    EndTime: 0
+  - StartTime: 201539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 201642
+    Lane: 1
+    EndTime: 0
+  - StartTime: 201746
+    Lane: 2
+    EndTime: 0
+  - StartTime: 201849
+    Lane: 3
+    EndTime: 0
+  - StartTime: 201953
+    Lane: 1
+    EndTime: 0
+  - StartTime: 201953
+    Lane: 4
+    EndTime: 0
+  - StartTime: 202056
+    Lane: 3
+    EndTime: 0
+  - StartTime: 202160
+    Lane: 2
+    EndTime: 0
+  - StartTime: 202263
+    Lane: 3
+    EndTime: 0
+  - StartTime: 202367
+    Lane: 4
+    EndTime: 0
+  - StartTime: 202367
+    Lane: 2
+    EndTime: 0
+  - StartTime: 202470
+    Lane: 1
+    EndTime: 0
+  - StartTime: 202573
+    Lane: 3
+    EndTime: 0
+  - StartTime: 202677
+    Lane: 2
+    EndTime: 0
+  - StartTime: 202780
+    Lane: 1
+    EndTime: 0
+  - StartTime: 202780
+    Lane: 3
+    EndTime: 0
+  - StartTime: 202884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 202987
+    Lane: 3
+    EndTime: 0
+  - StartTime: 203091
+    Lane: 2
+    EndTime: 0
+  - StartTime: 203194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 203194
+    Lane: 4
+    EndTime: 0
+  - StartTime: 203298
+    Lane: 2
+    EndTime: 0
+  - StartTime: 203401
+    Lane: 1
+    EndTime: 0
+  - StartTime: 203470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 203539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 203608
+    Lane: 4
+    EndTime: 0
+  - StartTime: 203608
+    Lane: 1
+    EndTime: 204022
+  - StartTime: 204022
+    Lane: 4
+    EndTime: 0
+  - StartTime: 204125
+    Lane: 2
+    EndTime: 0
+  - StartTime: 204203
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204280
+    Lane: 1
+    EndTime: 0
+  - StartTime: 204358
+    Lane: 2
+    EndTime: 0
+  - StartTime: 204436
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204487
+    Lane: 4
+    EndTime: 0
+  - StartTime: 204591
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204668
+    Lane: 2
+    EndTime: 0
+  - StartTime: 204746
+    Lane: 1
+    EndTime: 0
+  - StartTime: 204823
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 204953
+    Lane: 3
+    EndTime: 0
+  - StartTime: 205004
+    Lane: 4
+    EndTime: 0
+  - StartTime: 205082
+    Lane: 2
+    EndTime: 0
+  - StartTime: 205186
+    Lane: 1
+    EndTime: 0
+  - StartTime: 205211
+    Lane: 2
+    EndTime: 0
+  - StartTime: 205263
+    Lane: 3
+    EndTime: 0
+  - StartTime: 205341
+    Lane: 4
+    EndTime: 0
+  - StartTime: 205392
+    Lane: 3
+    EndTime: 0
+  - StartTime: 205444
+    Lane: 2
+    EndTime: 0
+  - StartTime: 205539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 205573
+    Lane: 2
+    EndTime: 0
+  - StartTime: 205625
+    Lane: 1
+    EndTime: 0
+  - StartTime: 205677
+    Lane: 4
+    EndTime: 205884
+  - StartTime: 205884
+    Lane: 3
+    EndTime: 206039
+  - StartTime: 206039
+    Lane: 2
+    EndTime: 206194
+  - StartTime: 206194
+    Lane: 3
+    EndTime: 206323
+  - StartTime: 206323
+    Lane: 2
+    EndTime: 206504
+  - StartTime: 206504
+    Lane: 1
+    EndTime: 206634
+  - StartTime: 206634
+    Lane: 2
+    EndTime: 206763
+  - StartTime: 206763
+    Lane: 3
+    EndTime: 206918
+  - StartTime: 206918
+    Lane: 4
+    EndTime: 207229
+  - StartTime: 206918
+    Lane: 1
+    EndTime: 207229
+  - StartTime: 207125
+    Lane: 2
+    EndTime: 0
+  - StartTime: 207125
+    Lane: 3
+    EndTime: 0
+  - StartTime: 207332
+    Lane: 1
+    EndTime: 0
+  - StartTime: 207332
+    Lane: 2
+    EndTime: 0
+  - StartTime: 207332
+    Lane: 4
+    EndTime: 0
+  - StartTime: 207384
+    Lane: 3
+    EndTime: 0
+  - StartTime: 207436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 207487
+    Lane: 1
+    EndTime: 0
+  - StartTime: 207539
+    Lane: 4
+    EndTime: 0
+  - StartTime: 207591
+    Lane: 3
+    EndTime: 0
+  - StartTime: 207694
+    Lane: 4
+    EndTime: 0
+  - StartTime: 207746
+    Lane: 2
+    EndTime: 0
+  - StartTime: 207746
+    Lane: 1
+    EndTime: 0
+  - StartTime: 207798
+    Lane: 3
+    EndTime: 0
+  - StartTime: 207849
+    Lane: 4
+    EndTime: 0
+  - StartTime: 207901
+    Lane: 1
+    EndTime: 0
+  - StartTime: 207953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 208004
+    Lane: 3
+    EndTime: 0
+  - StartTime: 208056
+    Lane: 4
+    EndTime: 0
+  - StartTime: 208108
+    Lane: 1
+    EndTime: 0
+  - StartTime: 208160
+    Lane: 2
+    EndTime: 0
+  - StartTime: 208160
+    Lane: 4
+    EndTime: 0
+  - StartTime: 208211
+    Lane: 3
+    EndTime: 0
+  - StartTime: 208263
+    Lane: 1
+    EndTime: 0
+  - StartTime: 208315
+    Lane: 2
+    EndTime: 0
+  - StartTime: 208367
+    Lane: 4
+    EndTime: 0
+  - StartTime: 208367
+    Lane: 3
+    EndTime: 0
+  - StartTime: 208436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 208470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 208504
+    Lane: 4
+    EndTime: 0
+  - StartTime: 208539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 208573
+    Lane: 2
+    EndTime: 0
+  - StartTime: 208573
+    Lane: 1
+    EndTime: 0
+  - StartTime: 208625
+    Lane: 4
+    EndTime: 0
+  - StartTime: 208677
+    Lane: 3
+    EndTime: 0
+  - StartTime: 208729
+    Lane: 1
+    EndTime: 0
+  - StartTime: 208780
+    Lane: 2
+    EndTime: 0
+  - StartTime: 208884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 208987
+    Lane: 2
+    EndTime: 0
+  - StartTime: 208987
+    Lane: 4
+    EndTime: 0
+  - StartTime: 209056
+    Lane: 3
+    EndTime: 0
+  - StartTime: 209125
+    Lane: 2
+    EndTime: 0
+  - StartTime: 209194
+    Lane: 1
+    EndTime: 0
+  - StartTime: 209194
+    Lane: 4
+    EndTime: 0
+  - StartTime: 209298
+    Lane: 3
+    EndTime: 0
+  - StartTime: 209401
+    Lane: 1
+    EndTime: 0
+  - StartTime: 209401
+    Lane: 2
+    EndTime: 0
+  - StartTime: 209504
+    Lane: 4
+    EndTime: 0
+  - StartTime: 209608
+    Lane: 3
+    EndTime: 0
+  - StartTime: 209608
+    Lane: 2
+    EndTime: 0
+  - StartTime: 209711
+    Lane: 1
+    EndTime: 0
+  - StartTime: 209815
+    Lane: 3
+    EndTime: 0
+  - StartTime: 209815
+    Lane: 4
+    EndTime: 0
+  - StartTime: 209953
+    Lane: 1
+    EndTime: 0
+  - StartTime: 210022
+    Lane: 2
+    EndTime: 0
+  - StartTime: 210022
+    Lane: 4
+    EndTime: 0
+  - StartTime: 210073
+    Lane: 3
+    EndTime: 0
+  - StartTime: 210229
+    Lane: 1
+    EndTime: 0
+  - StartTime: 210229
+    Lane: 2
+    EndTime: 0
+  - StartTime: 210332
+    Lane: 3
+    EndTime: 0
+  - StartTime: 210436
+    Lane: 4
+    EndTime: 0
+  - StartTime: 210513
+    Lane: 2
+    EndTime: 0
+  - StartTime: 210642
+    Lane: 1
+    EndTime: 0
+  - StartTime: 210642
+    Lane: 4
+    EndTime: 0
+  - StartTime: 210746
+    Lane: 2
+    EndTime: 0
+  - StartTime: 210849
+    Lane: 3
+    EndTime: 0
+  - StartTime: 210953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 211004
+    Lane: 3
+    EndTime: 0
+  - StartTime: 211056
+    Lane: 1
+    EndTime: 0
+  - StartTime: 211056
+    Lane: 4
+    EndTime: 0
+  - StartTime: 211160
+    Lane: 3
+    EndTime: 0
+  - StartTime: 211263
+    Lane: 4
+    EndTime: 0
+  - StartTime: 211315
+    Lane: 2
+    EndTime: 0
+  - StartTime: 211367
+    Lane: 1
+    EndTime: 0
+  - StartTime: 211470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 211470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 211573
+    Lane: 3
+    EndTime: 0
+  - StartTime: 211677
+    Lane: 2
+    EndTime: 0
+  - StartTime: 211780
+    Lane: 1
+    EndTime: 0
+  - StartTime: 211884
+    Lane: 4
+    EndTime: 212091
+  - StartTime: 211884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 211987
+    Lane: 2
+    EndTime: 0
+  - StartTime: 212091
+    Lane: 1
+    EndTime: 0
+  - StartTime: 212194
+    Lane: 2
+    EndTime: 0
+  - StartTime: 212298
+    Lane: 3
+    EndTime: 0
+  - StartTime: 212298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 212401
+    Lane: 2
+    EndTime: 0
+  - StartTime: 212504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 212504
+    Lane: 4
+    EndTime: 0
+  - StartTime: 212608
+    Lane: 2
+    EndTime: 0
+  - StartTime: 212608
+    Lane: 1
+    EndTime: 0
+  - StartTime: 212711
+    Lane: 3
+    EndTime: 0
+  - StartTime: 212711
+    Lane: 4
+    EndTime: 0
+  - StartTime: 212815
+    Lane: 2
+    EndTime: 0
+  - StartTime: 212918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 212918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 213022
+    Lane: 4
+    EndTime: 0
+  - StartTime: 213073
+    Lane: 3
+    EndTime: 0
+  - StartTime: 213125
+    Lane: 2
+    EndTime: 0
+  - StartTime: 213125
+    Lane: 1
+    EndTime: 0
+  - StartTime: 213194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 213263
+    Lane: 4
+    EndTime: 0
+  - StartTime: 213332
+    Lane: 3
+    EndTime: 0
+  - StartTime: 213332
+    Lane: 2
+    EndTime: 0
+  - StartTime: 213436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 213487
+    Lane: 2
+    EndTime: 0
+  - StartTime: 213539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 213539
+    Lane: 4
+    EndTime: 0
+  - StartTime: 213642
+    Lane: 2
+    EndTime: 0
+  - StartTime: 213746
+    Lane: 4
+    EndTime: 0
+  - StartTime: 213746
+    Lane: 1
+    EndTime: 0
+  - StartTime: 213849
+    Lane: 2
+    EndTime: 0
+  - StartTime: 213953
+    Lane: 3
+    EndTime: 0
+  - StartTime: 213953
+    Lane: 4
+    EndTime: 214367
+  - StartTime: 213953
+    Lane: 1
+    EndTime: 0
+  - StartTime: 214160
+    Lane: 2
+    EndTime: 214367
+  - StartTime: 214367
+    Lane: 3
+    EndTime: 0
+  - StartTime: 214367
+    Lane: 1
+    EndTime: 214780
+  - StartTime: 214573
+    Lane: 4
+    EndTime: 214780
+  - StartTime: 214780
+    Lane: 3
+    EndTime: 215194
+  - StartTime: 214780
+    Lane: 2
+    EndTime: 0
+  - StartTime: 214987
+    Lane: 1
+    EndTime: 215194
+  - StartTime: 215194
+    Lane: 4
+    EndTime: 215608
+  - StartTime: 215194
+    Lane: 2
+    EndTime: 0
+  - StartTime: 215401
+    Lane: 2
+    EndTime: 215608
+  - StartTime: 215608
+    Lane: 1
+    EndTime: 0
+  - StartTime: 215608
+    Lane: 3
+    EndTime: 215815
+  - StartTime: 215815
+    Lane: 1
+    EndTime: 215918
+  - StartTime: 215815
+    Lane: 2
+    EndTime: 0
+  - StartTime: 216022
+    Lane: 1
+    EndTime: 216125
+  - StartTime: 216022
+    Lane: 2
+    EndTime: 0
+  - StartTime: 216229
+    Lane: 1
+    EndTime: 216849
+  - StartTime: 216229
+    Lane: 4
+    EndTime: 216539
+  - StartTime: 216436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 216642
+    Lane: 2
+    EndTime: 216746
+  - StartTime: 216642
+    Lane: 3
+    EndTime: 0
+  - StartTime: 216849
+    Lane: 3
+    EndTime: 216953
+  - StartTime: 216849
+    Lane: 4
+    EndTime: 0
+  - StartTime: 217056
+    Lane: 4
+    EndTime: 217160
+  - StartTime: 217056
+    Lane: 1
+    EndTime: 0
+  - StartTime: 217263
+    Lane: 1
+    EndTime: 0
+  - StartTime: 217263
+    Lane: 4
+    EndTime: 0
+  - StartTime: 217263
+    Lane: 3
+    EndTime: 0
+  - StartTime: 217332
+    Lane: 2
+    EndTime: 0
+  - StartTime: 217401
+    Lane: 4
+    EndTime: 0
+  - StartTime: 217470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 217470
+    Lane: 1
+    EndTime: 0
+  - StartTime: 217573
+    Lane: 2
+    EndTime: 0
+  - StartTime: 217677
+    Lane: 4
+    EndTime: 0
+  - StartTime: 217677
+    Lane: 3
+    EndTime: 0
+  - StartTime: 217780
+    Lane: 1
+    EndTime: 0
+  - StartTime: 217884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 217884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 217987
+    Lane: 3
+    EndTime: 0
+  - StartTime: 218091
+    Lane: 4
+    EndTime: 0
+  - StartTime: 218091
+    Lane: 1
+    EndTime: 0
+  - StartTime: 218194
+    Lane: 2
+    EndTime: 0
+  - StartTime: 218298
+    Lane: 3
+    EndTime: 0
+  - StartTime: 218298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 218401
+    Lane: 4
+    EndTime: 0
+  - StartTime: 218401
+    Lane: 1
+    EndTime: 0
+  - StartTime: 218504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 218504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 218608
+    Lane: 1
+    EndTime: 0
+  - StartTime: 218711
+    Lane: 3
+    EndTime: 0
+  - StartTime: 218711
+    Lane: 4
+    EndTime: 0
+  - StartTime: 218815
+    Lane: 2
+    EndTime: 0
+  - StartTime: 218918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 218918
+    Lane: 4
+    EndTime: 219125
+  - StartTime: 219125
+    Lane: 3
+    EndTime: 219332
+  - StartTime: 219125
+    Lane: 1
+    EndTime: 0
+  - StartTime: 219332
+    Lane: 2
+    EndTime: 0
+  - StartTime: 219332
+    Lane: 1
+    EndTime: 0
+  - StartTime: 219539
+    Lane: 4
+    EndTime: 219953
+  - StartTime: 219539
+    Lane: 1
+    EndTime: 219953
+  - StartTime: 219953
+    Lane: 3
+    EndTime: 0
+  - StartTime: 219953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 220056
+    Lane: 4
+    EndTime: 0
+  - StartTime: 220056
+    Lane: 1
+    EndTime: 0
+  - StartTime: 220160
+    Lane: 3
+    EndTime: 0
+  - StartTime: 220160
+    Lane: 2
+    EndTime: 0
+  - StartTime: 220263
+    Lane: 4
+    EndTime: 0
+  - StartTime: 220367
+    Lane: 1
+    EndTime: 0
+  - StartTime: 220367
+    Lane: 2
+    EndTime: 0
+  - StartTime: 220470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 220573
+    Lane: 3
+    EndTime: 0
+  - StartTime: 220573
+    Lane: 2
+    EndTime: 0
+  - StartTime: 220573
+    Lane: 1
+    EndTime: 221194
+  - StartTime: 220987
+    Lane: 3
+    EndTime: 0
+  - StartTime: 220987
+    Lane: 4
+    EndTime: 221194
+  - StartTime: 221194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 221194
+    Lane: 2
+    EndTime: 221815
+  - StartTime: 221608
+    Lane: 1
+    EndTime: 0
+  - StartTime: 221608
+    Lane: 4
+    EndTime: 221815
+  - StartTime: 221815
+    Lane: 1
+    EndTime: 0
+  - StartTime: 221815
+    Lane: 3
+    EndTime: 222436
+  - StartTime: 222229
+    Lane: 1
+    EndTime: 222436
+  - StartTime: 222229
+    Lane: 2
+    EndTime: 0
+  - StartTime: 222436
+    Lane: 4
+    EndTime: 222642
+  - StartTime: 222642
+    Lane: 3
+    EndTime: 222849
+  - StartTime: 222642
+    Lane: 1
+    EndTime: 0
+  - StartTime: 222849
+    Lane: 2
+    EndTime: 223056
+  - StartTime: 222849
+    Lane: 4
+    EndTime: 0
+  - StartTime: 223056
+    Lane: 1
+    EndTime: 0
+  - StartTime: 223056
+    Lane: 3
+    EndTime: 0
+  - StartTime: 223125
+    Lane: 4
+    EndTime: 0
+  - StartTime: 223194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 223263
+    Lane: 2
+    EndTime: 223367
+  - StartTime: 223367
+    Lane: 1
+    EndTime: 223470
+  - StartTime: 223470
+    Lane: 4
+    EndTime: 223573
+  - StartTime: 223470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 223573
+    Lane: 3
+    EndTime: 223677
+  - StartTime: 223677
+    Lane: 1
+    EndTime: 223780
+  - StartTime: 223780
+    Lane: 2
+    EndTime: 223884
+  - StartTime: 223884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 223884
+    Lane: 3
+    EndTime: 223987
+  - StartTime: 223987
+    Lane: 2
+    EndTime: 224091
+  - StartTime: 224091
+    Lane: 1
+    EndTime: 224194
+  - StartTime: 224194
+    Lane: 4
+    EndTime: 224298
+  - StartTime: 224298
+    Lane: 3
+    EndTime: 224401
+  - StartTime: 224298
+    Lane: 2
+    EndTime: 0
+  - StartTime: 224401
+    Lane: 4
+    EndTime: 224504
+  - StartTime: 224504
+    Lane: 3
+    EndTime: 224608
+  - StartTime: 224504
+    Lane: 1
+    EndTime: 0
+  - StartTime: 224608
+    Lane: 2
+    EndTime: 224711
+  - StartTime: 224711
+    Lane: 1
+    EndTime: 224815
+  - StartTime: 224815
+    Lane: 4
+    EndTime: 224918
+  - StartTime: 224918
+    Lane: 3
+    EndTime: 225022
+  - StartTime: 224918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 225022
+    Lane: 4
+    EndTime: 225125
+  - StartTime: 225125
+    Lane: 2
+    EndTime: 225229
+  - StartTime: 225125
+    Lane: 1
+    EndTime: 0
+  - StartTime: 225229
+    Lane: 3
+    EndTime: 225332
+  - StartTime: 225332
+    Lane: 1
+    EndTime: 225436
+  - StartTime: 225436
+    Lane: 2
+    EndTime: 225539
+  - StartTime: 225539
+    Lane: 4
+    EndTime: 0
+  - StartTime: 225539
+    Lane: 3
+    EndTime: 225642
+  - StartTime: 225642
+    Lane: 1
+    EndTime: 0
+  - StartTime: 225642
+    Lane: 2
+    EndTime: 0
+  - StartTime: 225746
+    Lane: 4
+    EndTime: 225849
+  - StartTime: 225746
+    Lane: 3
+    EndTime: 0
+  - StartTime: 225953
+    Lane: 1
+    EndTime: 226056
+  - StartTime: 225953
+    Lane: 3
+    EndTime: 0
+  - StartTime: 226160
+    Lane: 1
+    EndTime: 226263
+  - StartTime: 226160
+    Lane: 4
+    EndTime: 0
+  - StartTime: 226263
+    Lane: 2
+    EndTime: 0
+  - StartTime: 226367
+    Lane: 3
+    EndTime: 226470
+  - StartTime: 226367
+    Lane: 4
+    EndTime: 226470
+  - StartTime: 226367
+    Lane: 1
+    EndTime: 0
+  - StartTime: 226573
+    Lane: 3
+    EndTime: 226677
+  - StartTime: 226573
+    Lane: 4
+    EndTime: 226677
+  - StartTime: 226780
+    Lane: 3
+    EndTime: 226884
+  - StartTime: 226780
+    Lane: 4
+    EndTime: 226884
+  - StartTime: 226884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 226987
+    Lane: 2
+    EndTime: 227091
+  - StartTime: 226987
+    Lane: 3
+    EndTime: 227091
+  - StartTime: 227091
+    Lane: 1
+    EndTime: 0
+  - StartTime: 227194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 227194
+    Lane: 4
+    EndTime: 227401
+  - StartTime: 227194
+    Lane: 2
+    EndTime: 0
+  - StartTime: 227401
+    Lane: 1
+    EndTime: 227608
+  - StartTime: 227608
+    Lane: 2
+    EndTime: 227815
+  - StartTime: 227608
+    Lane: 3
+    EndTime: 0
+  - StartTime: 227815
+    Lane: 4
+    EndTime: 228022
+  - StartTime: 227815
+    Lane: 1
+    EndTime: 0
+  - StartTime: 228022
+    Lane: 3
+    EndTime: 228229
+  - StartTime: 228229
+    Lane: 4
+    EndTime: 228436
+  - StartTime: 228229
+    Lane: 1
+    EndTime: 0
+  - StartTime: 228436
+    Lane: 2
+    EndTime: 228642
+  - StartTime: 228436
+    Lane: 3
+    EndTime: 0
+  - StartTime: 228642
+    Lane: 1
+    EndTime: 228849
+  - StartTime: 228642
+    Lane: 4
+    EndTime: 0
+  - StartTime: 228849
+    Lane: 4
+    EndTime: 0
+  - StartTime: 228849
+    Lane: 3
+    EndTime: 229056
+  - StartTime: 228849
+    Lane: 2
+    EndTime: 0
+  - StartTime: 229056
+    Lane: 1
+    EndTime: 229263
+  - StartTime: 229263
+    Lane: 2
+    EndTime: 229470
+  - StartTime: 229263
+    Lane: 3
+    EndTime: 0
+  - StartTime: 229470
+    Lane: 4
+    EndTime: 229677
+  - StartTime: 229470
+    Lane: 1
+    EndTime: 0
+  - StartTime: 229677
+    Lane: 3
+    EndTime: 229884
+  - StartTime: 229884
+    Lane: 2
+    EndTime: 230091
+  - StartTime: 229884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 230091
+    Lane: 3
+    EndTime: 230298
+  - StartTime: 230091
+    Lane: 4
+    EndTime: 0
+  - StartTime: 230298
+    Lane: 2
+    EndTime: 0
+  - StartTime: 230298
+    Lane: 1
+    EndTime: 230504
+  - StartTime: 230504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 230504
+    Lane: 4
+    EndTime: 230711
+  - StartTime: 230504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 230711
+    Lane: 3
+    EndTime: 230918
+  - StartTime: 230918
+    Lane: 2
+    EndTime: 231125
+  - StartTime: 230918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 231125
+    Lane: 3
+    EndTime: 231332
+  - StartTime: 231125
+    Lane: 1
+    EndTime: 0
+  - StartTime: 231332
+    Lane: 2
+    EndTime: 231539
+  - StartTime: 231539
+    Lane: 1
+    EndTime: 231746
+  - StartTime: 231539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 231746
+    Lane: 2
+    EndTime: 231953
+  - StartTime: 231746
+    Lane: 4
+    EndTime: 0
+  - StartTime: 231953
+    Lane: 3
+    EndTime: 232160
+  - StartTime: 231953
+    Lane: 1
+    EndTime: 0
+  - StartTime: 232160
+    Lane: 1
+    EndTime: 0
+  - StartTime: 232160
+    Lane: 4
+    EndTime: 232367
+  - StartTime: 232367
+    Lane: 3
+    EndTime: 232573
+  - StartTime: 232573
+    Lane: 2
+    EndTime: 232780
+  - StartTime: 232573
+    Lane: 4
+    EndTime: 0
+  - StartTime: 232780
+    Lane: 1
+    EndTime: 232987
+  - StartTime: 232780
+    Lane: 3
+    EndTime: 0
+  - StartTime: 232987
+    Lane: 2
+    EndTime: 233401
+  - StartTime: 232987
+    Lane: 4
+    EndTime: 233401
+  - StartTime: 233194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 233194
+    Lane: 1
+    EndTime: 0
+  - StartTime: 233401
+    Lane: 3
+    EndTime: 233815
+  - StartTime: 233401
+    Lane: 1
+    EndTime: 233815
+  - StartTime: 233815
+    Lane: 4
+    EndTime: 234022
+  - StartTime: 233815
+    Lane: 2
+    EndTime: 0
+  - StartTime: 234022
+    Lane: 1
+    EndTime: 234229
+  - StartTime: 234229
+    Lane: 2
+    EndTime: 0
+  - StartTime: 234229
+    Lane: 3
+    EndTime: 234436
+  - StartTime: 234436
+    Lane: 4
+    EndTime: 234642
+  - StartTime: 234436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 234642
+    Lane: 3
+    EndTime: 234849
+  - StartTime: 234849
+    Lane: 1
+    EndTime: 0
+  - StartTime: 234849
+    Lane: 2
+    EndTime: 235056
+  - StartTime: 235056
+    Lane: 4
+    EndTime: 235263
+  - StartTime: 235056
+    Lane: 3
+    EndTime: 0
+  - StartTime: 235263
+    Lane: 1
+    EndTime: 235470
+  - StartTime: 235263
+    Lane: 2
+    EndTime: 0
+  - StartTime: 235470
+    Lane: 3
+    EndTime: 235677
+  - StartTime: 235470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 235677
+    Lane: 1
+    EndTime: 235884
+  - StartTime: 235884
+    Lane: 3
+    EndTime: 236091
+  - StartTime: 235884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 236091
+    Lane: 1
+    EndTime: 0
+  - StartTime: 236091
+    Lane: 4
+    EndTime: 236298
+  - StartTime: 236298
+    Lane: 3
+    EndTime: 236504
+  - StartTime: 236504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 236504
+    Lane: 1
+    EndTime: 236711
+  - StartTime: 236711
+    Lane: 3
+    EndTime: 236918
+  - StartTime: 236711
+    Lane: 2
+    EndTime: 0
+  - StartTime: 236711
+    Lane: 4
+    EndTime: 0
+  - StartTime: 236918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 236918
+    Lane: 4
+    EndTime: 237125
+  - StartTime: 237125
+    Lane: 1
+    EndTime: 237332
+  - StartTime: 237125
+    Lane: 2
+    EndTime: 0
+  - StartTime: 237229
+    Lane: 4
+    EndTime: 0
+  - StartTime: 237332
+    Lane: 2
+    EndTime: 237539
+  - StartTime: 237332
+    Lane: 3
+    EndTime: 0
+  - StartTime: 237436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 237539
+    Lane: 3
+    EndTime: 237746
+  - StartTime: 237539
+    Lane: 4
+    EndTime: 0
+  - StartTime: 237642
+    Lane: 2
+    EndTime: 0
+  - StartTime: 237746
+    Lane: 4
+    EndTime: 237953
+  - StartTime: 237746
+    Lane: 1
+    EndTime: 0
+  - StartTime: 237849
+    Lane: 3
+    EndTime: 0
+  - StartTime: 237953
+    Lane: 1
+    EndTime: 238160
+  - StartTime: 237953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 238056
+    Lane: 4
+    EndTime: 0
+  - StartTime: 238160
+    Lane: 3
+    EndTime: 238367
+  - StartTime: 238160
+    Lane: 2
+    EndTime: 0
+  - StartTime: 238263
+    Lane: 1
+    EndTime: 0
+  - StartTime: 238367
+    Lane: 2
+    EndTime: 238573
+  - StartTime: 238367
+    Lane: 4
+    EndTime: 0
+  - StartTime: 238470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 238573
+    Lane: 4
+    EndTime: 238780
+  - StartTime: 238573
+    Lane: 1
+    EndTime: 0
+  - StartTime: 238677
+    Lane: 2
+    EndTime: 0
+  - StartTime: 238780
+    Lane: 1
+    EndTime: 238987
+  - StartTime: 238780
+    Lane: 3
+    EndTime: 0
+  - StartTime: 238884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 238987
+    Lane: 2
+    EndTime: 239194
+  - StartTime: 238987
+    Lane: 3
+    EndTime: 0
+  - StartTime: 239091
+    Lane: 4
+    EndTime: 0
+  - StartTime: 239194
+    Lane: 3
+    EndTime: 239401
+  - StartTime: 239194
+    Lane: 1
+    EndTime: 0
+  - StartTime: 239298
+    Lane: 2
+    EndTime: 0
+  - StartTime: 239401
+    Lane: 4
+    EndTime: 239608
+  - StartTime: 239401
+    Lane: 1
+    EndTime: 0
+  - StartTime: 239504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 239608
+    Lane: 2
+    EndTime: 0
+  - StartTime: 239608
+    Lane: 1
+    EndTime: 240022
+  - StartTime: 239711
+    Lane: 4
+    EndTime: 0
+  - StartTime: 239711
+    Lane: 3
+    EndTime: 0
+  - StartTime: 239815
+    Lane: 2
+    EndTime: 0
+  - StartTime: 239918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 240022
+    Lane: 2
+    EndTime: 0
+  - StartTime: 240022
+    Lane: 4
+    EndTime: 240436
+  - StartTime: 240125
+    Lane: 1
+    EndTime: 0
+  - StartTime: 240229
+    Lane: 3
+    EndTime: 0
+  - StartTime: 240332
+    Lane: 2
+    EndTime: 0
+  - StartTime: 240436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 240436
+    Lane: 3
+    EndTime: 243742
+  - StartTime: 240436
+    Lane: 2
+    EndTime: 243742
+  - StartTime: 243742
+    Lane: 4
+    EndTime: 0
+  - StartTime: 243742
+    Lane: 1
+    EndTime: 0
+  - StartTime: 243826
+    Lane: 2
+    EndTime: 0
+  - StartTime: 243911
+    Lane: 3
+    EndTime: 0
+  - StartTime: 243996
+    Lane: 1
+    EndTime: 0
+  - StartTime: 244080
+    Lane: 4
+    EndTime: 0
+  - StartTime: 244165
+    Lane: 3
+    EndTime: 0
+  - StartTime: 244250
+    Lane: 4
+    EndTime: 0
+  - StartTime: 244335
+    Lane: 1
+    EndTime: 0
+  - StartTime: 244419
+    Lane: 2
+    EndTime: 0
+  - StartTime: 244504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 244589
+    Lane: 4
+    EndTime: 0
+  - StartTime: 244674
+    Lane: 3
+    EndTime: 0
+  - StartTime: 244758
+    Lane: 2
+    EndTime: 0
+  - StartTime: 244843
+    Lane: 1
+    EndTime: 0
+  - StartTime: 244928
+    Lane: 2
+    EndTime: 0
+  - StartTime: 245013
+    Lane: 4
+    EndTime: 0
+  - StartTime: 245097
+    Lane: 3
+    EndTime: 0
+  - StartTime: 245182
+    Lane: 2
+    EndTime: 0
+  - StartTime: 245267
+    Lane: 3
+    EndTime: 0
+  - StartTime: 245352
+    Lane: 1
+    EndTime: 0
+  - StartTime: 245436
+    Lane: 3
+    EndTime: 0
+  - StartTime: 245521
+    Lane: 1
+    EndTime: 0
+  - StartTime: 245606
+    Lane: 4
+    EndTime: 0
+  - StartTime: 245691
+    Lane: 3
+    EndTime: 0
+  - StartTime: 245775
+    Lane: 2
+    EndTime: 0
+  - StartTime: 245860
+    Lane: 3
+    EndTime: 0
+  - StartTime: 245945
+    Lane: 2
+    EndTime: 0
+  - StartTime: 246030
+    Lane: 1
+    EndTime: 0
+  - StartTime: 246114
+    Lane: 4
+    EndTime: 0
+  - StartTime: 246199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 246284
+    Lane: 2
+    EndTime: 0
+  - StartTime: 246369
+    Lane: 4
+    EndTime: 0
+  - StartTime: 246453
+    Lane: 3
+    EndTime: 0
+  - StartTime: 246453
+    Lane: 2
+    EndTime: 0
+  - StartTime: 246453
+    Lane: 1
+    EndTime: 0
+  - StartTime: 246538
+    Lane: 4
+    EndTime: 0
+  - StartTime: 246623
+    Lane: 1
+    EndTime: 0
+  - StartTime: 246708
+    Lane: 2
+    EndTime: 0
+  - StartTime: 246792
+    Lane: 4
+    EndTime: 0
+  - StartTime: 246877
+    Lane: 3
+    EndTime: 0
+  - StartTime: 246962
+    Lane: 2
+    EndTime: 0
+  - StartTime: 246962
+    Lane: 1
+    EndTime: 0
+  - StartTime: 247047
+    Lane: 4
+    EndTime: 0
+  - StartTime: 247131
+    Lane: 3
+    EndTime: 0
+  - StartTime: 247216
+    Lane: 2
+    EndTime: 0
+  - StartTime: 247301
+    Lane: 1
+    EndTime: 0
+  - StartTime: 247386
+    Lane: 2
+    EndTime: 0
+  - StartTime: 247470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 247470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 247555
+    Lane: 1
+    EndTime: 0
+  - StartTime: 247640
+    Lane: 3
+    EndTime: 0
+  - StartTime: 247725
+    Lane: 2
+    EndTime: 0
+  - StartTime: 247809
+    Lane: 1
+    EndTime: 0
+  - StartTime: 247809
+    Lane: 4
+    EndTime: 0
+  - StartTime: 247809
+    Lane: 3
+    EndTime: 0
+  - StartTime: 247894
+    Lane: 2
+    EndTime: 0
+  - StartTime: 247979
+    Lane: 3
+    EndTime: 0
+  - StartTime: 248064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 248148
+    Lane: 3
+    EndTime: 0
+  - StartTime: 248233
+    Lane: 4
+    EndTime: 0
+  - StartTime: 248318
+    Lane: 1
+    EndTime: 0
+  - StartTime: 248403
+    Lane: 3
+    EndTime: 0
+  - StartTime: 248487
+    Lane: 2
+    EndTime: 0
+  - StartTime: 248487
+    Lane: 1
+    EndTime: 0
+  - StartTime: 248572
+    Lane: 4
+    EndTime: 0
+  - StartTime: 248657
+    Lane: 3
+    EndTime: 0
+  - StartTime: 248742
+    Lane: 4
+    EndTime: 0
+  - StartTime: 248826
+    Lane: 2
+    EndTime: 0
+  - StartTime: 248826
+    Lane: 1
+    EndTime: 0
+  - StartTime: 248911
+    Lane: 3
+    EndTime: 0
+  - StartTime: 248996
+    Lane: 4
+    EndTime: 0
+  - StartTime: 249080
+    Lane: 3
+    EndTime: 0
+  - StartTime: 249165
+    Lane: 2
+    EndTime: 0
+  - StartTime: 249165
+    Lane: 1
+    EndTime: 0
+  - StartTime: 249250
+    Lane: 4
+    EndTime: 0
+  - StartTime: 249250
+    Lane: 3
+    EndTime: 0
+  - StartTime: 249335
+    Lane: 2
+    EndTime: 0
+  - StartTime: 249335
+    Lane: 1
+    EndTime: 0
+  - StartTime: 249419
+    Lane: 3
+    EndTime: 0
+  - StartTime: 249419
+    Lane: 4
+    EndTime: 0
+  - StartTime: 249504
+    Lane: 1
+    EndTime: 0
+  - StartTime: 249504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 249589
+    Lane: 3
+    EndTime: 0
+  - StartTime: 249674
+    Lane: 1
+    EndTime: 0
+  - StartTime: 249674
+    Lane: 4
+    EndTime: 0
+  - StartTime: 249758
+    Lane: 3
+    EndTime: 0
+  - StartTime: 249758
+    Lane: 2
+    EndTime: 0
+  - StartTime: 249843
+    Lane: 1
+    EndTime: 0
+  - StartTime: 249843
+    Lane: 4
+    EndTime: 0
+  - StartTime: 249928
+    Lane: 3
+    EndTime: 0
+  - StartTime: 249928
+    Lane: 2
+    EndTime: 0
+  - StartTime: 250013
+    Lane: 1
+    EndTime: 0
+  - StartTime: 250013
+    Lane: 4
+    EndTime: 0
+  - StartTime: 250097
+    Lane: 2
+    EndTime: 0
+  - StartTime: 250182
+    Lane: 3
+    EndTime: 0
+  - StartTime: 250182
+    Lane: 4
+    EndTime: 0
+  - StartTime: 250267
+    Lane: 1
+    EndTime: 0
+  - StartTime: 250267
+    Lane: 2
+    EndTime: 0
+  - StartTime: 250352
+    Lane: 3
+    EndTime: 0
+  - StartTime: 250352
+    Lane: 4
+    EndTime: 0
+  - StartTime: 250436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 250436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 250521
+    Lane: 3
+    EndTime: 0
+  - StartTime: 250521
+    Lane: 4
+    EndTime: 0
+  - StartTime: 250606
+    Lane: 1
+    EndTime: 0
+  - StartTime: 250691
+    Lane: 2
+    EndTime: 0
+  - StartTime: 250691
+    Lane: 4
+    EndTime: 0
+  - StartTime: 250775
+    Lane: 3
+    EndTime: 0
+  - StartTime: 250775
+    Lane: 1
+    EndTime: 0
+  - StartTime: 250860
+    Lane: 2
+    EndTime: 0
+  - StartTime: 250860
+    Lane: 4
+    EndTime: 0
+  - StartTime: 250945
+    Lane: 1
+    EndTime: 0
+  - StartTime: 250945
+    Lane: 3
+    EndTime: 0
+  - StartTime: 251030
+    Lane: 4
+    EndTime: 0
+  - StartTime: 251030
+    Lane: 2
+    EndTime: 0
+  - StartTime: 251114
+    Lane: 1
+    EndTime: 0
+  - StartTime: 251199
+    Lane: 3
+    EndTime: 0
+  - StartTime: 251199
+    Lane: 4
+    EndTime: 0
+  - StartTime: 251284
+    Lane: 2
+    EndTime: 0
+  - StartTime: 251369
+    Lane: 1
+    EndTime: 0
+  - StartTime: 251453
+    Lane: 4
+    EndTime: 0
+  - StartTime: 251538
+    Lane: 3
+    EndTime: 0
+  - StartTime: 251538
+    Lane: 2
+    EndTime: 0
+  - StartTime: 251623
+    Lane: 1
+    EndTime: 0
+  - StartTime: 251708
+    Lane: 4
+    EndTime: 0
+  - StartTime: 251792
+    Lane: 3
+    EndTime: 0
+  - StartTime: 251877
+    Lane: 2
+    EndTime: 0
+  - StartTime: 251877
+    Lane: 1
+    EndTime: 0
+  - StartTime: 251877
+    Lane: 4
+    EndTime: 0
+  - StartTime: 251962
+    Lane: 3
+    EndTime: 0
+  - StartTime: 252047
+    Lane: 2
+    EndTime: 0
+  - StartTime: 252131
+    Lane: 1
+    EndTime: 0
+  - StartTime: 252131
+    Lane: 3
+    EndTime: 0
+  - StartTime: 252131
+    Lane: 4
+    EndTime: 0
+  - StartTime: 252216
+    Lane: 2
+    EndTime: 0
+  - StartTime: 252301
+    Lane: 3
+    EndTime: 0
+  - StartTime: 252386
+    Lane: 1
+    EndTime: 0
+  - StartTime: 252386
+    Lane: 2
+    EndTime: 0
+  - StartTime: 252386
+    Lane: 4
+    EndTime: 0
+  - StartTime: 252470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 252555
+    Lane: 4
+    EndTime: 0
+  - StartTime: 252555
+    Lane: 1
+    EndTime: 0
+  - StartTime: 252555
+    Lane: 2
+    EndTime: 0
+  - StartTime: 252640
+    Lane: 3
+    EndTime: 0
+  - StartTime: 252725
+    Lane: 1
+    EndTime: 0
+  - StartTime: 252809
+    Lane: 3
+    EndTime: 0
+  - StartTime: 252894
+    Lane: 2
+    EndTime: 0
+  - StartTime: 252894
+    Lane: 4
+    EndTime: 0
+  - StartTime: 252979
+    Lane: 1
+    EndTime: 0
+  - StartTime: 253064
+    Lane: 3
+    EndTime: 0
+  - StartTime: 253064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 253148
+    Lane: 4
+    EndTime: 0
+  - StartTime: 253233
+    Lane: 1
+    EndTime: 0
+  - StartTime: 253233
+    Lane: 3
+    EndTime: 0
+  - StartTime: 253318
+    Lane: 2
+    EndTime: 0
+  - StartTime: 253403
+    Lane: 1
+    EndTime: 0
+  - StartTime: 253487
+    Lane: 2
+    EndTime: 0
+  - StartTime: 253572
+    Lane: 3
+    EndTime: 0
+  - StartTime: 253572
+    Lane: 4
+    EndTime: 0
+  - StartTime: 253657
+    Lane: 1
+    EndTime: 0
+  - StartTime: 253742
+    Lane: 3
+    EndTime: 0
+  - StartTime: 253742
+    Lane: 4
+    EndTime: 0
+  - StartTime: 253826
+    Lane: 1
+    EndTime: 0
+  - StartTime: 253911
+    Lane: 3
+    EndTime: 0
+  - StartTime: 253996
+    Lane: 2
+    EndTime: 0
+  - StartTime: 254080
+    Lane: 1
+    EndTime: 0
+  - StartTime: 254165
+    Lane: 4
+    EndTime: 0
+  - StartTime: 254250
+    Lane: 3
+    EndTime: 0
+  - StartTime: 254250
+    Lane: 2
+    EndTime: 0
+  - StartTime: 254335
+    Lane: 1
+    EndTime: 0
+  - StartTime: 254419
+    Lane: 2
+    EndTime: 0
+  - StartTime: 254504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 254589
+    Lane: 4
+    EndTime: 0
+  - StartTime: 254589
+    Lane: 2
+    EndTime: 0
+  - StartTime: 254589
+    Lane: 1
+    EndTime: 0
+  - StartTime: 254674
+    Lane: 3
+    EndTime: 0
+  - StartTime: 254758
+    Lane: 2
+    EndTime: 0
+  - StartTime: 254758
+    Lane: 4
+    EndTime: 0
+  - StartTime: 254843
+    Lane: 1
+    EndTime: 0
+  - StartTime: 254928
+    Lane: 2
+    EndTime: 0
+  - StartTime: 255013
+    Lane: 3
+    EndTime: 0
+  - StartTime: 255013
+    Lane: 1
+    EndTime: 0
+  - StartTime: 255097
+    Lane: 4
+    EndTime: 0
+  - StartTime: 255097
+    Lane: 2
+    EndTime: 0
+  - StartTime: 255182
+    Lane: 3
+    EndTime: 0
+  - StartTime: 255267
+    Lane: 2
+    EndTime: 0
+  - StartTime: 255267
+    Lane: 1
+    EndTime: 0
+  - StartTime: 255352
+    Lane: 3
+    EndTime: 0
+  - StartTime: 255436
+    Lane: 4
+    EndTime: 0
+  - StartTime: 255436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 255521
+    Lane: 3
+    EndTime: 0
+  - StartTime: 255521
+    Lane: 2
+    EndTime: 0
+  - StartTime: 255606
+    Lane: 1
+    EndTime: 0
+  - StartTime: 255691
+    Lane: 3
+    EndTime: 0
+  - StartTime: 255691
+    Lane: 4
+    EndTime: 0
+  - StartTime: 255775
+    Lane: 2
+    EndTime: 0
+  - StartTime: 255775
+    Lane: 1
+    EndTime: 0
+  - StartTime: 255860
+    Lane: 3
+    EndTime: 0
+  - StartTime: 255945
+    Lane: 4
+    EndTime: 0
+  - StartTime: 255945
+    Lane: 1
+    EndTime: 0
+  - StartTime: 256030
+    Lane: 3
+    EndTime: 0
+  - StartTime: 256114
+    Lane: 4
+    EndTime: 0
+  - StartTime: 256114
+    Lane: 2
+    EndTime: 0
+  - StartTime: 256199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 256284
+    Lane: 4
+    EndTime: 0
+  - StartTime: 256369
+    Lane: 1
+    EndTime: 0
+  - StartTime: 256369
+    Lane: 2
+    EndTime: 0
+  - StartTime: 256453
+    Lane: 3
+    EndTime: 0
+  - StartTime: 256453
+    Lane: 4
+    EndTime: 0
+  - StartTime: 256538
+    Lane: 1
+    EndTime: 0
+  - StartTime: 256623
+    Lane: 2
+    EndTime: 0
+  - StartTime: 256623
+    Lane: 3
+    EndTime: 0
+  - StartTime: 256708
+    Lane: 1
+    EndTime: 0
+  - StartTime: 256792
+    Lane: 3
+    EndTime: 0
+  - StartTime: 256792
+    Lane: 4
+    EndTime: 0
+  - StartTime: 256877
+    Lane: 1
+    EndTime: 0
+  - StartTime: 256877
+    Lane: 2
+    EndTime: 0
+  - StartTime: 256962
+    Lane: 4
+    EndTime: 0
+  - StartTime: 257047
+    Lane: 2
+    EndTime: 0
+  - StartTime: 257047
+    Lane: 3
+    EndTime: 0
+  - StartTime: 257131
+    Lane: 4
+    EndTime: 0
+  - StartTime: 257131
+    Lane: 1
+    EndTime: 0
+  - StartTime: 257216
+    Lane: 3
+    EndTime: 0
+  - StartTime: 257301
+    Lane: 1
+    EndTime: 257470
+  - StartTime: 257301
+    Lane: 2
+    EndTime: 0
+  - StartTime: 257386
+    Lane: 4
+    EndTime: 0
+  - StartTime: 257470
+    Lane: 2
+    EndTime: 257640
+  - StartTime: 257470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 257555
+    Lane: 1
+    EndTime: 0
+  - StartTime: 257640
+    Lane: 3
+    EndTime: 257809
+  - StartTime: 257640
+    Lane: 4
+    EndTime: 0
+  - StartTime: 257725
+    Lane: 2
+    EndTime: 0
+  - StartTime: 257809
+    Lane: 1
+    EndTime: 0
+  - StartTime: 257809
+    Lane: 4
+    EndTime: 257979
+  - StartTime: 257894
+    Lane: 2
+    EndTime: 0
+  - StartTime: 257979
+    Lane: 3
+    EndTime: 258148
+  - StartTime: 257979
+    Lane: 1
+    EndTime: 0
+  - StartTime: 258064
+    Lane: 4
+    EndTime: 0
+  - StartTime: 258148
+    Lane: 2
+    EndTime: 258318
+  - StartTime: 258148
+    Lane: 1
+    EndTime: 0
+  - StartTime: 258233
+    Lane: 3
+    EndTime: 0
+  - StartTime: 258318
+    Lane: 4
+    EndTime: 0
+  - StartTime: 258318
+    Lane: 1
+    EndTime: 258487
+  - StartTime: 258403
+    Lane: 2
+    EndTime: 0
+  - StartTime: 258487
+    Lane: 3
+    EndTime: 0
+  - StartTime: 258487
+    Lane: 4
+    EndTime: 258657
+  - StartTime: 258572
+    Lane: 1
+    EndTime: 0
+  - StartTime: 258657
+    Lane: 2
+    EndTime: 258742
+  - StartTime: 258742
+    Lane: 3
+    EndTime: 258826
+  - StartTime: 258826
+    Lane: 1
+    EndTime: 258911
+  - StartTime: 258826
+    Lane: 4
+    EndTime: 0
+  - StartTime: 258911
+    Lane: 3
+    EndTime: 258996
+  - StartTime: 258996
+    Lane: 2
+    EndTime: 259080
+  - StartTime: 259080
+    Lane: 4
+    EndTime: 259165
+  - StartTime: 259165
+    Lane: 2
+    EndTime: 0
+  - StartTime: 259165
+    Lane: 1
+    EndTime: 259250
+  - StartTime: 259250
+    Lane: 3
+    EndTime: 259335
+  - StartTime: 259335
+    Lane: 1
+    EndTime: 259419
+  - StartTime: 259419
+    Lane: 4
+    EndTime: 259504
+  - StartTime: 259504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 259504
+    Lane: 2
+    EndTime: 259589
+  - StartTime: 259589
+    Lane: 4
+    EndTime: 259674
+  - StartTime: 259674
+    Lane: 3
+    EndTime: 259843
+  - StartTime: 259674
+    Lane: 1
+    EndTime: 259843
+  - StartTime: 260013
+    Lane: 1
+    EndTime: 0
+  - StartTime: 260013
+    Lane: 3
+    EndTime: 0
+  - StartTime: 260013
+    Lane: 4
+    EndTime: 0
+  - StartTime: 260097
+    Lane: 2
+    EndTime: 0
+  - StartTime: 260182
+    Lane: 4
+    EndTime: 0
+  - StartTime: 260182
+    Lane: 3
+    EndTime: 0
+  - StartTime: 260267
+    Lane: 2
+    EndTime: 0
+  - StartTime: 260352
+    Lane: 1
+    EndTime: 0
+  - StartTime: 260436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 260521
+    Lane: 4
+    EndTime: 0
+  - StartTime: 260521
+    Lane: 3
+    EndTime: 0
+  - StartTime: 260578
+    Lane: 2
+    EndTime: 0
+  - StartTime: 260634
+    Lane: 1
+    EndTime: 0
+  - StartTime: 260691
+    Lane: 3
+    EndTime: 0
+  - StartTime: 260747
+    Lane: 4
+    EndTime: 0
+  - StartTime: 260860
+    Lane: 3
+    EndTime: 0
+  - StartTime: 260860
+    Lane: 2
+    EndTime: 0
+  - StartTime: 260917
+    Lane: 1
+    EndTime: 0
+  - StartTime: 260945
+    Lane: 4
+    EndTime: 0
+  - StartTime: 261030
+    Lane: 3
+    EndTime: 0
+  - StartTime: 261086
+    Lane: 2
+    EndTime: 0
+  - StartTime: 261143
+    Lane: 1
+    EndTime: 0
+  - StartTime: 261199
+    Lane: 4
+    EndTime: 0
+  - StartTime: 261199
+    Lane: 3
+    EndTime: 0
+  - StartTime: 261284
+    Lane: 2
+    EndTime: 0
+  - StartTime: 261369
+    Lane: 4
+    EndTime: 0
+  - StartTime: 261453
+    Lane: 3
+    EndTime: 0
+  - StartTime: 261496
+    Lane: 2
+    EndTime: 0
+  - StartTime: 261538
+    Lane: 1
+    EndTime: 0
+  - StartTime: 261538
+    Lane: 4
+    EndTime: 0
+  - StartTime: 261595
+    Lane: 3
+    EndTime: 0
+  - StartTime: 261651
+    Lane: 2
+    EndTime: 0
+  - StartTime: 261708
+    Lane: 4
+    EndTime: 0
+  - StartTime: 261792
+    Lane: 3
+    EndTime: 0
+  - StartTime: 261849
+    Lane: 1
+    EndTime: 0
+  - StartTime: 261877
+    Lane: 2
+    EndTime: 0
+  - StartTime: 261877
+    Lane: 4
+    EndTime: 0
+  - StartTime: 261962
+    Lane: 3
+    EndTime: 0
+  - StartTime: 262047
+    Lane: 1
+    EndTime: 0
+  - StartTime: 262131
+    Lane: 4
+    EndTime: 0
+  - StartTime: 262216
+    Lane: 3
+    EndTime: 0
+  - StartTime: 262216
+    Lane: 1
+    EndTime: 0
+  - StartTime: 262301
+    Lane: 2
+    EndTime: 0
+  - StartTime: 262386
+    Lane: 3
+    EndTime: 0
+  - StartTime: 262386
+    Lane: 4
+    EndTime: 0
+  - StartTime: 262470
+    Lane: 1
+    EndTime: 0
+  - StartTime: 262555
+    Lane: 2
+    EndTime: 262725
+  - StartTime: 262555
+    Lane: 3
+    EndTime: 0
+  - StartTime: 262725
+    Lane: 4
+    EndTime: 0
+  - StartTime: 262725
+    Lane: 1
+    EndTime: 0
+  - StartTime: 262781
+    Lane: 3
+    EndTime: 0
+  - StartTime: 262894
+    Lane: 2
+    EndTime: 0
+  - StartTime: 262894
+    Lane: 1
+    EndTime: 0
+  - StartTime: 262979
+    Lane: 4
+    EndTime: 0
+  - StartTime: 263064
+    Lane: 3
+    EndTime: 0
+  - StartTime: 263064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 263148
+    Lane: 1
+    EndTime: 0
+  - StartTime: 263233
+    Lane: 3
+    EndTime: 0
+  - StartTime: 263233
+    Lane: 4
+    EndTime: 0
+  - StartTime: 263318
+    Lane: 2
+    EndTime: 0
+  - StartTime: 263403
+    Lane: 1
+    EndTime: 0
+  - StartTime: 263403
+    Lane: 4
+    EndTime: 0
+  - StartTime: 263487
+    Lane: 3
+    EndTime: 0
+  - StartTime: 263572
+    Lane: 2
+    EndTime: 0
+  - StartTime: 263572
+    Lane: 4
+    EndTime: 0
+  - StartTime: 263657
+    Lane: 1
+    EndTime: 0
+  - StartTime: 263742
+    Lane: 3
+    EndTime: 0
+  - StartTime: 263742
+    Lane: 4
+    EndTime: 0
+  - StartTime: 263826
+    Lane: 2
+    EndTime: 0
+  - StartTime: 263911
+    Lane: 1
+    EndTime: 0
+  - StartTime: 263911
+    Lane: 3
+    EndTime: 0
+  - StartTime: 263996
+    Lane: 4
+    EndTime: 0
+  - StartTime: 264080
+    Lane: 2
+    EndTime: 0
+  - StartTime: 264080
+    Lane: 1
+    EndTime: 0
+  - StartTime: 264080
+    Lane: 3
+    EndTime: 0
+  - StartTime: 264165
+    Lane: 4
+    EndTime: 0
+  - StartTime: 264250
+    Lane: 1
+    EndTime: 0
+  - StartTime: 264250
+    Lane: 2
+    EndTime: 0
+  - StartTime: 264335
+    Lane: 3
+    EndTime: 0
+  - StartTime: 264335
+    Lane: 4
+    EndTime: 0
+  - StartTime: 264419
+    Lane: 1
+    EndTime: 0
+  - StartTime: 264419
+    Lane: 2
+    EndTime: 0
+  - StartTime: 264504
+    Lane: 4
+    EndTime: 0
+  - StartTime: 264589
+    Lane: 3
+    EndTime: 0
+  - StartTime: 264589
+    Lane: 1
+    EndTime: 0
+  - StartTime: 264674
+    Lane: 4
+    EndTime: 0
+  - StartTime: 264758
+    Lane: 2
+    EndTime: 0
+  - StartTime: 264758
+    Lane: 1
+    EndTime: 264843
+  - StartTime: 264843
+    Lane: 4
+    EndTime: 0
+  - StartTime: 264843
+    Lane: 3
+    EndTime: 264928
+  - StartTime: 264928
+    Lane: 1
+    EndTime: 0
+  - StartTime: 264928
+    Lane: 2
+    EndTime: 265013
+  - StartTime: 265013
+    Lane: 3
+    EndTime: 0
+  - StartTime: 265013
+    Lane: 4
+    EndTime: 265097
+  - StartTime: 265097
+    Lane: 2
+    EndTime: 0
+  - StartTime: 265097
+    Lane: 1
+    EndTime: 265182
+  - StartTime: 265182
+    Lane: 4
+    EndTime: 0
+  - StartTime: 265182
+    Lane: 3
+    EndTime: 265267
+  - StartTime: 265267
+    Lane: 1
+    EndTime: 0
+  - StartTime: 265267
+    Lane: 2
+    EndTime: 265352
+  - StartTime: 265352
+    Lane: 3
+    EndTime: 0
+  - StartTime: 265352
+    Lane: 4
+    EndTime: 265436
+  - StartTime: 265436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 265436
+    Lane: 1
+    EndTime: 265775
+  - StartTime: 265521
+    Lane: 3
+    EndTime: 0
+  - StartTime: 265606
+    Lane: 4
+    EndTime: 0
+  - StartTime: 265606
+    Lane: 2
+    EndTime: 0
+  - StartTime: 265691
+    Lane: 4
+    EndTime: 0
+  - StartTime: 265775
+    Lane: 3
+    EndTime: 0
+  - StartTime: 265860
+    Lane: 4
+    EndTime: 0
+  - StartTime: 265945
+    Lane: 3
+    EndTime: 0
+  - StartTime: 265945
+    Lane: 2
+    EndTime: 0
+  - StartTime: 266030
+    Lane: 2
+    EndTime: 0
+  - StartTime: 266114
+    Lane: 1
+    EndTime: 0
+  - StartTime: 266199
+    Lane: 4
+    EndTime: 0
+  - StartTime: 266284
+    Lane: 3
+    EndTime: 0
+  - StartTime: 266284
+    Lane: 1
+    EndTime: 0
+  - StartTime: 266369
+    Lane: 3
+    EndTime: 0
+  - StartTime: 266453
+    Lane: 2
+    EndTime: 0
+  - StartTime: 266538
+    Lane: 4
+    EndTime: 0
+  - StartTime: 266623
+    Lane: 1
+    EndTime: 0
+  - StartTime: 266623
+    Lane: 3
+    EndTime: 0
+  - StartTime: 266708
+    Lane: 1
+    EndTime: 0
+  - StartTime: 266792
+    Lane: 4
+    EndTime: 267047
+  - StartTime: 266792
+    Lane: 2
+    EndTime: 0
+  - StartTime: 266877
+    Lane: 3
+    EndTime: 267131
+  - StartTime: 266962
+    Lane: 1
+    EndTime: 267301
+  - StartTime: 267047
+    Lane: 2
+    EndTime: 267216
+  - StartTime: 267131
+    Lane: 4
+    EndTime: 267386
+  - StartTime: 267216
+    Lane: 3
+    EndTime: 267386
+  - StartTime: 267301
+    Lane: 2
+    EndTime: 267470
+  - StartTime: 267386
+    Lane: 1
+    EndTime: 267470
+  - StartTime: 267470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 267470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 267513
+    Lane: 2
+    EndTime: 0
+  - StartTime: 267555
+    Lane: 1
+    EndTime: 0
+  - StartTime: 267597
+    Lane: 4
+    EndTime: 0
+  - StartTime: 267640
+    Lane: 2
+    EndTime: 0
+  - StartTime: 267640
+    Lane: 3
+    EndTime: 0
+  - StartTime: 267682
+    Lane: 1
+    EndTime: 0
+  - StartTime: 267725
+    Lane: 4
+    EndTime: 0
+  - StartTime: 267767
+    Lane: 3
+    EndTime: 0
+  - StartTime: 267809
+    Lane: 2
+    EndTime: 0
+  - StartTime: 267809
+    Lane: 1
+    EndTime: 0
+  - StartTime: 267852
+    Lane: 4
+    EndTime: 0
+  - StartTime: 267894
+    Lane: 3
+    EndTime: 0
+  - StartTime: 267936
+    Lane: 2
+    EndTime: 0
+  - StartTime: 267979
+    Lane: 1
+    EndTime: 0
+  - StartTime: 267979
+    Lane: 4
+    EndTime: 0
+  - StartTime: 268021
+    Lane: 3
+    EndTime: 0
+  - StartTime: 268064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 268106
+    Lane: 4
+    EndTime: 0
+  - StartTime: 268148
+    Lane: 1
+    EndTime: 268657
+  - StartTime: 268148
+    Lane: 3
+    EndTime: 0
+  - StartTime: 268318
+    Lane: 4
+    EndTime: 0
+  - StartTime: 268318
+    Lane: 2
+    EndTime: 0
+  - StartTime: 268572
+    Lane: 4
+    EndTime: 0
+  - StartTime: 268657
+    Lane: 2
+    EndTime: 0
+  - StartTime: 268657
+    Lane: 3
+    EndTime: 0
+  - StartTime: 268742
+    Lane: 1
+    EndTime: 0
+  - StartTime: 268826
+    Lane: 4
+    EndTime: 0
+  - StartTime: 268826
+    Lane: 3
+    EndTime: 268996
+  - StartTime: 268996
+    Lane: 2
+    EndTime: 0
+  - StartTime: 269080
+    Lane: 4
+    EndTime: 0
+  - StartTime: 269080
+    Lane: 1
+    EndTime: 269250
+  - StartTime: 269250
+    Lane: 3
+    EndTime: 0
+  - StartTime: 269335
+    Lane: 2
+    EndTime: 0
+  - StartTime: 269335
+    Lane: 4
+    EndTime: 269504
+  - StartTime: 269504
+    Lane: 1
+    EndTime: 270182
+  - StartTime: 269504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 269674
+    Lane: 4
+    EndTime: 0
+  - StartTime: 269674
+    Lane: 3
+    EndTime: 0
+  - StartTime: 269758
+    Lane: 2
+    EndTime: 0
+  - StartTime: 269928
+    Lane: 2
+    EndTime: 0
+  - StartTime: 270013
+    Lane: 3
+    EndTime: 0
+  - StartTime: 270013
+    Lane: 4
+    EndTime: 0
+  - StartTime: 270182
+    Lane: 3
+    EndTime: 0
+  - StartTime: 270182
+    Lane: 4
+    EndTime: 0
+  - StartTime: 270267
+    Lane: 2
+    EndTime: 0
+  - StartTime: 270352
+    Lane: 4
+    EndTime: 0
+  - StartTime: 270352
+    Lane: 3
+    EndTime: 0
+  - StartTime: 270436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 270436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 270521
+    Lane: 4
+    EndTime: 0
+  - StartTime: 270521
+    Lane: 3
+    EndTime: 0
+  - StartTime: 270606
+    Lane: 2
+    EndTime: 0
+  - StartTime: 270691
+    Lane: 4
+    EndTime: 0
+  - StartTime: 270691
+    Lane: 1
+    EndTime: 0
+  - StartTime: 270775
+    Lane: 2
+    EndTime: 0
+  - StartTime: 270860
+    Lane: 4
+    EndTime: 0
+  - StartTime: 270860
+    Lane: 3
+    EndTime: 0
+  - StartTime: 270860
+    Lane: 1
+    EndTime: 0
+  - StartTime: 270917
+    Lane: 2
+    EndTime: 0
+  - StartTime: 270973
+    Lane: 3
+    EndTime: 0
+  - StartTime: 271030
+    Lane: 1
+    EndTime: 0
+  - StartTime: 271030
+    Lane: 4
+    EndTime: 0
+  - StartTime: 271086
+    Lane: 2
+    EndTime: 0
+  - StartTime: 271143
+    Lane: 3
+    EndTime: 0
+  - StartTime: 271199
+    Lane: 4
+    EndTime: 0
+  - StartTime: 271199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 271256
+    Lane: 2
+    EndTime: 0
+  - StartTime: 271312
+    Lane: 3
+    EndTime: 0
+  - StartTime: 271369
+    Lane: 4
+    EndTime: 0
+  - StartTime: 271369
+    Lane: 1
+    EndTime: 0
+  - StartTime: 271453
+    Lane: 3
+    EndTime: 0
+  - StartTime: 271538
+    Lane: 2
+    EndTime: 0
+  - StartTime: 271538
+    Lane: 1
+    EndTime: 0
+  - StartTime: 271623
+    Lane: 4
+    EndTime: 0
+  - StartTime: 271708
+    Lane: 2
+    EndTime: 0
+  - StartTime: 271708
+    Lane: 3
+    EndTime: 0
+  - StartTime: 271764
+    Lane: 1
+    EndTime: 0
+  - StartTime: 271792
+    Lane: 4
+    EndTime: 0
+  - StartTime: 271821
+    Lane: 2
+    EndTime: 0
+  - StartTime: 271877
+    Lane: 3
+    EndTime: 0
+  - StartTime: 271934
+    Lane: 4
+    EndTime: 0
+  - StartTime: 271962
+    Lane: 1
+    EndTime: 0
+  - StartTime: 271990
+    Lane: 2
+    EndTime: 0
+  - StartTime: 272047
+    Lane: 4
+    EndTime: 0
+  - StartTime: 272047
+    Lane: 3
+    EndTime: 0
+  - StartTime: 272103
+    Lane: 1
+    EndTime: 0
+  - StartTime: 272160
+    Lane: 2
+    EndTime: 0
+  - StartTime: 272216
+    Lane: 3
+    EndTime: 0
+  - StartTime: 272216
+    Lane: 4
+    EndTime: 0
+  - StartTime: 272329
+    Lane: 1
+    EndTime: 0
+  - StartTime: 272386
+    Lane: 3
+    EndTime: 0
+  - StartTime: 272386
+    Lane: 4
+    EndTime: 0
+  - StartTime: 272470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 272555
+    Lane: 4
+    EndTime: 0
+  - StartTime: 272612
+    Lane: 3
+    EndTime: 0
+  - StartTime: 272640
+    Lane: 2
+    EndTime: 0
+  - StartTime: 272668
+    Lane: 1
+    EndTime: 0
+  - StartTime: 272725
+    Lane: 3
+    EndTime: 0
+  - StartTime: 272725
+    Lane: 4
+    EndTime: 0
+  - StartTime: 272809
+    Lane: 1
+    EndTime: 0
+  - StartTime: 272894
+    Lane: 3
+    EndTime: 0
+  - StartTime: 272894
+    Lane: 2
+    EndTime: 0
+  - StartTime: 272951
+    Lane: 4
+    EndTime: 0
+  - StartTime: 273007
+    Lane: 3
+    EndTime: 0
+  - StartTime: 273064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 273064
+    Lane: 1
+    EndTime: 0
+  - StartTime: 273120
+    Lane: 4
+    EndTime: 0
+  - StartTime: 273148
+    Lane: 3
+    EndTime: 0
+  - StartTime: 273177
+    Lane: 2
+    EndTime: 0
+  - StartTime: 273233
+    Lane: 1
+    EndTime: 0
+  - StartTime: 273290
+    Lane: 4
+    EndTime: 0
+  - StartTime: 273318
+    Lane: 3
+    EndTime: 0
+  - StartTime: 273346
+    Lane: 2
+    EndTime: 0
+  - StartTime: 273403
+    Lane: 1
+    EndTime: 0
+  - StartTime: 273403
+    Lane: 4
+    EndTime: 0
+  - StartTime: 273445
+    Lane: 3
+    EndTime: 0
+  - StartTime: 273487
+    Lane: 2
+    EndTime: 0
+  - StartTime: 273572
+    Lane: 4
+    EndTime: 0
+  - StartTime: 273572
+    Lane: 1
+    EndTime: 0
+  - StartTime: 273657
+    Lane: 3
+    EndTime: 0
+  - StartTime: 273742
+    Lane: 1
+    EndTime: 0
+  - StartTime: 273826
+    Lane: 3
+    EndTime: 0
+  - StartTime: 273911
+    Lane: 2
+    EndTime: 0
+  - StartTime: 273911
+    Lane: 1
+    EndTime: 0
+  - StartTime: 273911
+    Lane: 4
+    EndTime: 0
+  - StartTime: 273996
+    Lane: 3
+    EndTime: 0
+  - StartTime: 274080
+    Lane: 2
+    EndTime: 0
+  - StartTime: 274080
+    Lane: 1
+    EndTime: 0
+  - StartTime: 274080
+    Lane: 4
+    EndTime: 0
+  - StartTime: 274165
+    Lane: 3
+    EndTime: 0
+  - StartTime: 274250
+    Lane: 4
+    EndTime: 0
+  - StartTime: 274250
+    Lane: 1
+    EndTime: 0
+  - StartTime: 274306
+    Lane: 2
+    EndTime: 0
+  - StartTime: 274335
+    Lane: 3
+    EndTime: 0
+  - StartTime: 274363
+    Lane: 4
+    EndTime: 0
+  - StartTime: 274419
+    Lane: 2
+    EndTime: 0
+  - StartTime: 274419
+    Lane: 1
+    EndTime: 0
+  - StartTime: 274504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 274589
+    Lane: 1
+    EndTime: 0
+  - StartTime: 274589
+    Lane: 4
+    EndTime: 0
+  - StartTime: 274674
+    Lane: 3
+    EndTime: 0
+  - StartTime: 274674
+    Lane: 2
+    EndTime: 0
+  - StartTime: 274758
+    Lane: 1
+    EndTime: 0
+  - StartTime: 274758
+    Lane: 4
+    EndTime: 0
+  - StartTime: 274843
+    Lane: 3
+    EndTime: 0
+  - StartTime: 274928
+    Lane: 4
+    EndTime: 0
+  - StartTime: 274928
+    Lane: 1
+    EndTime: 0
+  - StartTime: 274928
+    Lane: 2
+    EndTime: 0
+  - StartTime: 275267
+    Lane: 1
+    EndTime: 0
+  - StartTime: 275267
+    Lane: 4
+    EndTime: 0
+  - StartTime: 275267
+    Lane: 3
+    EndTime: 0
+  - StartTime: 275606
+    Lane: 2
+    EndTime: 0
+  - StartTime: 275606
+    Lane: 1
+    EndTime: 0
+  - StartTime: 275606
+    Lane: 4
+    EndTime: 0
+  - StartTime: 275945
+    Lane: 2
+    EndTime: 0
+  - StartTime: 275945
+    Lane: 3
+    EndTime: 0
+  - StartTime: 275945
+    Lane: 4
+    EndTime: 0
+  - StartTime: 276284
+    Lane: 1
+    EndTime: 0
+  - StartTime: 276284
+    Lane: 2
+    EndTime: 0
+  - StartTime: 276284
+    Lane: 4
+    EndTime: 0
+  - StartTime: 276369
+    Lane: 3
+    EndTime: 0
+  - StartTime: 276453
+    Lane: 1
+    EndTime: 0
+  - StartTime: 276538
+    Lane: 3
+    EndTime: 0
+  - StartTime: 276623
+    Lane: 1
+    EndTime: 0
+  - StartTime: 276623
+    Lane: 2
+    EndTime: 0
+  - StartTime: 276623
+    Lane: 4
+    EndTime: 0
+  - StartTime: 276708
+    Lane: 3
+    EndTime: 0
+  - StartTime: 276792
+    Lane: 1
+    EndTime: 0
+  - StartTime: 276877
+    Lane: 3
+    EndTime: 0
+  - StartTime: 276962
+    Lane: 1
+    EndTime: 0
+  - StartTime: 276962
+    Lane: 2
+    EndTime: 0
+  - StartTime: 276962
+    Lane: 4
+    EndTime: 0
+  - StartTime: 277047
+    Lane: 3
+    EndTime: 0
+  - StartTime: 277131
+    Lane: 1
+    EndTime: 0
+  - StartTime: 277216
+    Lane: 2
+    EndTime: 0
+  - StartTime: 277301
+    Lane: 1
+    EndTime: 0
+  - StartTime: 277301
+    Lane: 3
+    EndTime: 0
+  - StartTime: 277301
+    Lane: 4
+    EndTime: 0
+  - StartTime: 277386
+    Lane: 2
+    EndTime: 0
+  - StartTime: 277470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 277555
+    Lane: 3
+    EndTime: 0
+  - StartTime: 277640
+    Lane: 1
+    EndTime: 0
+  - StartTime: 277640
+    Lane: 2
+    EndTime: 0
+  - StartTime: 277640
+    Lane: 3
+    EndTime: 0
+  - StartTime: 277640
+    Lane: 4
+    EndTime: 0
+  - StartTime: 278996
+    Lane: 2
+    EndTime: 0
+  - StartTime: 278996
+    Lane: 4
+    EndTime: 0
+  - StartTime: 278996
+    Lane: 1
+    EndTime: 0
+  - StartTime: 279080
+    Lane: 3
+    EndTime: 0
+  - StartTime: 279165
+    Lane: 1
+    EndTime: 0
+  - StartTime: 279165
+    Lane: 2
+    EndTime: 0
+  - StartTime: 279165
+    Lane: 4
+    EndTime: 0
+  - StartTime: 279250
+    Lane: 3
+    EndTime: 0
+  - StartTime: 279335
+    Lane: 1
+    EndTime: 0
+  - StartTime: 279419
+    Lane: 2
+    EndTime: 0
+  - StartTime: 279504
+    Lane: 1
+    EndTime: 0
+  - StartTime: 279504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 279504
+    Lane: 4
+    EndTime: 0
+  - StartTime: 279589
+    Lane: 2
+    EndTime: 0
+  - StartTime: 279674
+    Lane: 3
+    EndTime: 0
+  - StartTime: 279758
+    Lane: 4
+    EndTime: 0
+  - StartTime: 279843
+    Lane: 1
+    EndTime: 0
+  - StartTime: 279843
+    Lane: 2
+    EndTime: 0
+  - StartTime: 279843
+    Lane: 3
+    EndTime: 0
+  - StartTime: 279928
+    Lane: 4
+    EndTime: 0
+  - StartTime: 280013
+    Lane: 2
+    EndTime: 0
+  - StartTime: 280097
+    Lane: 3
+    EndTime: 0
+  - StartTime: 280182
+    Lane: 1
+    EndTime: 0
+  - StartTime: 280182
+    Lane: 4
+    EndTime: 0
+  - StartTime: 280182
+    Lane: 2
+    EndTime: 0
+  - StartTime: 280267
+    Lane: 3
+    EndTime: 0
+  - StartTime: 280352
+    Lane: 1
+    EndTime: 0
+  - StartTime: 280436
+    Lane: 3
+    EndTime: 0
+  - StartTime: 280521
+    Lane: 2
+    EndTime: 0
+  - StartTime: 280521
+    Lane: 1
+    EndTime: 0
+  - StartTime: 280521
+    Lane: 4
+    EndTime: 0
+  - StartTime: 280606
+    Lane: 3
+    EndTime: 0
+  - StartTime: 280691
+    Lane: 2
+    EndTime: 0
+  - StartTime: 280775
+    Lane: 4
+    EndTime: 0
+  - StartTime: 280860
+    Lane: 2
+    EndTime: 0
+  - StartTime: 280860
+    Lane: 3
+    EndTime: 0
+  - StartTime: 280860
+    Lane: 1
+    EndTime: 0
+  - StartTime: 280945
+    Lane: 4
+    EndTime: 0
+  - StartTime: 281030
+    Lane: 3
+    EndTime: 0
+  - StartTime: 281114
+    Lane: 1
+    EndTime: 0
+  - StartTime: 281199
+    Lane: 2
+    EndTime: 0
+  - StartTime: 281199
+    Lane: 3
+    EndTime: 0
+  - StartTime: 281199
+    Lane: 4
+    EndTime: 0
+  - StartTime: 281284
+    Lane: 1
+    EndTime: 0
+  - StartTime: 281369
+    Lane: 2
+    EndTime: 0
+  - StartTime: 281453
+    Lane: 3
+    EndTime: 0
+  - StartTime: 281538
+    Lane: 1
+    EndTime: 0
+  - StartTime: 281538
+    Lane: 2
+    EndTime: 0
+  - StartTime: 281538
+    Lane: 4
+    EndTime: 0
+  - StartTime: 281623
+    Lane: 3
+    EndTime: 0
+  - StartTime: 281708
+    Lane: 1
+    EndTime: 281877
+  - StartTime: 281708
+    Lane: 2
+    EndTime: 281877
+  - StartTime: 281877
+    Lane: 3
+    EndTime: 282047
+  - StartTime: 281877
+    Lane: 4
+    EndTime: 282047
+  - StartTime: 282047
+    Lane: 1
+    EndTime: 0
+  - StartTime: 282047
+    Lane: 2
+    EndTime: 0
+  - StartTime: 282131
+    Lane: 3
+    EndTime: 0
+  - StartTime: 282131
+    Lane: 4
+    EndTime: 0
+  - StartTime: 282216
+    Lane: 2
+    EndTime: 282386
+  - StartTime: 282216
+    Lane: 1
+    EndTime: 282386
+  - StartTime: 282386
+    Lane: 3
+    EndTime: 282555
+  - StartTime: 282386
+    Lane: 4
+    EndTime: 282555
+  - StartTime: 282555
+    Lane: 1
+    EndTime: 0
+  - StartTime: 282555
+    Lane: 2
+    EndTime: 0
+  - StartTime: 282640
+    Lane: 3
+    EndTime: 0
+  - StartTime: 282640
+    Lane: 4
+    EndTime: 0
+  - StartTime: 282725
+    Lane: 1
+    EndTime: 282894
+  - StartTime: 282725
+    Lane: 2
+    EndTime: 282894
+  - StartTime: 282894
+    Lane: 3
+    EndTime: 0
+  - StartTime: 282894
+    Lane: 4
+    EndTime: 0
+  - StartTime: 282979
+    Lane: 2
+    EndTime: 0
+  - StartTime: 282979
+    Lane: 1
+    EndTime: 0
+  - StartTime: 283064
+    Lane: 3
+    EndTime: 0
+  - StartTime: 283064
+    Lane: 4
+    EndTime: 0
+  - StartTime: 283148
+    Lane: 2
+    EndTime: 0
+  - StartTime: 283233
+    Lane: 1
+    EndTime: 0
+  - StartTime: 283233
+    Lane: 4
+    EndTime: 0
+  - StartTime: 283233
+    Lane: 3
+    EndTime: 0
+  - StartTime: 283318
+    Lane: 2
+    EndTime: 0
+  - StartTime: 283403
+    Lane: 4
+    EndTime: 0
+  - StartTime: 283403
+    Lane: 1
+    EndTime: 0
+  - StartTime: 283487
+    Lane: 3
+    EndTime: 0
+  - StartTime: 283572
+    Lane: 1
+    EndTime: 0
+  - StartTime: 283572
+    Lane: 4
+    EndTime: 0
+  - StartTime: 283572
+    Lane: 2
+    EndTime: 0
+  - StartTime: 283657
+    Lane: 3
+    EndTime: 0
+  - StartTime: 283742
+    Lane: 2
+    EndTime: 0
+  - StartTime: 283742
+    Lane: 1
+    EndTime: 0
+  - StartTime: 283826
+    Lane: 3
+    EndTime: 0
+  - StartTime: 283911
+    Lane: 4
+    EndTime: 0
+  - StartTime: 283911
+    Lane: 1
+    EndTime: 0
+  - StartTime: 283911
+    Lane: 2
+    EndTime: 0
+  - StartTime: 283996
+    Lane: 3
+    EndTime: 0
+  - StartTime: 284080
+    Lane: 1
+    EndTime: 0
+  - StartTime: 284080
+    Lane: 4
+    EndTime: 0
+  - StartTime: 284165
+    Lane: 2
+    EndTime: 0
+  - StartTime: 284250
+    Lane: 1
+    EndTime: 0
+  - StartTime: 284250
+    Lane: 4
+    EndTime: 0
+  - StartTime: 284250
+    Lane: 3
+    EndTime: 0
+  - StartTime: 284335
+    Lane: 2
+    EndTime: 0
+  - StartTime: 284419
+    Lane: 3
+    EndTime: 0
+  - StartTime: 284419
+    Lane: 4
+    EndTime: 0
+  - StartTime: 284504
+    Lane: 1
+    EndTime: 0
+  - StartTime: 284589
+    Lane: 3
+    EndTime: 0
+  - StartTime: 284589
+    Lane: 2
+    EndTime: 0
+  - StartTime: 284589
+    Lane: 4
+    EndTime: 0
+  - StartTime: 284674
+    Lane: 1
+    EndTime: 0
+  - StartTime: 284758
+    Lane: 3
+    EndTime: 0
+  - StartTime: 284758
+    Lane: 2
+    EndTime: 0
+  - StartTime: 284843
+    Lane: 4
+    EndTime: 0
+  - StartTime: 284928
+    Lane: 3
+    EndTime: 0
+  - StartTime: 284928
+    Lane: 2
+    EndTime: 0
+  - StartTime: 284928
+    Lane: 1
+    EndTime: 0
+  - StartTime: 285013
+    Lane: 4
+    EndTime: 0
+  - StartTime: 285097
+    Lane: 1
+    EndTime: 0
+  - StartTime: 285097
+    Lane: 2
+    EndTime: 0
+  - StartTime: 285182
+    Lane: 4
+    EndTime: 0
+  - StartTime: 285267
+    Lane: 2
+    EndTime: 0
+  - StartTime: 285267
+    Lane: 3
+    EndTime: 0
+  - StartTime: 285267
+    Lane: 1
+    EndTime: 0
+  - StartTime: 285352
+    Lane: 4
+    EndTime: 0
+  - StartTime: 285436
+    Lane: 3
+    EndTime: 0
+  - StartTime: 285436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 285521
+    Lane: 1
+    EndTime: 0
+  - StartTime: 285606
+    Lane: 2
+    EndTime: 0
+  - StartTime: 285606
+    Lane: 3
+    EndTime: 0
+  - StartTime: 285606
+    Lane: 4
+    EndTime: 0
+  - StartTime: 285691
+    Lane: 1
+    EndTime: 0
+  - StartTime: 285775
+    Lane: 3
+    EndTime: 0
+  - StartTime: 285775
+    Lane: 4
+    EndTime: 286030
+  - StartTime: 285860
+    Lane: 2
+    EndTime: 0
+  - StartTime: 285945
+    Lane: 1
+    EndTime: 0
+  - StartTime: 286030
+    Lane: 2
+    EndTime: 0
+  - StartTime: 286114
+    Lane: 3
+    EndTime: 0
+  - StartTime: 286114
+    Lane: 4
+    EndTime: 286369
+  - StartTime: 286199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 286284
+    Lane: 2
+    EndTime: 0
+  - StartTime: 286369
+    Lane: 3
+    EndTime: 0
+  - StartTime: 286453
+    Lane: 1
+    EndTime: 0
+  - StartTime: 286453
+    Lane: 4
+    EndTime: 286708
+  - StartTime: 286538
+    Lane: 3
+    EndTime: 0
+  - StartTime: 286623
+    Lane: 2
+    EndTime: 0
+  - StartTime: 286708
+    Lane: 1
+    EndTime: 0
+  - StartTime: 286792
+    Lane: 2
+    EndTime: 0
+  - StartTime: 286792
+    Lane: 4
+    EndTime: 287047
+  - StartTime: 286877
+    Lane: 3
+    EndTime: 0
+  - StartTime: 286962
+    Lane: 1
+    EndTime: 0
+  - StartTime: 287047
+    Lane: 2
+    EndTime: 0
+  - StartTime: 287131
+    Lane: 3
+    EndTime: 0
+  - StartTime: 287131
+    Lane: 4
+    EndTime: 0
+  - StartTime: 287131
+    Lane: 1
+    EndTime: 0
+  - StartTime: 287301
+    Lane: 1
+    EndTime: 0
+  - StartTime: 287301
+    Lane: 2
+    EndTime: 0
+  - StartTime: 287301
+    Lane: 4
+    EndTime: 0
+  - StartTime: 287470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 287470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 287555
+    Lane: 2
+    EndTime: 0
+  - StartTime: 287640
+    Lane: 1
+    EndTime: 0
+  - StartTime: 287640
+    Lane: 3
+    EndTime: 0
+  - StartTime: 287640
+    Lane: 4
+    EndTime: 0
+  - StartTime: 287809
+    Lane: 1
+    EndTime: 0
+  - StartTime: 287809
+    Lane: 2
+    EndTime: 0
+  - StartTime: 287809
+    Lane: 4
+    EndTime: 0
+  - StartTime: 287979
+    Lane: 3
+    EndTime: 0
+  - StartTime: 287979
+    Lane: 4
+    EndTime: 0
+  - StartTime: 288064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 288064
+    Lane: 1
+    EndTime: 0
+  - StartTime: 288148
+    Lane: 3
+    EndTime: 0
+  - StartTime: 288148
+    Lane: 4
+    EndTime: 0
+  - StartTime: 288233
+    Lane: 2
+    EndTime: 0
+  - StartTime: 288233
+    Lane: 1
+    EndTime: 0
+  - StartTime: 288318
+    Lane: 3
+    EndTime: 0
+  - StartTime: 288318
+    Lane: 4
+    EndTime: 0
+  - StartTime: 288403
+    Lane: 2
+    EndTime: 0
+  - StartTime: 288487
+    Lane: 3
+    EndTime: 0
+  - StartTime: 288487
+    Lane: 4
+    EndTime: 0
+  - StartTime: 288487
+    Lane: 1
+    EndTime: 0
+  - StartTime: 288657
+    Lane: 2
+    EndTime: 0
+  - StartTime: 288657
+    Lane: 4
+    EndTime: 0
+  - StartTime: 288742
+    Lane: 3
+    EndTime: 0
+  - StartTime: 288742
+    Lane: 1
+    EndTime: 0
+  - StartTime: 288911
+    Lane: 2
+    EndTime: 0
+  - StartTime: 288911
+    Lane: 1
+    EndTime: 0
+  - StartTime: 288996
+    Lane: 4
+    EndTime: 0
+  - StartTime: 288996
+    Lane: 3
+    EndTime: 0
+  - StartTime: 289165
+    Lane: 1
+    EndTime: 0
+  - StartTime: 289165
+    Lane: 2
+    EndTime: 0
+  - StartTime: 289335
+    Lane: 2
+    EndTime: 0
+  - StartTime: 289335
+    Lane: 4
+    EndTime: 0
+  - StartTime: 289419
+    Lane: 3
+    EndTime: 0
+  - StartTime: 289504
+    Lane: 1
+    EndTime: 0
+  - StartTime: 289589
+    Lane: 2
+    EndTime: 0
+  - StartTime: 289674
+    Lane: 4
+    EndTime: 0
+  - StartTime: 289674
+    Lane: 1
+    EndTime: 0
+  - StartTime: 289674
+    Lane: 3
+    EndTime: 0
+  - StartTime: 289843
+    Lane: 4
+    EndTime: 290521
+  - StartTime: 289843
+    Lane: 2
+    EndTime: 0
+  - StartTime: 290013
+    Lane: 1
+    EndTime: 0
+  - StartTime: 290013
+    Lane: 3
+    EndTime: 0
+  - StartTime: 290182
+    Lane: 2
+    EndTime: 0
+  - StartTime: 290267
+    Lane: 1
+    EndTime: 0
+  - StartTime: 290352
+    Lane: 2
+    EndTime: 0
+  - StartTime: 290352
+    Lane: 3
+    EndTime: 0
+  - StartTime: 290521
+    Lane: 1
+    EndTime: 0
+  - StartTime: 290521
+    Lane: 2
+    EndTime: 0
+  - StartTime: 290691
+    Lane: 2
+    EndTime: 0
+  - StartTime: 290691
+    Lane: 4
+    EndTime: 0
+  - StartTime: 290775
+    Lane: 3
+    EndTime: 0
+  - StartTime: 290860
+    Lane: 2
+    EndTime: 0
+  - StartTime: 290945
+    Lane: 1
+    EndTime: 0
+  - StartTime: 291030
+    Lane: 2
+    EndTime: 0
+  - StartTime: 291030
+    Lane: 3
+    EndTime: 0
+  - StartTime: 291030
+    Lane: 4
+    EndTime: 0
+  - StartTime: 291199
+    Lane: 3
+    EndTime: 0
+  - StartTime: 291199
+    Lane: 1
+    EndTime: 291538
+  - StartTime: 291369
+    Lane: 2
+    EndTime: 0
+  - StartTime: 291369
+    Lane: 4
+    EndTime: 0
+  - StartTime: 291538
+    Lane: 2
+    EndTime: 0
+  - StartTime: 291538
+    Lane: 3
+    EndTime: 0
+  - StartTime: 291623
+    Lane: 1
+    EndTime: 0
+  - StartTime: 291708
+    Lane: 3
+    EndTime: 0
+  - StartTime: 291708
+    Lane: 4
+    EndTime: 0
+  - StartTime: 291708
+    Lane: 2
+    EndTime: 0
+  - StartTime: 291877
+    Lane: 1
+    EndTime: 0
+  - StartTime: 291877
+    Lane: 2
+    EndTime: 0
+  - StartTime: 292047
+    Lane: 2
+    EndTime: 0
+  - StartTime: 292047
+    Lane: 4
+    EndTime: 0
+  - StartTime: 292131
+    Lane: 3
+    EndTime: 0
+  - StartTime: 292216
+    Lane: 1
+    EndTime: 0
+  - StartTime: 292301
+    Lane: 3
+    EndTime: 0
+  - StartTime: 292386
+    Lane: 4
+    EndTime: 0
+  - StartTime: 292386
+    Lane: 1
+    EndTime: 0
+  - StartTime: 292386
+    Lane: 2
+    EndTime: 0
+  - StartTime: 292555
+    Lane: 3
+    EndTime: 292894
+  - StartTime: 292555
+    Lane: 2
+    EndTime: 0
+  - StartTime: 292725
+    Lane: 2
+    EndTime: 292894
+  - StartTime: 292725
+    Lane: 1
+    EndTime: 0
+  - StartTime: 292894
+    Lane: 1
+    EndTime: 293064
+  - StartTime: 292894
+    Lane: 4
+    EndTime: 0
+  - StartTime: 292979
+    Lane: 3
+    EndTime: 0
+  - StartTime: 293064
+    Lane: 4
+    EndTime: 293233
+  - StartTime: 293064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 293148
+    Lane: 1
+    EndTime: 0
+  - StartTime: 293233
+    Lane: 2
+    EndTime: 293403
+  - StartTime: 293233
+    Lane: 3
+    EndTime: 0
+  - StartTime: 293318
+    Lane: 4
+    EndTime: 0
+  - StartTime: 293403
+    Lane: 1
+    EndTime: 293572
+  - StartTime: 293403
+    Lane: 3
+    EndTime: 0
+  - StartTime: 293487
+    Lane: 4
+    EndTime: 0
+  - StartTime: 293572
+    Lane: 3
+    EndTime: 293742
+  - StartTime: 293572
+    Lane: 2
+    EndTime: 0
+  - StartTime: 293657
+    Lane: 1
+    EndTime: 0
+  - StartTime: 293742
+    Lane: 2
+    EndTime: 293911
+  - StartTime: 293742
+    Lane: 4
+    EndTime: 0
+  - StartTime: 293826
+    Lane: 1
+    EndTime: 0
+  - StartTime: 293911
+    Lane: 4
+    EndTime: 294419
+  - StartTime: 293911
+    Lane: 3
+    EndTime: 0
+  - StartTime: 293996
+    Lane: 1
+    EndTime: 0
+  - StartTime: 294080
+    Lane: 2
+    EndTime: 0
+  - StartTime: 294080
+    Lane: 3
+    EndTime: 0
+  - StartTime: 294165
+    Lane: 1
+    EndTime: 0
+  - StartTime: 294250
+    Lane: 2
+    EndTime: 0
+  - StartTime: 294335
+    Lane: 3
+    EndTime: 0
+  - StartTime: 294419
+    Lane: 2
+    EndTime: 0
+  - StartTime: 294419
+    Lane: 1
+    EndTime: 0
+  - StartTime: 294504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 294589
+    Lane: 4
+    EndTime: 0
+  - StartTime: 294674
+    Lane: 2
+    EndTime: 0
+  - StartTime: 294758
+    Lane: 1
+    EndTime: 0
+  - StartTime: 294758
+    Lane: 3
+    EndTime: 0
+  - StartTime: 294843
+    Lane: 2
+    EndTime: 0
+  - StartTime: 294843
+    Lane: 4
+    EndTime: 0
+  - StartTime: 294928
+    Lane: 1
+    EndTime: 0
+  - StartTime: 295013
+    Lane: 3
+    EndTime: 0
+  - StartTime: 295013
+    Lane: 4
+    EndTime: 0
+  - StartTime: 295097
+    Lane: 2
+    EndTime: 0
+  - StartTime: 295097
+    Lane: 1
+    EndTime: 0
+  - StartTime: 295182
+    Lane: 3
+    EndTime: 0
+  - StartTime: 295267
+    Lane: 4
+    EndTime: 0
+  - StartTime: 295267
+    Lane: 2
+    EndTime: 0
+  - StartTime: 295352
+    Lane: 1
+    EndTime: 0
+  - StartTime: 295436
+    Lane: 3
+    EndTime: 0
+  - StartTime: 295436
+    Lane: 4
+    EndTime: 0
+  - StartTime: 295521
+    Lane: 2
+    EndTime: 0
+  - StartTime: 295606
+    Lane: 1
+    EndTime: 0
+  - StartTime: 295606
+    Lane: 4
+    EndTime: 0
+  - StartTime: 295691
+    Lane: 3
+    EndTime: 0
+  - StartTime: 295775
+    Lane: 2
+    EndTime: 0
+  - StartTime: 295775
+    Lane: 1
+    EndTime: 0
+  - StartTime: 295860
+    Lane: 3
+    EndTime: 0
+  - StartTime: 295945
+    Lane: 2
+    EndTime: 0
+  - StartTime: 295945
+    Lane: 4
+    EndTime: 0
+  - StartTime: 296030
+    Lane: 1
+    EndTime: 0
+  - StartTime: 296114
+    Lane: 3
+    EndTime: 0
+  - StartTime: 296114
+    Lane: 4
+    EndTime: 0
+  - StartTime: 296199
+    Lane: 2
+    EndTime: 0
+  - StartTime: 296199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 296284
+    Lane: 3
+    EndTime: 0
+  - StartTime: 296369
+    Lane: 4
+    EndTime: 0
+  - StartTime: 296369
+    Lane: 1
+    EndTime: 0
+  - StartTime: 296453
+    Lane: 2
+    EndTime: 0
+  - StartTime: 296453
+    Lane: 3
+    EndTime: 0
+  - StartTime: 296538
+    Lane: 4
+    EndTime: 0
+  - StartTime: 296623
+    Lane: 1
+    EndTime: 0
+  - StartTime: 296623
+    Lane: 2
+    EndTime: 0
+  - StartTime: 296708
+    Lane: 3
+    EndTime: 0
+  - StartTime: 296792
+    Lane: 2
+    EndTime: 0
+  - StartTime: 296792
+    Lane: 4
+    EndTime: 0
+  - StartTime: 296877
+    Lane: 1
+    EndTime: 0
+  - StartTime: 296962
+    Lane: 2
+    EndTime: 0
+  - StartTime: 296962
+    Lane: 4
+    EndTime: 0
+  - StartTime: 297047
+    Lane: 3
+    EndTime: 0
+  - StartTime: 297131
+    Lane: 4
+    EndTime: 0
+  - StartTime: 297131
+    Lane: 2
+    EndTime: 0
+  - StartTime: 297216
+    Lane: 1
+    EndTime: 0
+  - StartTime: 297301
+    Lane: 2
+    EndTime: 0
+  - StartTime: 297301
+    Lane: 4
+    EndTime: 0
+  - StartTime: 297386
+    Lane: 3
+    EndTime: 0
+  - StartTime: 297470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 297470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 297555
+    Lane: 1
+    EndTime: 0
+  - StartTime: 297640
+    Lane: 2
+    EndTime: 0
+  - StartTime: 297640
+    Lane: 4
+    EndTime: 0
+  - StartTime: 297725
+    Lane: 3
+    EndTime: 0
+  - StartTime: 297809
+    Lane: 2
+    EndTime: 0
+  - StartTime: 297809
+    Lane: 4
+    EndTime: 0
+  - StartTime: 297894
+    Lane: 1
+    EndTime: 0
+  - StartTime: 297979
+    Lane: 3
+    EndTime: 0
+  - StartTime: 297979
+    Lane: 4
+    EndTime: 0
+  - StartTime: 298064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 298064
+    Lane: 1
+    EndTime: 0
+  - StartTime: 298148
+    Lane: 3
+    EndTime: 0
+  - StartTime: 298148
+    Lane: 4
+    EndTime: 0
+  - StartTime: 298233
+    Lane: 2
+    EndTime: 0
+  - StartTime: 298233
+    Lane: 1
+    EndTime: 0
+  - StartTime: 298318
+    Lane: 3
+    EndTime: 0
+  - StartTime: 298318
+    Lane: 4
+    EndTime: 0
+  - StartTime: 298403
+    Lane: 2
+    EndTime: 0
+  - StartTime: 298487
+    Lane: 1
+    EndTime: 0
+  - StartTime: 298572
+    Lane: 2
+    EndTime: 0
+  - StartTime: 298657
+    Lane: 4
+    EndTime: 0
+  - StartTime: 298657
+    Lane: 3
+    EndTime: 0
+  - StartTime: 298742
+    Lane: 2
+    EndTime: 0
+  - StartTime: 298742
+    Lane: 1
+    EndTime: 0
+  - StartTime: 298826
+    Lane: 4
+    EndTime: 0
+  - StartTime: 298826
+    Lane: 3
+    EndTime: 0
+  - StartTime: 298911
+    Lane: 1
+    EndTime: 0
+  - StartTime: 298996
+    Lane: 3
+    EndTime: 0
+  - StartTime: 298996
+    Lane: 4
+    EndTime: 299335
+  - StartTime: 298996
+    Lane: 2
+    EndTime: 0
+  - StartTime: 299080
+    Lane: 1
+    EndTime: 0
+  - StartTime: 299165
+    Lane: 2
+    EndTime: 0
+  - StartTime: 299250
+    Lane: 3
+    EndTime: 0
+  - StartTime: 299335
+    Lane: 2
+    EndTime: 0
+  - StartTime: 299335
+    Lane: 1
+    EndTime: 0
+  - StartTime: 299419
+    Lane: 4
+    EndTime: 0
+  - StartTime: 299504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 299504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 299504
+    Lane: 1
+    EndTime: 0
+  - StartTime: 299589
+    Lane: 4
+    EndTime: 0
+  - StartTime: 299674
+    Lane: 3
+    EndTime: 0
+  - StartTime: 299674
+    Lane: 1
+    EndTime: 0
+  - StartTime: 299758
+    Lane: 2
+    EndTime: 0
+  - StartTime: 299843
+    Lane: 3
+    EndTime: 0
+  - StartTime: 299843
+    Lane: 1
+    EndTime: 0
+  - StartTime: 299843
+    Lane: 4
+    EndTime: 0
+  - StartTime: 299928
+    Lane: 2
+    EndTime: 0
+  - StartTime: 300013
+    Lane: 4
+    EndTime: 0
+  - StartTime: 300013
+    Lane: 1
+    EndTime: 0
+  - StartTime: 300097
+    Lane: 3
+    EndTime: 0
+  - StartTime: 300182
+    Lane: 2
+    EndTime: 0
+  - StartTime: 300182
+    Lane: 4
+    EndTime: 0
+  - StartTime: 300182
+    Lane: 1
+    EndTime: 0
+  - StartTime: 300267
+    Lane: 3
+    EndTime: 0
+  - StartTime: 300352
+    Lane: 2
+    EndTime: 0
+  - StartTime: 300352
+    Lane: 1
+    EndTime: 0
+  - StartTime: 300436
+    Lane: 4
+    EndTime: 0
+  - StartTime: 300521
+    Lane: 3
+    EndTime: 0
+  - StartTime: 300521
+    Lane: 1
+    EndTime: 0
+  - StartTime: 300521
+    Lane: 2
+    EndTime: 0
+  - StartTime: 300606
+    Lane: 4
+    EndTime: 0
+  - StartTime: 300691
+    Lane: 2
+    EndTime: 0
+  - StartTime: 300691
+    Lane: 1
+    EndTime: 0
+  - StartTime: 300775
+    Lane: 3
+    EndTime: 0
+  - StartTime: 300860
+    Lane: 4
+    EndTime: 0
+  - StartTime: 300860
+    Lane: 1
+    EndTime: 0
+  - StartTime: 300860
+    Lane: 2
+    EndTime: 0
+  - StartTime: 300945
+    Lane: 3
+    EndTime: 0
+  - StartTime: 301030
+    Lane: 4
+    EndTime: 0
+  - StartTime: 301030
+    Lane: 1
+    EndTime: 0
+  - StartTime: 301114
+    Lane: 2
+    EndTime: 0
+  - StartTime: 301199
+    Lane: 4
+    EndTime: 0
+  - StartTime: 301199
+    Lane: 3
+    EndTime: 0
+  - StartTime: 301199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 301284
+    Lane: 2
+    EndTime: 0
+  - StartTime: 301369
+    Lane: 3
+    EndTime: 0
+  - StartTime: 301369
+    Lane: 4
+    EndTime: 0
+  - StartTime: 301453
+    Lane: 1
+    EndTime: 0
+  - StartTime: 301538
+    Lane: 4
+    EndTime: 0
+  - StartTime: 301538
+    Lane: 3
+    EndTime: 0
+  - StartTime: 301538
+    Lane: 2
+    EndTime: 0
+  - StartTime: 301623
+    Lane: 1
+    EndTime: 0
+  - StartTime: 301708
+    Lane: 3
+    EndTime: 0
+  - StartTime: 301708
+    Lane: 2
+    EndTime: 0
+  - StartTime: 301792
+    Lane: 4
+    EndTime: 0
+  - StartTime: 301877
+    Lane: 3
+    EndTime: 0
+  - StartTime: 301877
+    Lane: 2
+    EndTime: 0
+  - StartTime: 301877
+    Lane: 1
+    EndTime: 0
+  - StartTime: 301962
+    Lane: 4
+    EndTime: 0
+  - StartTime: 302047
+    Lane: 3
+    EndTime: 0
+  - StartTime: 302047
+    Lane: 2
+    EndTime: 0
+  - StartTime: 302047
+    Lane: 1
+    EndTime: 0
+  - StartTime: 302216
+    Lane: 2
+    EndTime: 0
+  - StartTime: 302216
+    Lane: 3
+    EndTime: 0
+  - StartTime: 302216
+    Lane: 4
+    EndTime: 0
+  - StartTime: 302386
+    Lane: 3
+    EndTime: 0
+  - StartTime: 302470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 302555
+    Lane: 2
+    EndTime: 0
+  - StartTime: 302555
+    Lane: 4
+    EndTime: 0
+  - StartTime: 302555
+    Lane: 1
+    EndTime: 0
+  - StartTime: 302725
+    Lane: 1
+    EndTime: 0
+  - StartTime: 302725
+    Lane: 3
+    EndTime: 0
+  - StartTime: 302725
+    Lane: 4
+    EndTime: 0
+  - StartTime: 302894
+    Lane: 4
+    EndTime: 0
+  - StartTime: 302894
+    Lane: 2
+    EndTime: 0
+  - StartTime: 302979
+    Lane: 1
+    EndTime: 0
+  - StartTime: 302979
+    Lane: 3
+    EndTime: 0
+  - StartTime: 303064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 303064
+    Lane: 4
+    EndTime: 0
+  - StartTime: 303148
+    Lane: 1
+    EndTime: 0
+  - StartTime: 303148
+    Lane: 3
+    EndTime: 0
+  - StartTime: 303233
+    Lane: 2
+    EndTime: 0
+  - StartTime: 303233
+    Lane: 4
+    EndTime: 0
+  - StartTime: 303318
+    Lane: 1
+    EndTime: 0
+  - StartTime: 303403
+    Lane: 4
+    EndTime: 0
+  - StartTime: 303403
+    Lane: 3
+    EndTime: 0
+  - StartTime: 303487
+    Lane: 2
+    EndTime: 0
+  - StartTime: 303487
+    Lane: 1
+    EndTime: 0
+  - StartTime: 303572
+    Lane: 3
+    EndTime: 0
+  - StartTime: 303572
+    Lane: 4
+    EndTime: 0
+  - StartTime: 303657
+    Lane: 2
+    EndTime: 0
+  - StartTime: 303657
+    Lane: 1
+    EndTime: 0
+  - StartTime: 303742
+    Lane: 4
+    EndTime: 0
+  - StartTime: 303742
+    Lane: 3
+    EndTime: 0
+  - StartTime: 303826
+    Lane: 2
+    EndTime: 0
+  - StartTime: 303826
+    Lane: 1
+    EndTime: 0
+  - StartTime: 303911
+    Lane: 4
+    EndTime: 0
+  - StartTime: 303911
+    Lane: 3
+    EndTime: 0
+  - StartTime: 303996
+    Lane: 2
+    EndTime: 0
+  - StartTime: 303996
+    Lane: 1
+    EndTime: 0
+  - StartTime: 304080
+    Lane: 3
+    EndTime: 0
+  - StartTime: 304080
+    Lane: 4
+    EndTime: 0
+  - StartTime: 304165
+    Lane: 2
+    EndTime: 0
+  - StartTime: 304250
+    Lane: 1
+    EndTime: 0
+  - StartTime: 304335
+    Lane: 2
+    EndTime: 0
+  - StartTime: 304419
+    Lane: 3
+    EndTime: 0
+  - StartTime: 304419
+    Lane: 1
+    EndTime: 0
+  - StartTime: 304504
+    Lane: 4
+    EndTime: 0
+  - StartTime: 304589
+    Lane: 3
+    EndTime: 0
+  - StartTime: 304674
+    Lane: 2
+    EndTime: 0
+  - StartTime: 304758
+    Lane: 4
+    EndTime: 310040
+  - StartTime: 304758
+    Lane: 1
+    EndTime: 0
+  - StartTime: 304758
+    Lane: 3
+    EndTime: 306869
+  - StartTime: 306869
+    Lane: 2
+    EndTime: 310040
+  - StartTime: 306869
+    Lane: 1
+    EndTime: 310040
+  - StartTime: 308969
+    Lane: 3
+    EndTime: 310040
+  - StartTime: 310193
+    Lane: 1
+    EndTime: 314866
+  - StartTime: 310193
+    Lane: 4
+    EndTime: 314866
+  - StartTime: 310193
+    Lane: 3
+    EndTime: 314866
+  - StartTime: 310193
+    Lane: 2
+    EndTime: 314866
+  - StartTime: 315017
+    Lane: 4
+    EndTime: 0
+  - StartTime: 315017
+    Lane: 3
+    EndTime: 0
+  - StartTime: 315017
+    Lane: 1
+    EndTime: 0
+  - StartTime: 315017
+    Lane: 2
+    EndTime: 0
+  - StartTime: 315280
+    Lane: 4
+    EndTime: 316069
+  - StartTime: 315280
+    Lane: 3
+    EndTime: 316003
+  - StartTime: 315280
+    Lane: 1
+    EndTime: 315872
+  - StartTime: 315280
+    Lane: 2
+    EndTime: 315938

--- a/Quaver.API.Tests/Quaver/Resources/symphony.qua
+++ b/Quaver.API.Tests/Quaver/Resources/symphony.qua
@@ -1,0 +1,11287 @@
+---
+Mode: Keys4
+Title: Symphony of the Night
+Artist: DragonForce
+Creator: ArXXX
+DifficultyName: Melody of the Darkness  - Extreme
+AudioFile: audio.mp3
+BPMDoesNotAffectScrollVelocity: false
+InitialScrollVelocity: 0.0
+TimingPoints:
+  - StartTime: 410.0
+    Bpm: 177.0
+    Signature: 4
+  - StartTime: 144436.0
+    Bpm: 145.0
+    Signature: 4
+  - StartTime: 243742.0
+    Bpm: 177.0
+    Signature: 4
+  - StartTime: 304758.0
+    Bpm: 112.0
+    Signature: 4
+  - StartTime: 306869.0
+    Bpm: 106.0
+    Signature: 4
+  - StartTime: 308969.0
+    Bpm: 49.000003814697269
+    Signature: 4
+  - StartTime: 310193.0
+    Bpm: 49.75
+    Signature: 4
+  - StartTime: 315017.0
+    Bpm: 57.0
+    Signature: 4
+SliderVelocities:
+  - StartTime: 22104.0
+    Multiplier: 1.0
+  - StartTime: 22189.0
+    Multiplier: 1.0
+  - StartTime: 53291.0
+    Multiplier: 10.0
+  - StartTime: 53347.0
+    Multiplier: 5.0
+  - StartTime: 53404.0
+    Multiplier: 3.0
+  - StartTime: 53460.0
+    Multiplier: 1.0
+  - StartTime: 53517.0
+    Multiplier: 0.10000000149011612
+  - StartTime: 54393.0
+    Multiplier: 1.1999999284744263
+  - StartTime: 54647.0
+    Multiplier: 1.0
+  - StartTime: 76342.0
+    Multiplier: 1.0
+  - StartTime: 107528.0
+    Multiplier: 10.0
+  - StartTime: 108037.0
+    Multiplier: 0.10000000149011612
+  - StartTime: 108715.0
+    Multiplier: 1.5
+  - StartTime: 108884.0
+    Multiplier: 1.0
+  - StartTime: 130579.0
+    Multiplier: 1.0
+  - StartTime: 144436.0
+    Multiplier: 1.1206897497177125
+  - StartTime: 174229.0
+    Multiplier: 1.2206896543502808
+  - StartTime: 254589.0
+    Multiplier: 1.0
+  - StartTime: 265436.0
+    Multiplier: 1.0
+  - StartTime: 274928.0
+    Multiplier: 1.600000023841858
+  - StartTime: 275097.0
+    Multiplier: 0.4000000059604645
+  - StartTime: 275267.0
+    Multiplier: 1.600000023841858
+  - StartTime: 275436.0
+    Multiplier: 0.4000000059604645
+  - StartTime: 275606.0
+    Multiplier: 1.600000023841858
+  - StartTime: 275775.0
+    Multiplier: 0.4000000059604645
+  - StartTime: 275945.0
+    Multiplier: 1.600000023841858
+  - StartTime: 276114.0
+    Multiplier: 0.4000000059604645
+  - StartTime: 276284.0
+    Multiplier: 1.0
+  - StartTime: 277555.0
+    Multiplier: 1.0
+  - StartTime: 277640.0
+    Multiplier: -1.0
+  - StartTime: 277979.0
+    Multiplier: -0.6700000166893005
+  - StartTime: 278318.0
+    Multiplier: 1.0
+  - StartTime: 278996.0
+    Multiplier: 1.0
+  - StartTime: 304758.0
+    Multiplier: 1.5803571939468384
+  - StartTime: 306869.0
+    Multiplier: 1.6698113679885865
+  - StartTime: 308969.0
+    Multiplier: 3.6122448444366457
+  - StartTime: 310193.0
+    Multiplier: 3.557788848876953
+  - StartTime: 315017.0
+    Multiplier: 3.1052632331848146
+HitObjects:
+  - StartTime: 410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 1087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 1257
+    Lane: 1
+    EndTime: 0
+  - StartTime: 1426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 1483
+    Lane: 4
+    EndTime: 0
+  - StartTime: 1568
+    Lane: 3
+    EndTime: 0
+  - StartTime: 1652
+    Lane: 2
+    EndTime: 0
+  - StartTime: 1765
+    Lane: 4
+    EndTime: 0
+  - StartTime: 1935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 2104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 2274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 2443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 2613
+    Lane: 1
+    EndTime: 0
+  - StartTime: 2782
+    Lane: 2
+    EndTime: 0
+  - StartTime: 2867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 2952
+    Lane: 4
+    EndTime: 0
+  - StartTime: 3037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 3121
+    Lane: 4
+    EndTime: 0
+  - StartTime: 3291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 3460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 3630
+    Lane: 4
+    EndTime: 0
+  - StartTime: 3799
+    Lane: 2
+    EndTime: 0
+  - StartTime: 3969
+    Lane: 1
+    EndTime: 0
+  - StartTime: 4138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 4223
+    Lane: 3
+    EndTime: 0
+  - StartTime: 4308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 4393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 4477
+    Lane: 4
+    EndTime: 4816
+  - StartTime: 4647
+    Lane: 2
+    EndTime: 0
+  - StartTime: 4816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 4986
+    Lane: 3
+    EndTime: 0
+  - StartTime: 5155
+    Lane: 1
+    EndTime: 5494
+  - StartTime: 5325
+    Lane: 2
+    EndTime: 0
+  - StartTime: 5494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 5579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 5664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 5748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 5833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 6003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 6172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 6342
+    Lane: 3
+    EndTime: 0
+  - StartTime: 6511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 6681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 6850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 6935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 7020
+    Lane: 2
+    EndTime: 0
+  - StartTime: 7104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 7189
+    Lane: 3
+    EndTime: 0
+  - StartTime: 7359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 7528
+    Lane: 3
+    EndTime: 0
+  - StartTime: 7698
+    Lane: 4
+    EndTime: 0
+  - StartTime: 7867
+    Lane: 2
+    EndTime: 8206
+  - StartTime: 8037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 8206
+    Lane: 3
+    EndTime: 0
+  - StartTime: 8291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 8376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 8460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 8545
+    Lane: 1
+    EndTime: 0
+  - StartTime: 8715
+    Lane: 2
+    EndTime: 0
+  - StartTime: 8884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 9054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 9223
+    Lane: 2
+    EndTime: 0
+  - StartTime: 9393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 9562
+    Lane: 4
+    EndTime: 0
+  - StartTime: 9647
+    Lane: 2
+    EndTime: 0
+  - StartTime: 9732
+    Lane: 3
+    EndTime: 0
+  - StartTime: 9816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 9901
+    Lane: 2
+    EndTime: 10918
+  - StartTime: 10071
+    Lane: 4
+    EndTime: 0
+  - StartTime: 10240
+    Lane: 1
+    EndTime: 0
+  - StartTime: 10410
+    Lane: 3
+    EndTime: 0
+  - StartTime: 10579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 10748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 10918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 11003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 11087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 11257
+    Lane: 1
+    EndTime: 11765
+  - StartTime: 11257
+    Lane: 4
+    EndTime: 0
+  - StartTime: 11257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 11596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 11765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 11765
+    Lane: 3
+    EndTime: 12274
+  - StartTime: 11935
+    Lane: 4
+    EndTime: 0
+  - StartTime: 12274
+    Lane: 2
+    EndTime: 0
+  - StartTime: 12274
+    Lane: 1
+    EndTime: 12613
+  - StartTime: 12359
+    Lane: 4
+    EndTime: 0
+  - StartTime: 12443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 12528
+    Lane: 2
+    EndTime: 0
+  - StartTime: 12613
+    Lane: 3
+    EndTime: 0
+  - StartTime: 12613
+    Lane: 4
+    EndTime: 13121
+  - StartTime: 12952
+    Lane: 1
+    EndTime: 0
+  - StartTime: 13121
+    Lane: 2
+    EndTime: 13630
+  - StartTime: 13121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 13291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 13460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 13630
+    Lane: 4
+    EndTime: 13969
+  - StartTime: 13630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 13799
+    Lane: 1
+    EndTime: 0
+  - StartTime: 13969
+    Lane: 1
+    EndTime: 0
+  - StartTime: 13969
+    Lane: 2
+    EndTime: 14477
+  - StartTime: 14308
+    Lane: 4
+    EndTime: 0
+  - StartTime: 14477
+    Lane: 3
+    EndTime: 14986
+  - StartTime: 14477
+    Lane: 1
+    EndTime: 0
+  - StartTime: 14647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 14986
+    Lane: 4
+    EndTime: 15325
+  - StartTime: 14986
+    Lane: 1
+    EndTime: 0
+  - StartTime: 15071
+    Lane: 2
+    EndTime: 0
+  - StartTime: 15155
+    Lane: 3
+    EndTime: 0
+  - StartTime: 15240
+    Lane: 1
+    EndTime: 0
+  - StartTime: 15325
+    Lane: 3
+    EndTime: 15833
+  - StartTime: 15325
+    Lane: 2
+    EndTime: 0
+  - StartTime: 15664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 15833
+    Lane: 2
+    EndTime: 16342
+  - StartTime: 15833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 16003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 16003
+    Lane: 4
+    EndTime: 0
+  - StartTime: 16172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 16342
+    Lane: 1
+    EndTime: 16681
+  - StartTime: 16342
+    Lane: 4
+    EndTime: 0
+  - StartTime: 16511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 16681
+    Lane: 4
+    EndTime: 17189
+  - StartTime: 16681
+    Lane: 3
+    EndTime: 0
+  - StartTime: 17020
+    Lane: 2
+    EndTime: 0
+  - StartTime: 17189
+    Lane: 3
+    EndTime: 18037
+  - StartTime: 17189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 17359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 17528
+    Lane: 1
+    EndTime: 0
+  - StartTime: 17698
+    Lane: 4
+    EndTime: 18037
+  - StartTime: 17698
+    Lane: 2
+    EndTime: 0
+  - StartTime: 17867
+    Lane: 1
+    EndTime: 0
+  - StartTime: 18037
+    Lane: 2
+    EndTime: 18545
+  - StartTime: 18037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 18376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 18545
+    Lane: 1
+    EndTime: 19308
+  - StartTime: 18545
+    Lane: 3
+    EndTime: 0
+  - StartTime: 18715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 18884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 18969
+    Lane: 3
+    EndTime: 0
+  - StartTime: 19054
+    Lane: 4
+    EndTime: 19308
+  - StartTime: 19138
+    Lane: 3
+    EndTime: 0
+  - StartTime: 19223
+    Lane: 2
+    EndTime: 0
+  - StartTime: 19308
+    Lane: 3
+    EndTime: 0
+  - StartTime: 19393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 19393
+    Lane: 2
+    EndTime: 0
+  - StartTime: 19393
+    Lane: 4
+    EndTime: 20748
+  - StartTime: 19732
+    Lane: 2
+    EndTime: 21003
+  - StartTime: 20071
+    Lane: 3
+    EndTime: 20664
+  - StartTime: 20410
+    Lane: 1
+    EndTime: 20918
+  - StartTime: 20748
+    Lane: 3
+    EndTime: 20833
+  - StartTime: 20833
+    Lane: 4
+    EndTime: 21172
+  - StartTime: 20918
+    Lane: 3
+    EndTime: 21342
+  - StartTime: 21003
+    Lane: 1
+    EndTime: 21681
+  - StartTime: 21087
+    Lane: 2
+    EndTime: 21511
+  - StartTime: 21257
+    Lane: 4
+    EndTime: 21426
+  - StartTime: 21426
+    Lane: 3
+    EndTime: 21596
+  - StartTime: 21596
+    Lane: 2
+    EndTime: 21765
+  - StartTime: 21765
+    Lane: 1
+    EndTime: 21935
+  - StartTime: 21935
+    Lane: 4
+    EndTime: 22104
+  - StartTime: 22104
+    Lane: 2
+    EndTime: 0
+  - StartTime: 22104
+    Lane: 3
+    EndTime: 0
+  - StartTime: 22104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 22274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 22274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 22359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 22359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 22443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 22528
+    Lane: 3
+    EndTime: 0
+  - StartTime: 22613
+    Lane: 1
+    EndTime: 0
+  - StartTime: 22613
+    Lane: 2
+    EndTime: 0
+  - StartTime: 22698
+    Lane: 3
+    EndTime: 0
+  - StartTime: 22782
+    Lane: 1
+    EndTime: 0
+  - StartTime: 22782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 22867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 22952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 22952
+    Lane: 4
+    EndTime: 0
+  - StartTime: 23037
+    Lane: 3
+    EndTime: 0
+  - StartTime: 23037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 23121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 23206
+    Lane: 1
+    EndTime: 0
+  - StartTime: 23291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 23291
+    Lane: 4
+    EndTime: 0
+  - StartTime: 23376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 23460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 23460
+    Lane: 4
+    EndTime: 0
+  - StartTime: 23630
+    Lane: 2
+    EndTime: 0
+  - StartTime: 23630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 23715
+    Lane: 1
+    EndTime: 0
+  - StartTime: 23715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 23799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 23884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 23969
+    Lane: 1
+    EndTime: 0
+  - StartTime: 23969
+    Lane: 4
+    EndTime: 0
+  - StartTime: 24054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 24138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 24138
+    Lane: 4
+    EndTime: 0
+  - StartTime: 24308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 24308
+    Lane: 3
+    EndTime: 0
+  - StartTime: 24393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 24393
+    Lane: 4
+    EndTime: 0
+  - StartTime: 24477
+    Lane: 2
+    EndTime: 0
+  - StartTime: 24562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 24647
+    Lane: 1
+    EndTime: 0
+  - StartTime: 24647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 24816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 24816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 24901
+    Lane: 4
+    EndTime: 0
+  - StartTime: 24986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 24986
+    Lane: 3
+    EndTime: 0
+  - StartTime: 25071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 25155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 25155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 25240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 25325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 25325
+    Lane: 4
+    EndTime: 0
+  - StartTime: 25410
+    Lane: 3
+    EndTime: 0
+  - StartTime: 25494
+    Lane: 2
+    EndTime: 0
+  - StartTime: 25494
+    Lane: 1
+    EndTime: 0
+  - StartTime: 25579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 25664
+    Lane: 4
+    EndTime: 0
+  - StartTime: 25664
+    Lane: 2
+    EndTime: 0
+  - StartTime: 25748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 25833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 25833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 25918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 26003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 26003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 26087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 26172
+    Lane: 2
+    EndTime: 0
+  - StartTime: 26172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 26257
+    Lane: 1
+    EndTime: 0
+  - StartTime: 26342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 26342
+    Lane: 3
+    EndTime: 0
+  - StartTime: 26426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 26511
+    Lane: 1
+    EndTime: 0
+  - StartTime: 26511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 26596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 26681
+    Lane: 4
+    EndTime: 0
+  - StartTime: 26681
+    Lane: 2
+    EndTime: 0
+  - StartTime: 26765
+    Lane: 1
+    EndTime: 0
+  - StartTime: 26850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 26850
+    Lane: 3
+    EndTime: 0
+  - StartTime: 26935
+    Lane: 2
+    EndTime: 0
+  - StartTime: 26935
+    Lane: 1
+    EndTime: 0
+  - StartTime: 27020
+    Lane: 4
+    EndTime: 0
+  - StartTime: 27104
+    Lane: 3
+    EndTime: 0
+  - StartTime: 27189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 27189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 27274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 27274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 27359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 27359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 27443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 27443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 27528
+    Lane: 1
+    EndTime: 0
+  - StartTime: 27528
+    Lane: 2
+    EndTime: 0
+  - StartTime: 27528
+    Lane: 4
+    EndTime: 27782
+  - StartTime: 27698
+    Lane: 3
+    EndTime: 0
+  - StartTime: 27782
+    Lane: 1
+    EndTime: 28037
+  - StartTime: 27782
+    Lane: 2
+    EndTime: 0
+  - StartTime: 27952
+    Lane: 3
+    EndTime: 0
+  - StartTime: 28037
+    Lane: 2
+    EndTime: 0
+  - StartTime: 28037
+    Lane: 4
+    EndTime: 28206
+  - StartTime: 28206
+    Lane: 3
+    EndTime: 28460
+  - StartTime: 28206
+    Lane: 2
+    EndTime: 0
+  - StartTime: 28376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 28460
+    Lane: 1
+    EndTime: 28715
+  - StartTime: 28460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 28630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 28715
+    Lane: 2
+    EndTime: 28884
+  - StartTime: 28715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 28884
+    Lane: 4
+    EndTime: 29138
+  - StartTime: 28884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 29054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 29138
+    Lane: 2
+    EndTime: 29393
+  - StartTime: 29138
+    Lane: 1
+    EndTime: 0
+  - StartTime: 29308
+    Lane: 3
+    EndTime: 0
+  - StartTime: 29393
+    Lane: 1
+    EndTime: 29562
+  - StartTime: 29393
+    Lane: 4
+    EndTime: 0
+  - StartTime: 29562
+    Lane: 3
+    EndTime: 29816
+  - StartTime: 29562
+    Lane: 4
+    EndTime: 0
+  - StartTime: 29732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 29816
+    Lane: 1
+    EndTime: 30071
+  - StartTime: 29816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 29986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 30071
+    Lane: 4
+    EndTime: 30240
+  - StartTime: 30071
+    Lane: 3
+    EndTime: 0
+  - StartTime: 30240
+    Lane: 1
+    EndTime: 30325
+  - StartTime: 30325
+    Lane: 2
+    EndTime: 30410
+  - StartTime: 30410
+    Lane: 3
+    EndTime: 30494
+  - StartTime: 30410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 30494
+    Lane: 1
+    EndTime: 30579
+  - StartTime: 30579
+    Lane: 3
+    EndTime: 30664
+  - StartTime: 30579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 30664
+    Lane: 2
+    EndTime: 30748
+  - StartTime: 30748
+    Lane: 1
+    EndTime: 30833
+  - StartTime: 30833
+    Lane: 4
+    EndTime: 30918
+  - StartTime: 30918
+    Lane: 3
+    EndTime: 31003
+  - StartTime: 30918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 31003
+    Lane: 1
+    EndTime: 31087
+  - StartTime: 31087
+    Lane: 4
+    EndTime: 31172
+  - StartTime: 31087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 31172
+    Lane: 2
+    EndTime: 31257
+  - StartTime: 31257
+    Lane: 1
+    EndTime: 31342
+  - StartTime: 31342
+    Lane: 2
+    EndTime: 31426
+  - StartTime: 31426
+    Lane: 3
+    EndTime: 31511
+  - StartTime: 31426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 31511
+    Lane: 1
+    EndTime: 31596
+  - StartTime: 31596
+    Lane: 2
+    EndTime: 31681
+  - StartTime: 31681
+    Lane: 4
+    EndTime: 31765
+  - StartTime: 31765
+    Lane: 1
+    EndTime: 31850
+  - StartTime: 31765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 31850
+    Lane: 3
+    EndTime: 31935
+  - StartTime: 31935
+    Lane: 2
+    EndTime: 32020
+  - StartTime: 31935
+    Lane: 1
+    EndTime: 0
+  - StartTime: 32020
+    Lane: 4
+    EndTime: 32104
+  - StartTime: 32104
+    Lane: 3
+    EndTime: 32189
+  - StartTime: 32189
+    Lane: 2
+    EndTime: 32274
+  - StartTime: 32274
+    Lane: 1
+    EndTime: 32359
+  - StartTime: 32359
+    Lane: 4
+    EndTime: 32443
+  - StartTime: 32443
+    Lane: 2
+    EndTime: 32528
+  - StartTime: 32528
+    Lane: 3
+    EndTime: 32613
+  - StartTime: 32613
+    Lane: 1
+    EndTime: 32698
+  - StartTime: 32698
+    Lane: 4
+    EndTime: 32782
+  - StartTime: 32782
+    Lane: 2
+    EndTime: 32867
+  - StartTime: 32867
+    Lane: 3
+    EndTime: 32952
+  - StartTime: 32952
+    Lane: 1
+    EndTime: 0
+  - StartTime: 32952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 32952
+    Lane: 4
+    EndTime: 34308
+  - StartTime: 33121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 33121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 33206
+    Lane: 1
+    EndTime: 0
+  - StartTime: 33376
+    Lane: 1
+    EndTime: 0
+  - StartTime: 33460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 33460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 33630
+    Lane: 1
+    EndTime: 0
+  - StartTime: 33799
+    Lane: 2
+    EndTime: 0
+  - StartTime: 33799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 33884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 34054
+    Lane: 1
+    EndTime: 0
+  - StartTime: 34138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 34138
+    Lane: 3
+    EndTime: 0
+  - StartTime: 34308
+    Lane: 1
+    EndTime: 0
+  - StartTime: 34477
+    Lane: 2
+    EndTime: 0
+  - StartTime: 34477
+    Lane: 4
+    EndTime: 0
+  - StartTime: 34562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 34732
+    Lane: 2
+    EndTime: 0
+  - StartTime: 34816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 34816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 34986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 35155
+    Lane: 3
+    EndTime: 0
+  - StartTime: 35155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 35240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 35410
+    Lane: 1
+    EndTime: 0
+  - StartTime: 35494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 35494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 35664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 35664
+    Lane: 2
+    EndTime: 0
+  - StartTime: 35748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 35833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 35833
+    Lane: 1
+    EndTime: 0
+  - StartTime: 35918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 36003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 36003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 36087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 36172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 36172
+    Lane: 2
+    EndTime: 0
+  - StartTime: 36257
+    Lane: 4
+    EndTime: 0
+  - StartTime: 36342
+    Lane: 1
+    EndTime: 0
+  - StartTime: 36342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 36426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 36511
+    Lane: 1
+    EndTime: 0
+  - StartTime: 36511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 36596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 36681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 36681
+    Lane: 2
+    EndTime: 0
+  - StartTime: 36765
+    Lane: 3
+    EndTime: 0
+  - StartTime: 36850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 36850
+    Lane: 2
+    EndTime: 0
+  - StartTime: 36935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 37020
+    Lane: 1
+    EndTime: 0
+  - StartTime: 37020
+    Lane: 4
+    EndTime: 0
+  - StartTime: 37104
+    Lane: 2
+    EndTime: 0
+  - StartTime: 37189
+    Lane: 3
+    EndTime: 0
+  - StartTime: 37189
+    Lane: 4
+    EndTime: 0
+  - StartTime: 37274
+    Lane: 1
+    EndTime: 0
+  - StartTime: 37359
+    Lane: 4
+    EndTime: 0
+  - StartTime: 37359
+    Lane: 3
+    EndTime: 0
+  - StartTime: 37443
+    Lane: 2
+    EndTime: 0
+  - StartTime: 37528
+    Lane: 4
+    EndTime: 0
+  - StartTime: 37528
+    Lane: 3
+    EndTime: 0
+  - StartTime: 37613
+    Lane: 1
+    EndTime: 0
+  - StartTime: 37698
+    Lane: 3
+    EndTime: 0
+  - StartTime: 37698
+    Lane: 2
+    EndTime: 37867
+  - StartTime: 37782
+    Lane: 1
+    EndTime: 0
+  - StartTime: 37867
+    Lane: 4
+    EndTime: 0
+  - StartTime: 37867
+    Lane: 3
+    EndTime: 38037
+  - StartTime: 37952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 38037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 38037
+    Lane: 4
+    EndTime: 38206
+  - StartTime: 38121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 38206
+    Lane: 2
+    EndTime: 0
+  - StartTime: 38206
+    Lane: 1
+    EndTime: 38376
+  - StartTime: 38291
+    Lane: 4
+    EndTime: 0
+  - StartTime: 38376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 38376
+    Lane: 2
+    EndTime: 38884
+  - StartTime: 38545
+    Lane: 4
+    EndTime: 0
+  - StartTime: 38545
+    Lane: 1
+    EndTime: 0
+  - StartTime: 38630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 38799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 38884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 38884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 39054
+    Lane: 3
+    EndTime: 39562
+  - StartTime: 39054
+    Lane: 2
+    EndTime: 0
+  - StartTime: 39223
+    Lane: 4
+    EndTime: 0
+  - StartTime: 39223
+    Lane: 2
+    EndTime: 0
+  - StartTime: 39308
+    Lane: 1
+    EndTime: 0
+  - StartTime: 39477
+    Lane: 1
+    EndTime: 0
+  - StartTime: 39562
+    Lane: 2
+    EndTime: 0
+  - StartTime: 39562
+    Lane: 4
+    EndTime: 0
+  - StartTime: 39732
+    Lane: 1
+    EndTime: 40240
+  - StartTime: 39732
+    Lane: 3
+    EndTime: 0
+  - StartTime: 39901
+    Lane: 4
+    EndTime: 0
+  - StartTime: 39901
+    Lane: 3
+    EndTime: 0
+  - StartTime: 39986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 40155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 40240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 40240
+    Lane: 4
+    EndTime: 0
+  - StartTime: 40410
+    Lane: 3
+    EndTime: 40918
+  - StartTime: 40410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 40579
+    Lane: 1
+    EndTime: 0
+  - StartTime: 40579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 40664
+    Lane: 2
+    EndTime: 0
+  - StartTime: 40833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 40918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 40918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 41087
+    Lane: 4
+    EndTime: 41596
+  - StartTime: 41087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 41172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 41257
+    Lane: 3
+    EndTime: 0
+  - StartTime: 41257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 41342
+    Lane: 1
+    EndTime: 0
+  - StartTime: 41426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 41511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 41596
+    Lane: 1
+    EndTime: 41765
+  - StartTime: 41596
+    Lane: 2
+    EndTime: 0
+  - StartTime: 41681
+    Lane: 3
+    EndTime: 0
+  - StartTime: 41765
+    Lane: 4
+    EndTime: 41935
+  - StartTime: 41765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 41850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 41935
+    Lane: 2
+    EndTime: 42104
+  - StartTime: 41935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 42020
+    Lane: 4
+    EndTime: 0
+  - StartTime: 42104
+    Lane: 3
+    EndTime: 42274
+  - StartTime: 42104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 42189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 42274
+    Lane: 1
+    EndTime: 42443
+  - StartTime: 42274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 42359
+    Lane: 3
+    EndTime: 0
+  - StartTime: 42443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 42443
+    Lane: 2
+    EndTime: 0
+  - StartTime: 42613
+    Lane: 4
+    EndTime: 0
+  - StartTime: 42613
+    Lane: 2
+    EndTime: 0
+  - StartTime: 42782
+    Lane: 1
+    EndTime: 0
+  - StartTime: 42782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 42867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 42867
+    Lane: 2
+    EndTime: 0
+  - StartTime: 42952
+    Lane: 1
+    EndTime: 0
+  - StartTime: 42952
+    Lane: 4
+    EndTime: 0
+  - StartTime: 43121
+    Lane: 4
+    EndTime: 0
+  - StartTime: 43121
+    Lane: 1
+    EndTime: 0
+  - StartTime: 43291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 43291
+    Lane: 3
+    EndTime: 0
+  - StartTime: 43376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 43460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 43460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 43545
+    Lane: 2
+    EndTime: 0
+  - StartTime: 43630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 43630
+    Lane: 4
+    EndTime: 0
+  - StartTime: 43715
+    Lane: 2
+    EndTime: 0
+  - StartTime: 43799
+    Lane: 1
+    EndTime: 0
+  - StartTime: 43799
+    Lane: 4
+    EndTime: 0
+  - StartTime: 43799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 45155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 45155
+    Lane: 3
+    EndTime: 0
+  - StartTime: 45155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 45325
+    Lane: 2
+    EndTime: 0
+  - StartTime: 45325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 45494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 45494
+    Lane: 2
+    EndTime: 0
+  - StartTime: 45664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 45664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 45664
+    Lane: 4
+    EndTime: 46003
+  - StartTime: 46003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 46087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 46172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 46172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 46342
+    Lane: 3
+    EndTime: 0
+  - StartTime: 46342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 46511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 46511
+    Lane: 1
+    EndTime: 0
+  - StartTime: 46511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 47189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 47189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 47189
+    Lane: 4
+    EndTime: 0
+  - StartTime: 47867
+    Lane: 1
+    EndTime: 0
+  - StartTime: 47867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 47867
+    Lane: 4
+    EndTime: 0
+  - StartTime: 48545
+    Lane: 1
+    EndTime: 0
+  - StartTime: 48545
+    Lane: 2
+    EndTime: 0
+  - StartTime: 48545
+    Lane: 3
+    EndTime: 0
+  - StartTime: 48545
+    Lane: 4
+    EndTime: 0
+  - StartTime: 48715
+    Lane: 3
+    EndTime: 0
+  - StartTime: 48715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 48799
+    Lane: 2
+    EndTime: 0
+  - StartTime: 48799
+    Lane: 1
+    EndTime: 0
+  - StartTime: 48884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 48884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 48969
+    Lane: 2
+    EndTime: 0
+  - StartTime: 48969
+    Lane: 1
+    EndTime: 0
+  - StartTime: 49054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 49054
+    Lane: 4
+    EndTime: 0
+  - StartTime: 49138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 49223
+    Lane: 3
+    EndTime: 0
+  - StartTime: 49223
+    Lane: 4
+    EndTime: 0
+  - StartTime: 49223
+    Lane: 1
+    EndTime: 0
+  - StartTime: 49308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 49393
+    Lane: 4
+    EndTime: 0
+  - StartTime: 49393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 49477
+    Lane: 1
+    EndTime: 0
+  - StartTime: 49562
+    Lane: 2
+    EndTime: 0
+  - StartTime: 49647
+    Lane: 3
+    EndTime: 0
+  - StartTime: 49732
+    Lane: 1
+    EndTime: 0
+  - StartTime: 49732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 49816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 49901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 49986
+    Lane: 4
+    EndTime: 0
+  - StartTime: 50071
+    Lane: 3
+    EndTime: 0
+  - StartTime: 50071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 50155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 50240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 50325
+    Lane: 4
+    EndTime: 0
+  - StartTime: 50410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 50410
+    Lane: 3
+    EndTime: 0
+  - StartTime: 50494
+    Lane: 1
+    EndTime: 0
+  - StartTime: 50579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 50579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 50664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 50748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 50748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 50833
+    Lane: 3
+    EndTime: 0
+  - StartTime: 50918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 51003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 51087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 51087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 51172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 51257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 51342
+    Lane: 1
+    EndTime: 0
+  - StartTime: 51426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 51426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 51511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 51596
+    Lane: 1
+    EndTime: 0
+  - StartTime: 51681
+    Lane: 2
+    EndTime: 0
+  - StartTime: 51765
+    Lane: 4
+    EndTime: 0
+  - StartTime: 51765
+    Lane: 1
+    EndTime: 0
+  - StartTime: 51850
+    Lane: 3
+    EndTime: 0
+  - StartTime: 51935
+    Lane: 2
+    EndTime: 0
+  - StartTime: 51935
+    Lane: 1
+    EndTime: 0
+  - StartTime: 51935
+    Lane: 4
+    EndTime: 0
+  - StartTime: 52020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 52104
+    Lane: 2
+    EndTime: 0
+  - StartTime: 52189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 52189
+    Lane: 3
+    EndTime: 0
+  - StartTime: 52189
+    Lane: 4
+    EndTime: 0
+  - StartTime: 52274
+    Lane: 2
+    EndTime: 0
+  - StartTime: 52359
+    Lane: 3
+    EndTime: 0
+  - StartTime: 52443
+    Lane: 2
+    EndTime: 0
+  - StartTime: 52443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 52443
+    Lane: 1
+    EndTime: 0
+  - StartTime: 52528
+    Lane: 3
+    EndTime: 0
+  - StartTime: 52613
+    Lane: 4
+    EndTime: 0
+  - StartTime: 52613
+    Lane: 1
+    EndTime: 0
+  - StartTime: 52698
+    Lane: 2
+    EndTime: 0
+  - StartTime: 52698
+    Lane: 3
+    EndTime: 0
+  - StartTime: 52782
+    Lane: 1
+    EndTime: 0
+  - StartTime: 52782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 52867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 52952
+    Lane: 1
+    EndTime: 0
+  - StartTime: 52952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 53037
+    Lane: 3
+    EndTime: 0
+  - StartTime: 53037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 53121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 53121
+    Lane: 1
+    EndTime: 0
+  - StartTime: 53206
+    Lane: 3
+    EndTime: 0
+  - StartTime: 53291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 53291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 53291
+    Lane: 4
+    EndTime: 0
+  - StartTime: 54647
+    Lane: 1
+    EndTime: 0
+  - StartTime: 54647
+    Lane: 3
+    EndTime: 0
+  - StartTime: 54647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 54732
+    Lane: 2
+    EndTime: 0
+  - StartTime: 54816
+    Lane: 4
+    EndTime: 0
+  - StartTime: 54816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 54901
+    Lane: 3
+    EndTime: 0
+  - StartTime: 54986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 55071
+    Lane: 3
+    EndTime: 0
+  - StartTime: 55155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 55155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 55240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 55325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 55410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 55494
+    Lane: 1
+    EndTime: 0
+  - StartTime: 55494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 55579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 55664
+    Lane: 2
+    EndTime: 0
+  - StartTime: 55748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 55833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 55833
+    Lane: 1
+    EndTime: 0
+  - StartTime: 55918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 56003
+    Lane: 4
+    EndTime: 0
+  - StartTime: 56003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 56087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 56172
+    Lane: 2
+    EndTime: 0
+  - StartTime: 56172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 56257
+    Lane: 3
+    EndTime: 0
+  - StartTime: 56342
+    Lane: 4
+    EndTime: 0
+  - StartTime: 56342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 56426
+    Lane: 1
+    EndTime: 0
+  - StartTime: 56511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 56511
+    Lane: 4
+    EndTime: 0
+  - StartTime: 56596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 56681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 56681
+    Lane: 4
+    EndTime: 0
+  - StartTime: 56765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 56850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 56850
+    Lane: 3
+    EndTime: 0
+  - StartTime: 56935
+    Lane: 2
+    EndTime: 0
+  - StartTime: 57020
+    Lane: 1
+    EndTime: 0
+  - StartTime: 57020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 57104
+    Lane: 4
+    EndTime: 0
+  - StartTime: 57189
+    Lane: 3
+    EndTime: 0
+  - StartTime: 57189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 57274
+    Lane: 2
+    EndTime: 0
+  - StartTime: 57359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 57359
+    Lane: 4
+    EndTime: 0
+  - StartTime: 57443
+    Lane: 2
+    EndTime: 0
+  - StartTime: 57528
+    Lane: 3
+    EndTime: 0
+  - StartTime: 57528
+    Lane: 4
+    EndTime: 0
+  - StartTime: 57613
+    Lane: 2
+    EndTime: 0
+  - StartTime: 57698
+    Lane: 1
+    EndTime: 0
+  - StartTime: 57782
+    Lane: 3
+    EndTime: 0
+  - StartTime: 57867
+    Lane: 4
+    EndTime: 0
+  - StartTime: 57867
+    Lane: 2
+    EndTime: 0
+  - StartTime: 57952
+    Lane: 3
+    EndTime: 0
+  - StartTime: 58037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 58121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 58206
+    Lane: 3
+    EndTime: 0
+  - StartTime: 58206
+    Lane: 4
+    EndTime: 0
+  - StartTime: 58291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 58376
+    Lane: 1
+    EndTime: 0
+  - StartTime: 58460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 58545
+    Lane: 2
+    EndTime: 0
+  - StartTime: 58545
+    Lane: 4
+    EndTime: 0
+  - StartTime: 58630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 58715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 58715
+    Lane: 1
+    EndTime: 0
+  - StartTime: 58799
+    Lane: 2
+    EndTime: 0
+  - StartTime: 58884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 58884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 58969
+    Lane: 2
+    EndTime: 0
+  - StartTime: 59054
+    Lane: 1
+    EndTime: 0
+  - StartTime: 59054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 59138
+    Lane: 4
+    EndTime: 0
+  - StartTime: 59223
+    Lane: 3
+    EndTime: 0
+  - StartTime: 59223
+    Lane: 1
+    EndTime: 0
+  - StartTime: 59308
+    Lane: 4
+    EndTime: 0
+  - StartTime: 59393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 59393
+    Lane: 2
+    EndTime: 0
+  - StartTime: 59477
+    Lane: 1
+    EndTime: 0
+  - StartTime: 59562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 59562
+    Lane: 2
+    EndTime: 0
+  - StartTime: 59647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 59732
+    Lane: 1
+    EndTime: 0
+  - StartTime: 59732
+    Lane: 2
+    EndTime: 0
+  - StartTime: 59816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 59816
+    Lane: 4
+    EndTime: 0
+  - StartTime: 59901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 59901
+    Lane: 1
+    EndTime: 0
+  - StartTime: 59986
+    Lane: 4
+    EndTime: 0
+  - StartTime: 60071
+    Lane: 2
+    EndTime: 0
+  - StartTime: 60071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 60071
+    Lane: 3
+    EndTime: 0
+  - StartTime: 60155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 60240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 60240
+    Lane: 1
+    EndTime: 0
+  - StartTime: 60325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 60410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 60410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 60494
+    Lane: 1
+    EndTime: 0
+  - StartTime: 60579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 60579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 60664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 60748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 60748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 60833
+    Lane: 3
+    EndTime: 0
+  - StartTime: 60918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 60918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 61003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 61087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 61087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 61172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 61257
+    Lane: 3
+    EndTime: 0
+  - StartTime: 61257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 61342
+    Lane: 1
+    EndTime: 0
+  - StartTime: 61426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 61426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 61511
+    Lane: 1
+    EndTime: 0
+  - StartTime: 61596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 61596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 61681
+    Lane: 2
+    EndTime: 0
+  - StartTime: 61765
+    Lane: 3
+    EndTime: 0
+  - StartTime: 61765
+    Lane: 1
+    EndTime: 0
+  - StartTime: 61850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 61935
+    Lane: 1
+    EndTime: 0
+  - StartTime: 61935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 62020
+    Lane: 2
+    EndTime: 0
+  - StartTime: 62104
+    Lane: 4
+    EndTime: 0
+  - StartTime: 62104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 62189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 62274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 62274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 62359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 62443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 62443
+    Lane: 1
+    EndTime: 0
+  - StartTime: 62528
+    Lane: 4
+    EndTime: 0
+  - StartTime: 62613
+    Lane: 3
+    EndTime: 0
+  - StartTime: 62613
+    Lane: 2
+    EndTime: 0
+  - StartTime: 62698
+    Lane: 1
+    EndTime: 0
+  - StartTime: 62782
+    Lane: 2
+    EndTime: 0
+  - StartTime: 62782
+    Lane: 3
+    EndTime: 0
+  - StartTime: 62782
+    Lane: 4
+    EndTime: 63121
+  - StartTime: 63121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 63121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 63121
+    Lane: 1
+    EndTime: 63460
+  - StartTime: 63460
+    Lane: 4
+    EndTime: 0
+  - StartTime: 63460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 63460
+    Lane: 3
+    EndTime: 63799
+  - StartTime: 63799
+    Lane: 4
+    EndTime: 0
+  - StartTime: 63799
+    Lane: 1
+    EndTime: 0
+  - StartTime: 63799
+    Lane: 2
+    EndTime: 64138
+  - StartTime: 64138
+    Lane: 1
+    EndTime: 0
+  - StartTime: 64138
+    Lane: 3
+    EndTime: 0
+  - StartTime: 64138
+    Lane: 4
+    EndTime: 0
+  - StartTime: 64308
+    Lane: 1
+    EndTime: 0
+  - StartTime: 64308
+    Lane: 3
+    EndTime: 0
+  - StartTime: 64308
+    Lane: 4
+    EndTime: 0
+  - StartTime: 64647
+    Lane: 1
+    EndTime: 0
+  - StartTime: 64647
+    Lane: 2
+    EndTime: 0
+  - StartTime: 64647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 64816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 64816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 64816
+    Lane: 4
+    EndTime: 0
+  - StartTime: 64986
+    Lane: 1
+    EndTime: 0
+  - StartTime: 64986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 65071
+    Lane: 3
+    EndTime: 0
+  - StartTime: 65071
+    Lane: 4
+    EndTime: 0
+  - StartTime: 65155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 65155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 65240
+    Lane: 4
+    EndTime: 0
+  - StartTime: 65240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 65325
+    Lane: 2
+    EndTime: 0
+  - StartTime: 65325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 65410
+    Lane: 3
+    EndTime: 0
+  - StartTime: 65494
+    Lane: 1
+    EndTime: 0
+  - StartTime: 65494
+    Lane: 2
+    EndTime: 0
+  - StartTime: 65494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 65664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 65664
+    Lane: 4
+    EndTime: 0
+  - StartTime: 65748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 65918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 66003
+    Lane: 4
+    EndTime: 0
+  - StartTime: 66003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 66172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 66342
+    Lane: 3
+    EndTime: 0
+  - StartTime: 66342
+    Lane: 4
+    EndTime: 0
+  - StartTime: 66426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 66511
+    Lane: 1
+    EndTime: 0
+  - StartTime: 66596
+    Lane: 2
+    EndTime: 0
+  - StartTime: 66681
+    Lane: 3
+    EndTime: 0
+  - StartTime: 66681
+    Lane: 4
+    EndTime: 0
+  - StartTime: 66850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 67020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 67020
+    Lane: 4
+    EndTime: 0
+  - StartTime: 67189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 67274
+    Lane: 2
+    EndTime: 0
+  - StartTime: 67359
+    Lane: 3
+    EndTime: 0
+  - StartTime: 67359
+    Lane: 4
+    EndTime: 0
+  - StartTime: 67528
+    Lane: 1
+    EndTime: 0
+  - StartTime: 67698
+    Lane: 3
+    EndTime: 0
+  - StartTime: 67698
+    Lane: 4
+    EndTime: 0
+  - StartTime: 67782
+    Lane: 2
+    EndTime: 0
+  - StartTime: 67867
+    Lane: 1
+    EndTime: 0
+  - StartTime: 67952
+    Lane: 3
+    EndTime: 0
+  - StartTime: 68037
+    Lane: 2
+    EndTime: 0
+  - StartTime: 68037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 68206
+    Lane: 3
+    EndTime: 0
+  - StartTime: 68206
+    Lane: 1
+    EndTime: 68545
+  - StartTime: 68376
+    Lane: 2
+    EndTime: 0
+  - StartTime: 68376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 68545
+    Lane: 3
+    EndTime: 0
+  - StartTime: 68630
+    Lane: 2
+    EndTime: 0
+  - StartTime: 68715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 68715
+    Lane: 3
+    EndTime: 0
+  - StartTime: 68884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 69054
+    Lane: 4
+    EndTime: 0
+  - StartTime: 69054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 69138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 69223
+    Lane: 1
+    EndTime: 0
+  - StartTime: 69308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 69393
+    Lane: 4
+    EndTime: 0
+  - StartTime: 69393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 69562
+    Lane: 1
+    EndTime: 0
+  - StartTime: 69562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 69647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 69732
+    Lane: 3
+    EndTime: 0
+  - StartTime: 69732
+    Lane: 1
+    EndTime: 0
+  - StartTime: 69816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 69901
+    Lane: 4
+    EndTime: 0
+  - StartTime: 69901
+    Lane: 1
+    EndTime: 0
+  - StartTime: 69986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 70071
+    Lane: 4
+    EndTime: 0
+  - StartTime: 70071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 70155
+    Lane: 3
+    EndTime: 0
+  - StartTime: 70240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 70240
+    Lane: 4
+    EndTime: 0
+  - StartTime: 70410
+    Lane: 3
+    EndTime: 0
+  - StartTime: 70410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 70494
+    Lane: 1
+    EndTime: 0
+  - StartTime: 70579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 70579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 70664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 70748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 70748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 70833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 70918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 70918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 70918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 71003
+    Lane: 4
+    EndTime: 0
+  - StartTime: 71087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 71087
+    Lane: 1
+    EndTime: 0
+  - StartTime: 71172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 71257
+    Lane: 4
+    EndTime: 0
+  - StartTime: 71342
+    Lane: 3
+    EndTime: 0
+  - StartTime: 71426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 71426
+    Lane: 1
+    EndTime: 0
+  - StartTime: 71511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 71596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 71681
+    Lane: 3
+    EndTime: 0
+  - StartTime: 71765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 71765
+    Lane: 1
+    EndTime: 0
+  - StartTime: 71850
+    Lane: 3
+    EndTime: 0
+  - StartTime: 71935
+    Lane: 4
+    EndTime: 0
+  - StartTime: 72020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 72104
+    Lane: 2
+    EndTime: 0
+  - StartTime: 72104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 72189
+    Lane: 3
+    EndTime: 0
+  - StartTime: 72274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 72274
+    Lane: 1
+    EndTime: 0
+  - StartTime: 72359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 72443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 72443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 72528
+    Lane: 2
+    EndTime: 0
+  - StartTime: 72613
+    Lane: 1
+    EndTime: 0
+  - StartTime: 72698
+    Lane: 2
+    EndTime: 0
+  - StartTime: 72782
+    Lane: 3
+    EndTime: 0
+  - StartTime: 72782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 72867
+    Lane: 2
+    EndTime: 0
+  - StartTime: 72952
+    Lane: 1
+    EndTime: 0
+  - StartTime: 73037
+    Lane: 2
+    EndTime: 0
+  - StartTime: 73121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 73121
+    Lane: 4
+    EndTime: 0
+  - StartTime: 73206
+    Lane: 2
+    EndTime: 0
+  - StartTime: 73291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 73376
+    Lane: 2
+    EndTime: 0
+  - StartTime: 73460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 73460
+    Lane: 4
+    EndTime: 0
+  - StartTime: 73545
+    Lane: 2
+    EndTime: 0
+  - StartTime: 73630
+    Lane: 1
+    EndTime: 0
+  - StartTime: 73630
+    Lane: 4
+    EndTime: 0
+  - StartTime: 73630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 73799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 73884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 73884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 73884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 74054
+    Lane: 2
+    EndTime: 0
+  - StartTime: 74138
+    Lane: 1
+    EndTime: 0
+  - StartTime: 74138
+    Lane: 3
+    EndTime: 0
+  - StartTime: 74138
+    Lane: 4
+    EndTime: 0
+  - StartTime: 74308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 74308
+    Lane: 4
+    EndTime: 0
+  - StartTime: 74393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 74477
+    Lane: 4
+    EndTime: 0
+  - StartTime: 74477
+    Lane: 2
+    EndTime: 0
+  - StartTime: 74562
+    Lane: 1
+    EndTime: 0
+  - StartTime: 74647
+    Lane: 3
+    EndTime: 0
+  - StartTime: 74647
+    Lane: 2
+    EndTime: 0
+  - StartTime: 74732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 74816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 74816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 74901
+    Lane: 3
+    EndTime: 0
+  - StartTime: 74986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 74986
+    Lane: 4
+    EndTime: 0
+  - StartTime: 75071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 75155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 75155
+    Lane: 3
+    EndTime: 0
+  - StartTime: 75240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 75325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 75325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 75410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 75410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 75494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 75494
+    Lane: 1
+    EndTime: 0
+  - StartTime: 75579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 75664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 75664
+    Lane: 4
+    EndTime: 0
+  - StartTime: 75748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 75833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 75918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 76003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 76003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 76087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 76172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 76257
+    Lane: 1
+    EndTime: 0
+  - StartTime: 76342
+    Lane: 3
+    EndTime: 0
+  - StartTime: 76342
+    Lane: 4
+    EndTime: 0
+  - StartTime: 76342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 76426
+    Lane: 1
+    EndTime: 0
+  - StartTime: 76511
+    Lane: 4
+    EndTime: 0
+  - StartTime: 76511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 76596
+    Lane: 2
+    EndTime: 0
+  - StartTime: 76681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 76681
+    Lane: 4
+    EndTime: 0
+  - StartTime: 76765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 76850
+    Lane: 3
+    EndTime: 0
+  - StartTime: 76850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 76935
+    Lane: 1
+    EndTime: 0
+  - StartTime: 77020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 77020
+    Lane: 2
+    EndTime: 0
+  - StartTime: 77104
+    Lane: 4
+    EndTime: 0
+  - StartTime: 77189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 77189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 77274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 77359
+    Lane: 4
+    EndTime: 0
+  - StartTime: 77359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 77443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 77528
+    Lane: 2
+    EndTime: 0
+  - StartTime: 77528
+    Lane: 1
+    EndTime: 0
+  - StartTime: 77613
+    Lane: 4
+    EndTime: 0
+  - StartTime: 77698
+    Lane: 3
+    EndTime: 0
+  - StartTime: 77698
+    Lane: 2
+    EndTime: 0
+  - StartTime: 77698
+    Lane: 1
+    EndTime: 0
+  - StartTime: 77782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 77867
+    Lane: 2
+    EndTime: 0
+  - StartTime: 77867
+    Lane: 1
+    EndTime: 0
+  - StartTime: 77952
+    Lane: 3
+    EndTime: 0
+  - StartTime: 78037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 78037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 78121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 78206
+    Lane: 4
+    EndTime: 0
+  - StartTime: 78206
+    Lane: 2
+    EndTime: 0
+  - StartTime: 78291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 78376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 78376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 78460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 78545
+    Lane: 4
+    EndTime: 0
+  - StartTime: 78545
+    Lane: 3
+    EndTime: 0
+  - StartTime: 78630
+    Lane: 2
+    EndTime: 0
+  - StartTime: 78715
+    Lane: 1
+    EndTime: 0
+  - StartTime: 78715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 78799
+    Lane: 2
+    EndTime: 0
+  - StartTime: 78884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 78884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 78969
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79054
+    Lane: 1
+    EndTime: 0
+  - StartTime: 79054
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 79138
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79223
+    Lane: 3
+    EndTime: 0
+  - StartTime: 79223
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79308
+    Lane: 1
+    EndTime: 0
+  - StartTime: 79393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 79393
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79477
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79562
+    Lane: 1
+    EndTime: 0
+  - StartTime: 79562
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79647
+    Lane: 3
+    EndTime: 0
+  - StartTime: 79732
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79732
+    Lane: 1
+    EndTime: 0
+  - StartTime: 79816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 79901
+    Lane: 4
+    EndTime: 0
+  - StartTime: 79901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 79986
+    Lane: 1
+    EndTime: 0
+  - StartTime: 80071
+    Lane: 2
+    EndTime: 0
+  - StartTime: 80071
+    Lane: 3
+    EndTime: 0
+  - StartTime: 80155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 80240
+    Lane: 1
+    EndTime: 0
+  - StartTime: 80240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 80325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 80410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 80410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 80410
+    Lane: 1
+    EndTime: 0
+  - StartTime: 80494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 80579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 80579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 80664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 80748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 80748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 80833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 80918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 80918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 81003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 81087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 81087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 81172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 81172
+    Lane: 2
+    EndTime: 0
+  - StartTime: 81257
+    Lane: 3
+    EndTime: 0
+  - StartTime: 81257
+    Lane: 4
+    EndTime: 0
+  - StartTime: 81342
+    Lane: 1
+    EndTime: 0
+  - StartTime: 81342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 81426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 81426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 81511
+    Lane: 1
+    EndTime: 0
+  - StartTime: 81511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 81596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 81596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 81681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 81765
+    Lane: 3
+    EndTime: 0
+  - StartTime: 81765
+    Lane: 4
+    EndTime: 0
+  - StartTime: 81765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 81850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 81935
+    Lane: 2
+    EndTime: 0
+  - StartTime: 81935
+    Lane: 4
+    EndTime: 0
+  - StartTime: 82020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 82104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 82104
+    Lane: 4
+    EndTime: 0
+  - StartTime: 82189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 82274
+    Lane: 1
+    EndTime: 0
+  - StartTime: 82274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 82359
+    Lane: 4
+    EndTime: 0
+  - StartTime: 82443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 82443
+    Lane: 2
+    EndTime: 0
+  - StartTime: 82528
+    Lane: 4
+    EndTime: 0
+  - StartTime: 82613
+    Lane: 3
+    EndTime: 0
+  - StartTime: 82613
+    Lane: 1
+    EndTime: 0
+  - StartTime: 82698
+    Lane: 2
+    EndTime: 0
+  - StartTime: 82782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 82782
+    Lane: 1
+    EndTime: 0
+  - StartTime: 82867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 82952
+    Lane: 4
+    EndTime: 0
+  - StartTime: 82952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 83037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 83121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 83121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 83121
+    Lane: 4
+    EndTime: 0
+  - StartTime: 83206
+    Lane: 1
+    EndTime: 0
+  - StartTime: 83291
+    Lane: 4
+    EndTime: 0
+  - StartTime: 83291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 83376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 83460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 83460
+    Lane: 4
+    EndTime: 0
+  - StartTime: 83545
+    Lane: 2
+    EndTime: 0
+  - StartTime: 83630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 83630
+    Lane: 4
+    EndTime: 0
+  - StartTime: 83715
+    Lane: 1
+    EndTime: 0
+  - StartTime: 83799
+    Lane: 2
+    EndTime: 0
+  - StartTime: 83799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 83884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 83969
+    Lane: 1
+    EndTime: 0
+  - StartTime: 83969
+    Lane: 3
+    EndTime: 0
+  - StartTime: 84054
+    Lane: 2
+    EndTime: 0
+  - StartTime: 84138
+    Lane: 4
+    EndTime: 0
+  - StartTime: 84138
+    Lane: 1
+    EndTime: 0
+  - StartTime: 84223
+    Lane: 3
+    EndTime: 0
+  - StartTime: 84308
+    Lane: 1
+    EndTime: 0
+  - StartTime: 84308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 84393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 84477
+    Lane: 4
+    EndTime: 0
+  - StartTime: 84477
+    Lane: 1
+    EndTime: 0
+  - StartTime: 84562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 84562
+    Lane: 2
+    EndTime: 0
+  - StartTime: 84647
+    Lane: 1
+    EndTime: 0
+  - StartTime: 84647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 84732
+    Lane: 3
+    EndTime: 0
+  - StartTime: 84816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 84901
+    Lane: 1
+    EndTime: 0
+  - StartTime: 84986
+    Lane: 3
+    EndTime: 0
+  - StartTime: 84986
+    Lane: 4
+    EndTime: 0
+  - StartTime: 85071
+    Lane: 2
+    EndTime: 0
+  - StartTime: 85155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 85240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 85325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 85325
+    Lane: 4
+    EndTime: 0
+  - StartTime: 85410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 85410
+    Lane: 1
+    EndTime: 0
+  - StartTime: 85494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 85494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 85579
+    Lane: 1
+    EndTime: 0
+  - StartTime: 85664
+    Lane: 2
+    EndTime: 0
+  - StartTime: 85748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 85833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 85833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 85833
+    Lane: 1
+    EndTime: 0
+  - StartTime: 86003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 86172
+    Lane: 2
+    EndTime: 0
+  - StartTime: 86342
+    Lane: 1
+    EndTime: 0
+  - StartTime: 86511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 86511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 86511
+    Lane: 4
+    EndTime: 0
+  - StartTime: 86681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 86850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 87020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 87189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 87189
+    Lane: 4
+    EndTime: 0
+  - StartTime: 87189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 87359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 87359
+    Lane: 3
+    EndTime: 0
+  - StartTime: 87443
+    Lane: 2
+    EndTime: 0
+  - StartTime: 87613
+    Lane: 3
+    EndTime: 0
+  - StartTime: 87698
+    Lane: 2
+    EndTime: 0
+  - StartTime: 87698
+    Lane: 4
+    EndTime: 0
+  - StartTime: 87867
+    Lane: 1
+    EndTime: 0
+  - StartTime: 88037
+    Lane: 3
+    EndTime: 0
+  - StartTime: 88037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 88121
+    Lane: 1
+    EndTime: 0
+  - StartTime: 88291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 88376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 88376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 88545
+    Lane: 1
+    EndTime: 0
+  - StartTime: 88715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 88715
+    Lane: 3
+    EndTime: 0
+  - StartTime: 88799
+    Lane: 2
+    EndTime: 0
+  - StartTime: 88969
+    Lane: 3
+    EndTime: 0
+  - StartTime: 89054
+    Lane: 2
+    EndTime: 0
+  - StartTime: 89054
+    Lane: 4
+    EndTime: 0
+  - StartTime: 89223
+    Lane: 1
+    EndTime: 0
+  - StartTime: 89393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 89393
+    Lane: 2
+    EndTime: 0
+  - StartTime: 89477
+    Lane: 1
+    EndTime: 0
+  - StartTime: 89647
+    Lane: 2
+    EndTime: 0
+  - StartTime: 89732
+    Lane: 1
+    EndTime: 0
+  - StartTime: 89732
+    Lane: 3
+    EndTime: 0
+  - StartTime: 89901
+    Lane: 4
+    EndTime: 0
+  - StartTime: 89901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 89986
+    Lane: 3
+    EndTime: 0
+  - StartTime: 90071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 90071
+    Lane: 4
+    EndTime: 0
+  - StartTime: 90155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 90240
+    Lane: 1
+    EndTime: 0
+  - StartTime: 90240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 90325
+    Lane: 4
+    EndTime: 0
+  - StartTime: 90410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 90410
+    Lane: 1
+    EndTime: 0
+  - StartTime: 90494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 90579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 90579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 90664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 90748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 90748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 90833
+    Lane: 3
+    EndTime: 0
+  - StartTime: 90918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 90918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 91003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 91087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 91087
+    Lane: 1
+    EndTime: 0
+  - StartTime: 91172
+    Lane: 2
+    EndTime: 0
+  - StartTime: 91257
+    Lane: 1
+    EndTime: 0
+  - StartTime: 91257
+    Lane: 3
+    EndTime: 0
+  - StartTime: 91342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 91426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 91426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 91511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 91596
+    Lane: 1
+    EndTime: 0
+  - StartTime: 91596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 91681
+    Lane: 2
+    EndTime: 0
+  - StartTime: 91765
+    Lane: 1
+    EndTime: 0
+  - StartTime: 91765
+    Lane: 3
+    EndTime: 0
+  - StartTime: 91850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 91935
+    Lane: 2
+    EndTime: 92020
+  - StartTime: 92020
+    Lane: 3
+    EndTime: 92104
+  - StartTime: 92104
+    Lane: 4
+    EndTime: 92189
+  - StartTime: 92104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 92189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 92274
+    Lane: 3
+    EndTime: 92359
+  - StartTime: 92359
+    Lane: 2
+    EndTime: 92443
+  - StartTime: 92443
+    Lane: 1
+    EndTime: 92528
+  - StartTime: 92443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 92528
+    Lane: 3
+    EndTime: 0
+  - StartTime: 92613
+    Lane: 2
+    EndTime: 0
+  - StartTime: 92613
+    Lane: 1
+    EndTime: 92952
+  - StartTime: 92782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 92782
+    Lane: 3
+    EndTime: 0
+  - StartTime: 92867
+    Lane: 2
+    EndTime: 0
+  - StartTime: 93037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 93121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 93121
+    Lane: 4
+    EndTime: 0
+  - StartTime: 93291
+    Lane: 4
+    EndTime: 93630
+  - StartTime: 93291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 93460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 93460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 93545
+    Lane: 2
+    EndTime: 0
+  - StartTime: 93715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 93799
+    Lane: 1
+    EndTime: 0
+  - StartTime: 93799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 93969
+    Lane: 1
+    EndTime: 94308
+  - StartTime: 93969
+    Lane: 4
+    EndTime: 0
+  - StartTime: 94138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 94138
+    Lane: 3
+    EndTime: 0
+  - StartTime: 94223
+    Lane: 4
+    EndTime: 0
+  - StartTime: 94393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 94477
+    Lane: 3
+    EndTime: 0
+  - StartTime: 94477
+    Lane: 2
+    EndTime: 0
+  - StartTime: 94647
+    Lane: 4
+    EndTime: 94986
+  - StartTime: 94647
+    Lane: 3
+    EndTime: 0
+  - StartTime: 94816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 94816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 94901
+    Lane: 3
+    EndTime: 0
+  - StartTime: 95071
+    Lane: 4
+    EndTime: 0
+  - StartTime: 95155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 95155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 95325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 95325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 95410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 95494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 95494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 95579
+    Lane: 1
+    EndTime: 0
+  - StartTime: 95664
+    Lane: 2
+    EndTime: 0
+  - StartTime: 95748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 95833
+    Lane: 1
+    EndTime: 0
+  - StartTime: 95833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 95918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 96003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 96003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 96087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 96172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 96172
+    Lane: 2
+    EndTime: 0
+  - StartTime: 96257
+    Lane: 1
+    EndTime: 0
+  - StartTime: 96342
+    Lane: 4
+    EndTime: 0
+  - StartTime: 96342
+    Lane: 3
+    EndTime: 0
+  - StartTime: 96426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 96511
+    Lane: 4
+    EndTime: 0
+  - StartTime: 96511
+    Lane: 1
+    EndTime: 0
+  - StartTime: 96596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 96681
+    Lane: 2
+    EndTime: 0
+  - StartTime: 96681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 96765
+    Lane: 3
+    EndTime: 0
+  - StartTime: 96850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 96850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 96935
+    Lane: 2
+    EndTime: 0
+  - StartTime: 97020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 97104
+    Lane: 1
+    EndTime: 0
+  - StartTime: 97189
+    Lane: 4
+    EndTime: 0
+  - StartTime: 97189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 97274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 97359
+    Lane: 1
+    EndTime: 97528
+  - StartTime: 97359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 97443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 97528
+    Lane: 3
+    EndTime: 0
+  - StartTime: 97528
+    Lane: 2
+    EndTime: 97698
+  - StartTime: 97613
+    Lane: 1
+    EndTime: 0
+  - StartTime: 97698
+    Lane: 3
+    EndTime: 97867
+  - StartTime: 97698
+    Lane: 4
+    EndTime: 0
+  - StartTime: 97782
+    Lane: 2
+    EndTime: 0
+  - StartTime: 97867
+    Lane: 4
+    EndTime: 98037
+  - StartTime: 97867
+    Lane: 1
+    EndTime: 0
+  - StartTime: 97952
+    Lane: 3
+    EndTime: 0
+  - StartTime: 98037
+    Lane: 2
+    EndTime: 0
+  - StartTime: 98037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 98206
+    Lane: 3
+    EndTime: 0
+  - StartTime: 98206
+    Lane: 4
+    EndTime: 0
+  - StartTime: 98291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 98376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 98460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 98460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 98545
+    Lane: 3
+    EndTime: 0
+  - StartTime: 98545
+    Lane: 4
+    EndTime: 0
+  - StartTime: 98630
+    Lane: 2
+    EndTime: 0
+  - StartTime: 98715
+    Lane: 1
+    EndTime: 0
+  - StartTime: 98884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 98884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 98969
+    Lane: 1
+    EndTime: 0
+  - StartTime: 99054
+    Lane: 4
+    EndTime: 0
+  - StartTime: 99138
+    Lane: 1
+    EndTime: 0
+  - StartTime: 99138
+    Lane: 3
+    EndTime: 0
+  - StartTime: 99223
+    Lane: 4
+    EndTime: 0
+  - StartTime: 99223
+    Lane: 2
+    EndTime: 0
+  - StartTime: 99308
+    Lane: 3
+    EndTime: 0
+  - StartTime: 99393
+    Lane: 2
+    EndTime: 0
+  - StartTime: 99393
+    Lane: 1
+    EndTime: 99562
+  - StartTime: 99562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 99562
+    Lane: 2
+    EndTime: 99732
+  - StartTime: 99732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 99732
+    Lane: 3
+    EndTime: 99901
+  - StartTime: 99901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 99901
+    Lane: 1
+    EndTime: 100071
+  - StartTime: 100071
+    Lane: 3
+    EndTime: 0
+  - StartTime: 100071
+    Lane: 2
+    EndTime: 100240
+  - StartTime: 100240
+    Lane: 4
+    EndTime: 0
+  - StartTime: 100240
+    Lane: 3
+    EndTime: 100410
+  - StartTime: 100410
+    Lane: 1
+    EndTime: 0
+  - StartTime: 100410
+    Lane: 4
+    EndTime: 100579
+  - StartTime: 100579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 100579
+    Lane: 1
+    EndTime: 100748
+  - StartTime: 100748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 100748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 100918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 100918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 101003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 101003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 101172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 101172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 101257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 101257
+    Lane: 4
+    EndTime: 0
+  - StartTime: 101426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 101426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 101596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 101596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 101681
+    Lane: 2
+    EndTime: 0
+  - StartTime: 101681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 101850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 101850
+    Lane: 2
+    EndTime: 0
+  - StartTime: 101935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 101935
+    Lane: 4
+    EndTime: 0
+  - StartTime: 102104
+    Lane: 3
+    EndTime: 0
+  - StartTime: 102104
+    Lane: 1
+    EndTime: 102443
+  - StartTime: 102274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 102443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 102443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 102443
+    Lane: 2
+    EndTime: 102782
+  - StartTime: 102613
+    Lane: 4
+    EndTime: 0
+  - StartTime: 102782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 102782
+    Lane: 3
+    EndTime: 0
+  - StartTime: 102782
+    Lane: 1
+    EndTime: 0
+  - StartTime: 102867
+    Lane: 2
+    EndTime: 0
+  - StartTime: 102952
+    Lane: 3
+    EndTime: 0
+  - StartTime: 103037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 103037
+    Lane: 2
+    EndTime: 0
+  - StartTime: 103121
+    Lane: 1
+    EndTime: 0
+  - StartTime: 103206
+    Lane: 4
+    EndTime: 0
+  - StartTime: 103291
+    Lane: 3
+    EndTime: 0
+  - StartTime: 103291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 103376
+    Lane: 2
+    EndTime: 0
+  - StartTime: 103460
+    Lane: 4
+    EndTime: 0
+  - StartTime: 103460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 103460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 103545
+    Lane: 2
+    EndTime: 0
+  - StartTime: 103630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 103630
+    Lane: 1
+    EndTime: 0
+  - StartTime: 103715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 103799
+    Lane: 2
+    EndTime: 0
+  - StartTime: 103884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 103969
+    Lane: 4
+    EndTime: 0
+  - StartTime: 103969
+    Lane: 2
+    EndTime: 0
+  - StartTime: 104054
+    Lane: 1
+    EndTime: 0
+  - StartTime: 104138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 104223
+    Lane: 3
+    EndTime: 0
+  - StartTime: 104308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 104308
+    Lane: 4
+    EndTime: 0
+  - StartTime: 104393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 104477
+    Lane: 3
+    EndTime: 0
+  - StartTime: 104562
+    Lane: 2
+    EndTime: 0
+  - StartTime: 104647
+    Lane: 3
+    EndTime: 0
+  - StartTime: 104647
+    Lane: 1
+    EndTime: 0
+  - StartTime: 104732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 104816
+    Lane: 1
+    EndTime: 0
+  - StartTime: 104816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 104901
+    Lane: 3
+    EndTime: 0
+  - StartTime: 104986
+    Lane: 4
+    EndTime: 0
+  - StartTime: 104986
+    Lane: 1
+    EndTime: 0
+  - StartTime: 105071
+    Lane: 2
+    EndTime: 0
+  - StartTime: 105155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 105155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 105240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 105325
+    Lane: 4
+    EndTime: 0
+  - StartTime: 105325
+    Lane: 2
+    EndTime: 0
+  - StartTime: 105410
+    Lane: 1
+    EndTime: 0
+  - StartTime: 105494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 105494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 105579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 105664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 105664
+    Lane: 4
+    EndTime: 0
+  - StartTime: 105748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 105833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 105833
+    Lane: 3
+    EndTime: 0
+  - StartTime: 105918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 106003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 106003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 106087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 106172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 106172
+    Lane: 2
+    EndTime: 0
+  - StartTime: 106257
+    Lane: 1
+    EndTime: 0
+  - StartTime: 106342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 106426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 106426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 106511
+    Lane: 2
+    EndTime: 0
+  - StartTime: 106596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 106681
+    Lane: 4
+    EndTime: 0
+  - StartTime: 106681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 106765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 106850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 106850
+    Lane: 4
+    EndTime: 0
+  - StartTime: 106935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 107020
+    Lane: 2
+    EndTime: 0
+  - StartTime: 107020
+    Lane: 1
+    EndTime: 0
+  - StartTime: 107104
+    Lane: 3
+    EndTime: 0
+  - StartTime: 107104
+    Lane: 4
+    EndTime: 0
+  - StartTime: 107189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 107189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 107274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 107274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 107359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 107359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 107443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 107528
+    Lane: 4
+    EndTime: 0
+  - StartTime: 107528
+    Lane: 1
+    EndTime: 0
+  - StartTime: 107528
+    Lane: 2
+    EndTime: 0
+  - StartTime: 108884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 108884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 108884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 108969
+    Lane: 2
+    EndTime: 0
+  - StartTime: 109054
+    Lane: 4
+    EndTime: 0
+  - StartTime: 109054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 109138
+    Lane: 1
+    EndTime: 0
+  - StartTime: 109223
+    Lane: 2
+    EndTime: 0
+  - StartTime: 109308
+    Lane: 3
+    EndTime: 0
+  - StartTime: 109393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 109393
+    Lane: 4
+    EndTime: 0
+  - StartTime: 109477
+    Lane: 2
+    EndTime: 0
+  - StartTime: 109562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 109647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 109732
+    Lane: 1
+    EndTime: 0
+  - StartTime: 109732
+    Lane: 2
+    EndTime: 0
+  - StartTime: 109816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 109901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 109986
+    Lane: 3
+    EndTime: 0
+  - StartTime: 110071
+    Lane: 4
+    EndTime: 0
+  - StartTime: 110071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 110155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 110240
+    Lane: 4
+    EndTime: 0
+  - StartTime: 110240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 110325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 110410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 110410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 110494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 110579
+    Lane: 1
+    EndTime: 0
+  - StartTime: 110579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 110664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 110748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 110748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 110833
+    Lane: 1
+    EndTime: 0
+  - StartTime: 110918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 110918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 111003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 111087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 111087
+    Lane: 1
+    EndTime: 0
+  - StartTime: 111172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 111257
+    Lane: 4
+    EndTime: 0
+  - StartTime: 111257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 111342
+    Lane: 1
+    EndTime: 0
+  - StartTime: 111426
+    Lane: 4
+    EndTime: 0
+  - StartTime: 111426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 111511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 111596
+    Lane: 2
+    EndTime: 0
+  - StartTime: 111596
+    Lane: 1
+    EndTime: 0
+  - StartTime: 111681
+    Lane: 3
+    EndTime: 0
+  - StartTime: 111765
+    Lane: 4
+    EndTime: 0
+  - StartTime: 111765
+    Lane: 2
+    EndTime: 0
+  - StartTime: 111850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 111935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 112020
+    Lane: 2
+    EndTime: 0
+  - StartTime: 112104
+    Lane: 4
+    EndTime: 0
+  - StartTime: 112104
+    Lane: 3
+    EndTime: 0
+  - StartTime: 112189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 112274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 112359
+    Lane: 2
+    EndTime: 0
+  - StartTime: 112443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 112443
+    Lane: 1
+    EndTime: 0
+  - StartTime: 112528
+    Lane: 2
+    EndTime: 0
+  - StartTime: 112613
+    Lane: 4
+    EndTime: 0
+  - StartTime: 112698
+    Lane: 3
+    EndTime: 0
+  - StartTime: 112782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 112782
+    Lane: 1
+    EndTime: 0
+  - StartTime: 112867
+    Lane: 2
+    EndTime: 0
+  - StartTime: 112952
+    Lane: 3
+    EndTime: 0
+  - StartTime: 112952
+    Lane: 1
+    EndTime: 0
+  - StartTime: 112952
+    Lane: 4
+    EndTime: 0
+  - StartTime: 113121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 113121
+    Lane: 3
+    EndTime: 0
+  - StartTime: 113291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 113291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 113376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 113460
+    Lane: 4
+    EndTime: 0
+  - StartTime: 113460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 113460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 113630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 113630
+    Lane: 2
+    EndTime: 0
+  - StartTime: 113799
+    Lane: 4
+    EndTime: 0
+  - StartTime: 113799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 113884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 113969
+    Lane: 3
+    EndTime: 0
+  - StartTime: 113969
+    Lane: 4
+    EndTime: 0
+  - StartTime: 113969
+    Lane: 1
+    EndTime: 0
+  - StartTime: 114138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 114138
+    Lane: 1
+    EndTime: 0
+  - StartTime: 114223
+    Lane: 3
+    EndTime: 0
+  - StartTime: 114308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 114308
+    Lane: 1
+    EndTime: 0
+  - StartTime: 114308
+    Lane: 4
+    EndTime: 0
+  - StartTime: 114393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 114477
+    Lane: 2
+    EndTime: 0
+  - StartTime: 114477
+    Lane: 1
+    EndTime: 0
+  - StartTime: 114562
+    Lane: 4
+    EndTime: 0
+  - StartTime: 114647
+    Lane: 2
+    EndTime: 0
+  - StartTime: 114647
+    Lane: 3
+    EndTime: 0
+  - StartTime: 114732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 114816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 114816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 114901
+    Lane: 1
+    EndTime: 0
+  - StartTime: 114986
+    Lane: 4
+    EndTime: 0
+  - StartTime: 114986
+    Lane: 3
+    EndTime: 0
+  - StartTime: 115071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 115155
+    Lane: 3
+    EndTime: 0
+  - StartTime: 115155
+    Lane: 4
+    EndTime: 0
+  - StartTime: 115240
+    Lane: 1
+    EndTime: 0
+  - StartTime: 115325
+    Lane: 2
+    EndTime: 0
+  - StartTime: 115325
+    Lane: 3
+    EndTime: 0
+  - StartTime: 115410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 115494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 115494
+    Lane: 2
+    EndTime: 0
+  - StartTime: 115579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 115664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 115664
+    Lane: 2
+    EndTime: 0
+  - StartTime: 115748
+    Lane: 3
+    EndTime: 0
+  - StartTime: 115833
+    Lane: 1
+    EndTime: 0
+  - StartTime: 115833
+    Lane: 2
+    EndTime: 0
+  - StartTime: 115918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 116003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 116003
+    Lane: 3
+    EndTime: 0
+  - StartTime: 116087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 116172
+    Lane: 1
+    EndTime: 0
+  - StartTime: 116172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 116257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 116342
+    Lane: 3
+    EndTime: 0
+  - StartTime: 116342
+    Lane: 4
+    EndTime: 0
+  - StartTime: 116426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 116511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 116511
+    Lane: 4
+    EndTime: 0
+  - StartTime: 116596
+    Lane: 2
+    EndTime: 0
+  - StartTime: 116681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 116681
+    Lane: 3
+    EndTime: 0
+  - StartTime: 116765
+    Lane: 4
+    EndTime: 0
+  - StartTime: 116850
+    Lane: 3
+    EndTime: 0
+  - StartTime: 116850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 116935
+    Lane: 4
+    EndTime: 0
+  - StartTime: 117020
+    Lane: 2
+    EndTime: 0
+  - StartTime: 117020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 117020
+    Lane: 1
+    EndTime: 0
+  - StartTime: 117104
+    Lane: 4
+    EndTime: 0
+  - StartTime: 117189
+    Lane: 3
+    EndTime: 0
+  - StartTime: 117274
+    Lane: 2
+    EndTime: 0
+  - StartTime: 117359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 117443
+    Lane: 2
+    EndTime: 0
+  - StartTime: 117528
+    Lane: 3
+    EndTime: 0
+  - StartTime: 117528
+    Lane: 4
+    EndTime: 0
+  - StartTime: 117528
+    Lane: 1
+    EndTime: 0
+  - StartTime: 117613
+    Lane: 2
+    EndTime: 0
+  - StartTime: 117698
+    Lane: 3
+    EndTime: 0
+  - StartTime: 117782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 117867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 117952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 118037
+    Lane: 3
+    EndTime: 0
+  - StartTime: 118037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 118037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 118121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 118206
+    Lane: 1
+    EndTime: 0
+  - StartTime: 118291
+    Lane: 4
+    EndTime: 0
+  - StartTime: 118376
+    Lane: 1
+    EndTime: 0
+  - StartTime: 118376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 118460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 118545
+    Lane: 1
+    EndTime: 0
+  - StartTime: 118545
+    Lane: 3
+    EndTime: 0
+  - StartTime: 118630
+    Lane: 2
+    EndTime: 0
+  - StartTime: 118715
+    Lane: 3
+    EndTime: 0
+  - StartTime: 118715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 118799
+    Lane: 1
+    EndTime: 0
+  - StartTime: 118884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 118884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 118969
+    Lane: 1
+    EndTime: 0
+  - StartTime: 119054
+    Lane: 4
+    EndTime: 0
+  - StartTime: 119054
+    Lane: 2
+    EndTime: 0
+  - StartTime: 119138
+    Lane: 3
+    EndTime: 0
+  - StartTime: 119223
+    Lane: 4
+    EndTime: 0
+  - StartTime: 119223
+    Lane: 2
+    EndTime: 0
+  - StartTime: 119308
+    Lane: 3
+    EndTime: 0
+  - StartTime: 119393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 119393
+    Lane: 2
+    EndTime: 0
+  - StartTime: 119477
+    Lane: 4
+    EndTime: 0
+  - StartTime: 119562
+    Lane: 2
+    EndTime: 0
+  - StartTime: 119562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 119647
+    Lane: 1
+    EndTime: 0
+  - StartTime: 119732
+    Lane: 2
+    EndTime: 0
+  - StartTime: 119732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 119732
+    Lane: 3
+    EndTime: 0
+  - StartTime: 119901
+    Lane: 4
+    EndTime: 0
+  - StartTime: 119901
+    Lane: 3
+    EndTime: 0
+  - StartTime: 119986
+    Lane: 2
+    EndTime: 0
+  - StartTime: 120155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 120240
+    Lane: 4
+    EndTime: 0
+  - StartTime: 120240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 120410
+    Lane: 1
+    EndTime: 0
+  - StartTime: 120579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 120579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 120664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 120748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 120833
+    Lane: 1
+    EndTime: 0
+  - StartTime: 120918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 120918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 121087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 121257
+    Lane: 1
+    EndTime: 0
+  - StartTime: 121257
+    Lane: 4
+    EndTime: 0
+  - StartTime: 121426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 121511
+    Lane: 1
+    EndTime: 0
+  - StartTime: 121596
+    Lane: 4
+    EndTime: 0
+  - StartTime: 121596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 121765
+    Lane: 1
+    EndTime: 0
+  - StartTime: 121935
+    Lane: 4
+    EndTime: 0
+  - StartTime: 121935
+    Lane: 2
+    EndTime: 0
+  - StartTime: 122020
+    Lane: 3
+    EndTime: 0
+  - StartTime: 122104
+    Lane: 2
+    EndTime: 0
+  - StartTime: 122189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 122274
+    Lane: 4
+    EndTime: 0
+  - StartTime: 122274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 122443
+    Lane: 4
+    EndTime: 0
+  - StartTime: 122443
+    Lane: 2
+    EndTime: 122782
+  - StartTime: 122613
+    Lane: 1
+    EndTime: 0
+  - StartTime: 122613
+    Lane: 3
+    EndTime: 0
+  - StartTime: 122782
+    Lane: 4
+    EndTime: 0
+  - StartTime: 122867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 122952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 122952
+    Lane: 4
+    EndTime: 0
+  - StartTime: 123121
+    Lane: 1
+    EndTime: 0
+  - StartTime: 123291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 123291
+    Lane: 3
+    EndTime: 0
+  - StartTime: 123376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 123460
+    Lane: 1
+    EndTime: 0
+  - StartTime: 123545
+    Lane: 3
+    EndTime: 0
+  - StartTime: 123630
+    Lane: 2
+    EndTime: 0
+  - StartTime: 123630
+    Lane: 4
+    EndTime: 0
+  - StartTime: 123799
+    Lane: 1
+    EndTime: 0
+  - StartTime: 123799
+    Lane: 3
+    EndTime: 124138
+  - StartTime: 123969
+    Lane: 2
+    EndTime: 124138
+  - StartTime: 124138
+    Lane: 4
+    EndTime: 0
+  - StartTime: 124138
+    Lane: 1
+    EndTime: 124477
+  - StartTime: 124308
+    Lane: 3
+    EndTime: 124477
+  - StartTime: 124477
+    Lane: 4
+    EndTime: 0
+  - StartTime: 124477
+    Lane: 2
+    EndTime: 124816
+  - StartTime: 124647
+    Lane: 1
+    EndTime: 124816
+  - StartTime: 124816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 124816
+    Lane: 4
+    EndTime: 125155
+  - StartTime: 124986
+    Lane: 3
+    EndTime: 125155
+  - StartTime: 125155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 125155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 125240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 125325
+    Lane: 4
+    EndTime: 0
+  - StartTime: 125325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 125410
+    Lane: 2
+    EndTime: 0
+  - StartTime: 125494
+    Lane: 3
+    EndTime: 0
+  - StartTime: 125494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 125579
+    Lane: 2
+    EndTime: 0
+  - StartTime: 125664
+    Lane: 4
+    EndTime: 0
+  - StartTime: 125664
+    Lane: 1
+    EndTime: 0
+  - StartTime: 125748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 125833
+    Lane: 3
+    EndTime: 0
+  - StartTime: 125833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 125918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126003
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 126087
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 126172
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126342
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126342
+    Lane: 1
+    EndTime: 0
+  - StartTime: 126426
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126511
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126511
+    Lane: 3
+    EndTime: 0
+  - StartTime: 126596
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126681
+    Lane: 1
+    EndTime: 0
+  - StartTime: 126681
+    Lane: 4
+    EndTime: 0
+  - StartTime: 126765
+    Lane: 3
+    EndTime: 0
+  - StartTime: 126850
+    Lane: 2
+    EndTime: 0
+  - StartTime: 126850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 126935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127020
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127020
+    Lane: 4
+    EndTime: 0
+  - StartTime: 127104
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127189
+    Lane: 2
+    EndTime: 0
+  - StartTime: 127189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127359
+    Lane: 4
+    EndTime: 0
+  - StartTime: 127443
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127528
+    Lane: 2
+    EndTime: 0
+  - StartTime: 127528
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127613
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127698
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127698
+    Lane: 4
+    EndTime: 0
+  - StartTime: 127782
+    Lane: 3
+    EndTime: 0
+  - StartTime: 127867
+    Lane: 1
+    EndTime: 0
+  - StartTime: 127867
+    Lane: 4
+    EndTime: 0
+  - StartTime: 127867
+    Lane: 2
+    EndTime: 0
+  - StartTime: 127952
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128037
+    Lane: 4
+    EndTime: 0
+  - StartTime: 128121
+    Lane: 2
+    EndTime: 0
+  - StartTime: 128206
+    Lane: 4
+    EndTime: 0
+  - StartTime: 128206
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128291
+    Lane: 2
+    EndTime: 0
+  - StartTime: 128376
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128376
+    Lane: 4
+    EndTime: 0
+  - StartTime: 128376
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 128545
+    Lane: 4
+    EndTime: 0
+  - StartTime: 128545
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128630
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128715
+    Lane: 2
+    EndTime: 0
+  - StartTime: 128715
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128799
+    Lane: 3
+    EndTime: 0
+  - StartTime: 128884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 128884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 128884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 128969
+    Lane: 3
+    EndTime: 0
+  - StartTime: 129054
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129138
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129223
+    Lane: 1
+    EndTime: 0
+  - StartTime: 129223
+    Lane: 3
+    EndTime: 0
+  - StartTime: 129223
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 129393
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129477
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129562
+    Lane: 1
+    EndTime: 0
+  - StartTime: 129562
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129647
+    Lane: 3
+    EndTime: 0
+  - StartTime: 129732
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129732
+    Lane: 1
+    EndTime: 0
+  - StartTime: 129732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 129816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 129901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 129901
+    Lane: 1
+    EndTime: 0
+  - StartTime: 129986
+    Lane: 3
+    EndTime: 0
+  - StartTime: 130071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 130071
+    Lane: 4
+    EndTime: 0
+  - StartTime: 130155
+    Lane: 2
+    EndTime: 0
+  - StartTime: 130240
+    Lane: 3
+    EndTime: 0
+  - StartTime: 130240
+    Lane: 4
+    EndTime: 0
+  - StartTime: 130325
+    Lane: 2
+    EndTime: 0
+  - StartTime: 130325
+    Lane: 1
+    EndTime: 0
+  - StartTime: 130410
+    Lane: 3
+    EndTime: 0
+  - StartTime: 130410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 130494
+    Lane: 2
+    EndTime: 0
+  - StartTime: 130579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 130579
+    Lane: 1
+    EndTime: 0
+  - StartTime: 130579
+    Lane: 4
+    EndTime: 131935
+  - StartTime: 130748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 130918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 131087
+    Lane: 1
+    EndTime: 0
+  - StartTime: 131257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 131426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 131596
+    Lane: 2
+    EndTime: 0
+  - StartTime: 131652
+    Lane: 1
+    EndTime: 0
+  - StartTime: 131737
+    Lane: 3
+    EndTime: 0
+  - StartTime: 131822
+    Lane: 2
+    EndTime: 0
+  - StartTime: 131935
+    Lane: 1
+    EndTime: 0
+  - StartTime: 131935
+    Lane: 3
+    EndTime: 0
+  - StartTime: 132104
+    Lane: 2
+    EndTime: 0
+  - StartTime: 132104
+    Lane: 4
+    EndTime: 0
+  - StartTime: 132104
+    Lane: 1
+    EndTime: 132274
+  - StartTime: 132274
+    Lane: 3
+    EndTime: 0
+  - StartTime: 132443
+    Lane: 1
+    EndTime: 0
+  - StartTime: 132613
+    Lane: 2
+    EndTime: 0
+  - StartTime: 132782
+    Lane: 3
+    EndTime: 0
+  - StartTime: 132952
+    Lane: 4
+    EndTime: 0
+  - StartTime: 133037
+    Lane: 3
+    EndTime: 0
+  - StartTime: 133121
+    Lane: 1
+    EndTime: 0
+  - StartTime: 133206
+    Lane: 2
+    EndTime: 0
+  - StartTime: 133291
+    Lane: 4
+    EndTime: 0
+  - StartTime: 133291
+    Lane: 3
+    EndTime: 134647
+  - StartTime: 133291
+    Lane: 1
+    EndTime: 0
+  - StartTime: 133460
+    Lane: 2
+    EndTime: 0
+  - StartTime: 133630
+    Lane: 4
+    EndTime: 0
+  - StartTime: 133799
+    Lane: 1
+    EndTime: 0
+  - StartTime: 133969
+    Lane: 2
+    EndTime: 0
+  - StartTime: 134138
+    Lane: 4
+    EndTime: 0
+  - StartTime: 134308
+    Lane: 2
+    EndTime: 0
+  - StartTime: 134393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 134477
+    Lane: 4
+    EndTime: 0
+  - StartTime: 134562
+    Lane: 2
+    EndTime: 0
+  - StartTime: 134647
+    Lane: 1
+    EndTime: 0
+  - StartTime: 134647
+    Lane: 4
+    EndTime: 0
+  - StartTime: 134816
+    Lane: 2
+    EndTime: 0
+  - StartTime: 134816
+    Lane: 1
+    EndTime: 134986
+  - StartTime: 134816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 134986
+    Lane: 4
+    EndTime: 0
+  - StartTime: 135155
+    Lane: 1
+    EndTime: 0
+  - StartTime: 135325
+    Lane: 2
+    EndTime: 0
+  - StartTime: 135494
+    Lane: 4
+    EndTime: 0
+  - StartTime: 135664
+    Lane: 3
+    EndTime: 0
+  - StartTime: 135748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 135833
+    Lane: 4
+    EndTime: 0
+  - StartTime: 135918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 136003
+    Lane: 2
+    EndTime: 0
+  - StartTime: 136003
+    Lane: 1
+    EndTime: 0
+  - StartTime: 136003
+    Lane: 4
+    EndTime: 0
+  - StartTime: 136172
+    Lane: 3
+    EndTime: 0
+  - StartTime: 136342
+    Lane: 2
+    EndTime: 0
+  - StartTime: 136426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 136511
+    Lane: 4
+    EndTime: 0
+  - StartTime: 136596
+    Lane: 3
+    EndTime: 0
+  - StartTime: 136681
+    Lane: 2
+    EndTime: 0
+  - StartTime: 136850
+    Lane: 1
+    EndTime: 0
+  - StartTime: 137020
+    Lane: 4
+    EndTime: 0
+  - StartTime: 137104
+    Lane: 3
+    EndTime: 0
+  - StartTime: 137189
+    Lane: 1
+    EndTime: 0
+  - StartTime: 137274
+    Lane: 2
+    EndTime: 0
+  - StartTime: 137359
+    Lane: 4
+    EndTime: 0
+  - StartTime: 137359
+    Lane: 3
+    EndTime: 0
+  - StartTime: 137359
+    Lane: 1
+    EndTime: 0
+  - StartTime: 137528
+    Lane: 2
+    EndTime: 0
+  - StartTime: 137698
+    Lane: 1
+    EndTime: 0
+  - StartTime: 137782
+    Lane: 2
+    EndTime: 0
+  - StartTime: 137867
+    Lane: 3
+    EndTime: 0
+  - StartTime: 137952
+    Lane: 2
+    EndTime: 0
+  - StartTime: 138037
+    Lane: 1
+    EndTime: 0
+  - StartTime: 138206
+    Lane: 4
+    EndTime: 0
+  - StartTime: 138376
+    Lane: 2
+    EndTime: 0
+  - StartTime: 138460
+    Lane: 3
+    EndTime: 0
+  - StartTime: 138545
+    Lane: 1
+    EndTime: 0
+  - StartTime: 138630
+    Lane: 2
+    EndTime: 0
+  - StartTime: 138715
+    Lane: 3
+    EndTime: 0
+  - StartTime: 138715
+    Lane: 4
+    EndTime: 0
+  - StartTime: 138715
+    Lane: 1
+    EndTime: 0
+  - StartTime: 138884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 139054
+    Lane: 2
+    EndTime: 0
+  - StartTime: 139054
+    Lane: 3
+    EndTime: 0
+  - StartTime: 139054
+    Lane: 4
+    EndTime: 0
+  - StartTime: 139223
+    Lane: 2
+    EndTime: 0
+  - StartTime: 139393
+    Lane: 1
+    EndTime: 0
+  - StartTime: 139393
+    Lane: 3
+    EndTime: 0
+  - StartTime: 139393
+    Lane: 4
+    EndTime: 0
+  - StartTime: 139562
+    Lane: 2
+    EndTime: 0
+  - StartTime: 139562
+    Lane: 3
+    EndTime: 0
+  - StartTime: 139732
+    Lane: 1
+    EndTime: 0
+  - StartTime: 139732
+    Lane: 2
+    EndTime: 0
+  - StartTime: 139732
+    Lane: 4
+    EndTime: 0
+  - StartTime: 139816
+    Lane: 3
+    EndTime: 0
+  - StartTime: 139901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 139986
+    Lane: 3
+    EndTime: 0
+  - StartTime: 140071
+    Lane: 1
+    EndTime: 0
+  - StartTime: 140071
+    Lane: 2
+    EndTime: 0
+  - StartTime: 140071
+    Lane: 4
+    EndTime: 0
+  - StartTime: 140240
+    Lane: 1
+    EndTime: 0
+  - StartTime: 140240
+    Lane: 2
+    EndTime: 0
+  - StartTime: 140410
+    Lane: 1
+    EndTime: 0
+  - StartTime: 140410
+    Lane: 3
+    EndTime: 0
+  - StartTime: 140410
+    Lane: 4
+    EndTime: 0
+  - StartTime: 140579
+    Lane: 3
+    EndTime: 0
+  - StartTime: 140579
+    Lane: 4
+    EndTime: 0
+  - StartTime: 140748
+    Lane: 2
+    EndTime: 0
+  - StartTime: 140748
+    Lane: 1
+    EndTime: 0
+  - StartTime: 140748
+    Lane: 4
+    EndTime: 0
+  - StartTime: 140918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 140918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 141087
+    Lane: 1
+    EndTime: 0
+  - StartTime: 141087
+    Lane: 3
+    EndTime: 0
+  - StartTime: 141087
+    Lane: 4
+    EndTime: 0
+  - StartTime: 141257
+    Lane: 3
+    EndTime: 0
+  - StartTime: 141257
+    Lane: 2
+    EndTime: 0
+  - StartTime: 141426
+    Lane: 1
+    EndTime: 0
+  - StartTime: 141426
+    Lane: 3
+    EndTime: 0
+  - StartTime: 141426
+    Lane: 2
+    EndTime: 146918
+  - StartTime: 141426
+    Lane: 4
+    EndTime: 144436
+  - StartTime: 144436
+    Lane: 3
+    EndTime: 147746
+  - StartTime: 144436
+    Lane: 1
+    EndTime: 149401
+  - StartTime: 147746
+    Lane: 4
+    EndTime: 0
+  - StartTime: 147953
+    Lane: 3
+    EndTime: 0
+  - StartTime: 148160
+    Lane: 2
+    EndTime: 0
+  - StartTime: 148367
+    Lane: 4
+    EndTime: 0
+  - StartTime: 148573
+    Lane: 3
+    EndTime: 0
+  - StartTime: 148780
+    Lane: 2
+    EndTime: 0
+  - StartTime: 148987
+    Lane: 4
+    EndTime: 0
+  - StartTime: 149194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 149401
+    Lane: 2
+    EndTime: 0
+  - StartTime: 149815
+    Lane: 3
+    EndTime: 0
+  - StartTime: 150022
+    Lane: 4
+    EndTime: 0
+  - StartTime: 150229
+    Lane: 2
+    EndTime: 0
+  - StartTime: 150436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 150642
+    Lane: 3
+    EndTime: 0
+  - StartTime: 150849
+    Lane: 2
+    EndTime: 0
+  - StartTime: 151056
+    Lane: 4
+    EndTime: 0
+  - StartTime: 151263
+    Lane: 3
+    EndTime: 0
+  - StartTime: 151470
+    Lane: 1
+    EndTime: 0
+  - StartTime: 151677
+    Lane: 3
+    EndTime: 0
+  - StartTime: 151884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 152091
+    Lane: 1
+    EndTime: 0
+  - StartTime: 152298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 152504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 152711
+    Lane: 4
+    EndTime: 0
+  - StartTime: 153125
+    Lane: 2
+    EndTime: 0
+  - StartTime: 153332
+    Lane: 3
+    EndTime: 0
+  - StartTime: 153539
+    Lane: 2
+    EndTime: 0
+  - StartTime: 153746
+    Lane: 1
+    EndTime: 0
+  - StartTime: 153953
+    Lane: 3
+    EndTime: 0
+  - StartTime: 154160
+    Lane: 1
+    EndTime: 0
+  - StartTime: 154367
+    Lane: 4
+    EndTime: 0
+  - StartTime: 154573
+    Lane: 3
+    EndTime: 0
+  - StartTime: 154780
+    Lane: 2
+    EndTime: 0
+  - StartTime: 154987
+    Lane: 4
+    EndTime: 0
+  - StartTime: 155194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 155401
+    Lane: 1
+    EndTime: 0
+  - StartTime: 155608
+    Lane: 4
+    EndTime: 0
+  - StartTime: 155815
+    Lane: 2
+    EndTime: 0
+  - StartTime: 156022
+    Lane: 3
+    EndTime: 0
+  - StartTime: 156436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 156642
+    Lane: 4
+    EndTime: 0
+  - StartTime: 156849
+    Lane: 2
+    EndTime: 0
+  - StartTime: 157056
+    Lane: 1
+    EndTime: 0
+  - StartTime: 157263
+    Lane: 4
+    EndTime: 0
+  - StartTime: 157470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 157677
+    Lane: 4
+    EndTime: 0
+  - StartTime: 157884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 158091
+    Lane: 1
+    EndTime: 0
+  - StartTime: 158298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 158504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 158711
+    Lane: 1
+    EndTime: 0
+  - StartTime: 158918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 159125
+    Lane: 3
+    EndTime: 0
+  - StartTime: 159332
+    Lane: 4
+    EndTime: 0
+  - StartTime: 159539
+    Lane: 2
+    EndTime: 0
+  - StartTime: 159746
+    Lane: 1
+    EndTime: 0
+  - StartTime: 159953
+    Lane: 4
+    EndTime: 0
+  - StartTime: 160160
+    Lane: 2
+    EndTime: 0
+  - StartTime: 160367
+    Lane: 1
+    EndTime: 0
+  - StartTime: 160573
+    Lane: 4
+    EndTime: 0
+  - StartTime: 160780
+    Lane: 3
+    EndTime: 0
+  - StartTime: 160987
+    Lane: 2
+    EndTime: 162642
+  - StartTime: 161194
+    Lane: 4
+    EndTime: 0
+  - StartTime: 161401
+    Lane: 1
+    EndTime: 0
+  - StartTime: 161608
+    Lane: 3
+    EndTime: 0
+  - StartTime: 161815
+    Lane: 4
+    EndTime: 0
+  - StartTime: 162022
+    Lane: 1
+    EndTime: 0
+  - StartTime: 162229
+    Lane: 3
+    EndTime: 0
+  - StartTime: 162436
+    Lane: 4
+    EndTime: 0
+  - StartTime: 162642
+    Lane: 3
+    EndTime: 163470
+  - StartTime: 162849
+    Lane: 2
+    EndTime: 0
+  - StartTime: 163056
+    Lane: 1
+    EndTime: 0
+  - StartTime: 163263
+    Lane: 4
+    EndTime: 0
+  - StartTime: 163470
+    Lane: 2
+    EndTime: 164298
+  - StartTime: 163677
+    Lane: 1
+    EndTime: 0
+  - StartTime: 163884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 164091
+    Lane: 3
+    EndTime: 0
+  - StartTime: 164298
+    Lane: 1
+    EndTime: 167608
+  - StartTime: 164298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 164504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 164711
+    Lane: 2
+    EndTime: 0
+  - StartTime: 164918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 165125
+    Lane: 3
+    EndTime: 0
+  - StartTime: 165332
+    Lane: 2
+    EndTime: 0
+  - StartTime: 165539
+    Lane: 4
+    EndTime: 0
+  - StartTime: 165746
+    Lane: 2
+    EndTime: 0
+  - StartTime: 165953
+    Lane: 4
+    EndTime: 0
+  - StartTime: 166160
+    Lane: 3
+    EndTime: 0
+  - StartTime: 166367
+    Lane: 2
+    EndTime: 0
+  - StartTime: 166573
+    Lane: 4
+    EndTime: 0
+  - StartTime: 166780
+    Lane: 3
+    EndTime: 0
+  - StartTime: 166987
+    Lane: 2
+    EndTime: 0
+  - StartTime: 167194
+    Lane: 4
+    EndTime: 0
+  - StartTime: 167401
+    Lane: 3
+    EndTime: 0
+  - StartTime: 167608
+    Lane: 2
+    EndTime: 0
+  - StartTime: 167608
+    Lane: 4
+    EndTime: 169263
+  - StartTime: 169263
+    Lane: 3
+    EndTime: 169884
+  - StartTime: 169263
+    Lane: 1
+    EndTime: 0
+  - StartTime: 169884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 169987
+    Lane: 3
+    EndTime: 0
+  - StartTime: 170091
+    Lane: 2
+    EndTime: 170918
+  - StartTime: 170918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 170918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 170996
+    Lane: 3
+    EndTime: 174229
+  - StartTime: 172573
+    Lane: 1
+    EndTime: 0
+  - StartTime: 173608
+    Lane: 1
+    EndTime: 0
+  - StartTime: 173815
+    Lane: 1
+    EndTime: 0
+  - StartTime: 173815
+    Lane: 2
+    EndTime: 0
+  - StartTime: 174229
+    Lane: 1
+    EndTime: 0
+  - StartTime: 174229
+    Lane: 2
+    EndTime: 0
+  - StartTime: 174229
+    Lane: 4
+    EndTime: 0
+  - StartTime: 174642
+    Lane: 4
+    EndTime: 0
+  - StartTime: 174642
+    Lane: 2
+    EndTime: 0
+  - StartTime: 174849
+    Lane: 1
+    EndTime: 0
+  - StartTime: 175056
+    Lane: 4
+    EndTime: 0
+  - StartTime: 175263
+    Lane: 1
+    EndTime: 0
+  - StartTime: 175470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 175470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 175884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 175884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 176091
+    Lane: 3
+    EndTime: 0
+  - StartTime: 176298
+    Lane: 2
+    EndTime: 0
+  - StartTime: 176298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 176711
+    Lane: 1
+    EndTime: 0
+  - StartTime: 176711
+    Lane: 2
+    EndTime: 0
+  - StartTime: 176918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 177125
+    Lane: 2
+    EndTime: 0
+  - StartTime: 177125
+    Lane: 4
+    EndTime: 0
+  - StartTime: 177332
+    Lane: 1
+    EndTime: 0
+  - StartTime: 177539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 177539
+    Lane: 4
+    EndTime: 180436
+  - StartTime: 177953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 177953
+    Lane: 3
+    EndTime: 0
+  - StartTime: 178160
+    Lane: 1
+    EndTime: 0
+  - StartTime: 178367
+    Lane: 3
+    EndTime: 0
+  - StartTime: 178573
+    Lane: 1
+    EndTime: 0
+  - StartTime: 178780
+    Lane: 2
+    EndTime: 0
+  - StartTime: 178780
+    Lane: 3
+    EndTime: 0
+  - StartTime: 179194
+    Lane: 1
+    EndTime: 0
+  - StartTime: 179194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 179401
+    Lane: 1
+    EndTime: 0
+  - StartTime: 179608
+    Lane: 2
+    EndTime: 0
+  - StartTime: 179608
+    Lane: 3
+    EndTime: 0
+  - StartTime: 180022
+    Lane: 1
+    EndTime: 0
+  - StartTime: 180022
+    Lane: 3
+    EndTime: 0
+  - StartTime: 180229
+    Lane: 1
+    EndTime: 0
+  - StartTime: 180436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 180436
+    Lane: 3
+    EndTime: 0
+  - StartTime: 180642
+    Lane: 1
+    EndTime: 0
+  - StartTime: 180849
+    Lane: 1
+    EndTime: 0
+  - StartTime: 180849
+    Lane: 3
+    EndTime: 0
+  - StartTime: 180849
+    Lane: 4
+    EndTime: 0
+  - StartTime: 181263
+    Lane: 4
+    EndTime: 0
+  - StartTime: 181263
+    Lane: 3
+    EndTime: 0
+  - StartTime: 181470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 181677
+    Lane: 1
+    EndTime: 0
+  - StartTime: 181884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 182091
+    Lane: 3
+    EndTime: 0
+  - StartTime: 182091
+    Lane: 4
+    EndTime: 0
+  - StartTime: 182504
+    Lane: 1
+    EndTime: 0
+  - StartTime: 182504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 182711
+    Lane: 2
+    EndTime: 0
+  - StartTime: 182918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 182918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 183125
+    Lane: 4
+    EndTime: 183229
+  - StartTime: 183229
+    Lane: 3
+    EndTime: 183332
+  - StartTime: 183332
+    Lane: 2
+    EndTime: 184160
+  - StartTime: 183332
+    Lane: 1
+    EndTime: 0
+  - StartTime: 183539
+    Lane: 1
+    EndTime: 0
+  - StartTime: 183746
+    Lane: 4
+    EndTime: 0
+  - StartTime: 183746
+    Lane: 3
+    EndTime: 0
+  - StartTime: 183953
+    Lane: 1
+    EndTime: 0
+  - StartTime: 184160
+    Lane: 4
+    EndTime: 187470
+  - StartTime: 184160
+    Lane: 1
+    EndTime: 0
+  - StartTime: 184573
+    Lane: 2
+    EndTime: 0
+  - StartTime: 184573
+    Lane: 3
+    EndTime: 0
+  - StartTime: 184780
+    Lane: 1
+    EndTime: 0
+  - StartTime: 184987
+    Lane: 3
+    EndTime: 0
+  - StartTime: 185194
+    Lane: 1
+    EndTime: 0
+  - StartTime: 185401
+    Lane: 1
+    EndTime: 0
+  - StartTime: 185401
+    Lane: 3
+    EndTime: 0
+  - StartTime: 185608
+    Lane: 2
+    EndTime: 0
+  - StartTime: 185815
+    Lane: 1
+    EndTime: 0
+  - StartTime: 186022
+    Lane: 2
+    EndTime: 0
+  - StartTime: 186022
+    Lane: 3
+    EndTime: 0
+  - StartTime: 186229
+    Lane: 2
+    EndTime: 0
+  - StartTime: 186229
+    Lane: 3
+    EndTime: 0
+  - StartTime: 186436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 186642
+    Lane: 1
+    EndTime: 0
+  - StartTime: 186642
+    Lane: 3
+    EndTime: 0
+  - StartTime: 186849
+    Lane: 3
+    EndTime: 0
+  - StartTime: 186953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 187056
+    Lane: 1
+    EndTime: 0
+  - StartTime: 187056
+    Lane: 3
+    EndTime: 0
+  - StartTime: 187263
+    Lane: 3
+    EndTime: 0
+  - StartTime: 187367
+    Lane: 2
+    EndTime: 0
+  - StartTime: 187470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 187470
+    Lane: 1
+    EndTime: 0
+  - StartTime: 187677
+    Lane: 4
+    EndTime: 0
+  - StartTime: 187884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 188091
+    Lane: 2
+    EndTime: 0
+  - StartTime: 188091
+    Lane: 1
+    EndTime: 0
+  - StartTime: 188298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 188298
+    Lane: 3
+    EndTime: 0
+  - StartTime: 188504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 188711
+    Lane: 1
+    EndTime: 0
+  - StartTime: 188918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 188918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 189125
+    Lane: 3
+    EndTime: 0
+  - StartTime: 189125
+    Lane: 1
+    EndTime: 0
+  - StartTime: 189332
+    Lane: 4
+    EndTime: 0
+  - StartTime: 189539
+    Lane: 2
+    EndTime: 0
+  - StartTime: 189746
+    Lane: 3
+    EndTime: 0
+  - StartTime: 189746
+    Lane: 1
+    EndTime: 0
+  - StartTime: 189953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 189953
+    Lane: 4
+    EndTime: 0
+  - StartTime: 190160
+    Lane: 3
+    EndTime: 0
+  - StartTime: 190160
+    Lane: 2
+    EndTime: 0
+  - StartTime: 190367
+    Lane: 1
+    EndTime: 0
+  - StartTime: 190367
+    Lane: 3
+    EndTime: 0
+  - StartTime: 190573
+    Lane: 2
+    EndTime: 0
+  - StartTime: 190573
+    Lane: 1
+    EndTime: 0
+  - StartTime: 190780
+    Lane: 1
+    EndTime: 0
+  - StartTime: 190780
+    Lane: 4
+    EndTime: 191608
+  - StartTime: 190987
+    Lane: 3
+    EndTime: 0
+  - StartTime: 191194
+    Lane: 2
+    EndTime: 0
+  - StartTime: 191194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 191401
+    Lane: 1
+    EndTime: 191504
+  - StartTime: 191504
+    Lane: 2
+    EndTime: 191608
+  - StartTime: 191608
+    Lane: 3
+    EndTime: 192436
+  - StartTime: 191815
+    Lane: 1
+    EndTime: 0
+  - StartTime: 192022
+    Lane: 2
+    EndTime: 0
+  - StartTime: 192022
+    Lane: 4
+    EndTime: 0
+  - StartTime: 192229
+    Lane: 1
+    EndTime: 192332
+  - StartTime: 192332
+    Lane: 2
+    EndTime: 192436
+  - StartTime: 192436
+    Lane: 4
+    EndTime: 193263
+  - StartTime: 192642
+    Lane: 3
+    EndTime: 0
+  - StartTime: 192849
+    Lane: 2
+    EndTime: 0
+  - StartTime: 192849
+    Lane: 1
+    EndTime: 0
+  - StartTime: 193056
+    Lane: 3
+    EndTime: 193160
+  - StartTime: 193160
+    Lane: 2
+    EndTime: 193263
+  - StartTime: 193263
+    Lane: 1
+    EndTime: 193987
+  - StartTime: 193470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 193470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 193677
+    Lane: 4
+    EndTime: 193987
+  - StartTime: 193677
+    Lane: 2
+    EndTime: 0
+  - StartTime: 194091
+    Lane: 1
+    EndTime: 0
+  - StartTime: 194091
+    Lane: 3
+    EndTime: 0
+  - StartTime: 194091
+    Lane: 4
+    EndTime: 0
+  - StartTime: 194298
+    Lane: 2
+    EndTime: 0
+  - StartTime: 194504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 194711
+    Lane: 4
+    EndTime: 0
+  - StartTime: 194711
+    Lane: 3
+    EndTime: 0
+  - StartTime: 194918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 194918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 195125
+    Lane: 1
+    EndTime: 0
+  - StartTime: 195332
+    Lane: 2
+    EndTime: 0
+  - StartTime: 195539
+    Lane: 1
+    EndTime: 0
+  - StartTime: 195539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 195746
+    Lane: 3
+    EndTime: 0
+  - StartTime: 195746
+    Lane: 4
+    EndTime: 0
+  - StartTime: 195953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 196160
+    Lane: 1
+    EndTime: 0
+  - StartTime: 196160
+    Lane: 3
+    EndTime: 0
+  - StartTime: 196367
+    Lane: 4
+    EndTime: 0
+  - StartTime: 196367
+    Lane: 3
+    EndTime: 0
+  - StartTime: 196573
+    Lane: 2
+    EndTime: 0
+  - StartTime: 196573
+    Lane: 1
+    EndTime: 0
+  - StartTime: 196780
+    Lane: 2
+    EndTime: 0
+  - StartTime: 196780
+    Lane: 4
+    EndTime: 0
+  - StartTime: 196987
+    Lane: 3
+    EndTime: 0
+  - StartTime: 196987
+    Lane: 1
+    EndTime: 0
+  - StartTime: 197194
+    Lane: 1
+    EndTime: 0
+  - StartTime: 197194
+    Lane: 4
+    EndTime: 0
+  - StartTime: 197401
+    Lane: 3
+    EndTime: 0
+  - StartTime: 197401
+    Lane: 2
+    EndTime: 197815
+  - StartTime: 197815
+    Lane: 4
+    EndTime: 0
+  - StartTime: 197815
+    Lane: 3
+    EndTime: 198229
+  - StartTime: 198229
+    Lane: 4
+    EndTime: 0
+  - StartTime: 198229
+    Lane: 1
+    EndTime: 198642
+  - StartTime: 198642
+    Lane: 3
+    EndTime: 0
+  - StartTime: 198642
+    Lane: 2
+    EndTime: 199056
+  - StartTime: 198849
+    Lane: 4
+    EndTime: 0
+  - StartTime: 198953
+    Lane: 1
+    EndTime: 0
+  - StartTime: 199056
+    Lane: 3
+    EndTime: 0
+  - StartTime: 199056
+    Lane: 4
+    EndTime: 0
+  - StartTime: 199263
+    Lane: 2
+    EndTime: 0
+  - StartTime: 199263
+    Lane: 4
+    EndTime: 0
+  - StartTime: 199470
+    Lane: 1
+    EndTime: 0
+  - StartTime: 199470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 199677
+    Lane: 1
+    EndTime: 0
+  - StartTime: 199677
+    Lane: 3
+    EndTime: 0
+  - StartTime: 199884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 199884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200091
+    Lane: 2
+    EndTime: 0
+  - StartTime: 200091
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200298
+    Lane: 1
+    EndTime: 0
+  - StartTime: 200298
+    Lane: 3
+    EndTime: 0
+  - StartTime: 200349
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 200711
+    Lane: 1
+    EndTime: 0
+  - StartTime: 200711
+    Lane: 2
+    EndTime: 0
+  - StartTime: 200711
+    Lane: 4
+    EndTime: 0
+  - StartTime: 200815
+    Lane: 3
+    EndTime: 0
+  - StartTime: 200918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 201022
+    Lane: 3
+    EndTime: 0
+  - StartTime: 201125
+    Lane: 1
+    EndTime: 0
+  - StartTime: 201125
+    Lane: 2
+    EndTime: 0
+  - StartTime: 201229
+    Lane: 4
+    EndTime: 0
+  - StartTime: 201332
+    Lane: 3
+    EndTime: 0
+  - StartTime: 201436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 201539
+    Lane: 4
+    EndTime: 0
+  - StartTime: 201539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 201642
+    Lane: 1
+    EndTime: 0
+  - StartTime: 201746
+    Lane: 2
+    EndTime: 0
+  - StartTime: 201849
+    Lane: 3
+    EndTime: 0
+  - StartTime: 201953
+    Lane: 1
+    EndTime: 0
+  - StartTime: 201953
+    Lane: 4
+    EndTime: 0
+  - StartTime: 202056
+    Lane: 3
+    EndTime: 0
+  - StartTime: 202160
+    Lane: 2
+    EndTime: 0
+  - StartTime: 202263
+    Lane: 3
+    EndTime: 0
+  - StartTime: 202367
+    Lane: 4
+    EndTime: 0
+  - StartTime: 202367
+    Lane: 2
+    EndTime: 0
+  - StartTime: 202470
+    Lane: 1
+    EndTime: 0
+  - StartTime: 202573
+    Lane: 3
+    EndTime: 0
+  - StartTime: 202677
+    Lane: 2
+    EndTime: 0
+  - StartTime: 202780
+    Lane: 1
+    EndTime: 0
+  - StartTime: 202780
+    Lane: 3
+    EndTime: 0
+  - StartTime: 202884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 202987
+    Lane: 3
+    EndTime: 0
+  - StartTime: 203091
+    Lane: 2
+    EndTime: 0
+  - StartTime: 203194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 203194
+    Lane: 4
+    EndTime: 0
+  - StartTime: 203298
+    Lane: 2
+    EndTime: 0
+  - StartTime: 203401
+    Lane: 1
+    EndTime: 0
+  - StartTime: 203470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 203539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 203608
+    Lane: 4
+    EndTime: 0
+  - StartTime: 203608
+    Lane: 1
+    EndTime: 204022
+  - StartTime: 204022
+    Lane: 4
+    EndTime: 0
+  - StartTime: 204125
+    Lane: 2
+    EndTime: 0
+  - StartTime: 204203
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204280
+    Lane: 1
+    EndTime: 0
+  - StartTime: 204358
+    Lane: 2
+    EndTime: 0
+  - StartTime: 204436
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204487
+    Lane: 4
+    EndTime: 0
+  - StartTime: 204591
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204668
+    Lane: 2
+    EndTime: 0
+  - StartTime: 204746
+    Lane: 1
+    EndTime: 0
+  - StartTime: 204823
+    Lane: 3
+    EndTime: 0
+  - StartTime: 204901
+    Lane: 2
+    EndTime: 0
+  - StartTime: 204953
+    Lane: 3
+    EndTime: 0
+  - StartTime: 205004
+    Lane: 4
+    EndTime: 0
+  - StartTime: 205082
+    Lane: 2
+    EndTime: 0
+  - StartTime: 205186
+    Lane: 1
+    EndTime: 0
+  - StartTime: 205211
+    Lane: 2
+    EndTime: 0
+  - StartTime: 205263
+    Lane: 3
+    EndTime: 0
+  - StartTime: 205341
+    Lane: 4
+    EndTime: 0
+  - StartTime: 205392
+    Lane: 3
+    EndTime: 0
+  - StartTime: 205444
+    Lane: 2
+    EndTime: 0
+  - StartTime: 205539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 205573
+    Lane: 2
+    EndTime: 0
+  - StartTime: 205625
+    Lane: 1
+    EndTime: 0
+  - StartTime: 205677
+    Lane: 4
+    EndTime: 205884
+  - StartTime: 205884
+    Lane: 3
+    EndTime: 206039
+  - StartTime: 206039
+    Lane: 2
+    EndTime: 206194
+  - StartTime: 206194
+    Lane: 3
+    EndTime: 206323
+  - StartTime: 206323
+    Lane: 2
+    EndTime: 206504
+  - StartTime: 206504
+    Lane: 1
+    EndTime: 206634
+  - StartTime: 206634
+    Lane: 2
+    EndTime: 206763
+  - StartTime: 206763
+    Lane: 3
+    EndTime: 206918
+  - StartTime: 206918
+    Lane: 4
+    EndTime: 207229
+  - StartTime: 206918
+    Lane: 1
+    EndTime: 207229
+  - StartTime: 207125
+    Lane: 2
+    EndTime: 0
+  - StartTime: 207125
+    Lane: 3
+    EndTime: 0
+  - StartTime: 207332
+    Lane: 1
+    EndTime: 0
+  - StartTime: 207332
+    Lane: 2
+    EndTime: 0
+  - StartTime: 207332
+    Lane: 4
+    EndTime: 0
+  - StartTime: 207384
+    Lane: 3
+    EndTime: 0
+  - StartTime: 207436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 207487
+    Lane: 1
+    EndTime: 0
+  - StartTime: 207539
+    Lane: 4
+    EndTime: 0
+  - StartTime: 207591
+    Lane: 3
+    EndTime: 0
+  - StartTime: 207694
+    Lane: 4
+    EndTime: 0
+  - StartTime: 207746
+    Lane: 2
+    EndTime: 0
+  - StartTime: 207746
+    Lane: 1
+    EndTime: 0
+  - StartTime: 207798
+    Lane: 3
+    EndTime: 0
+  - StartTime: 207849
+    Lane: 4
+    EndTime: 0
+  - StartTime: 207901
+    Lane: 1
+    EndTime: 0
+  - StartTime: 207953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 208004
+    Lane: 3
+    EndTime: 0
+  - StartTime: 208056
+    Lane: 4
+    EndTime: 0
+  - StartTime: 208108
+    Lane: 1
+    EndTime: 0
+  - StartTime: 208160
+    Lane: 2
+    EndTime: 0
+  - StartTime: 208160
+    Lane: 4
+    EndTime: 0
+  - StartTime: 208211
+    Lane: 3
+    EndTime: 0
+  - StartTime: 208263
+    Lane: 1
+    EndTime: 0
+  - StartTime: 208315
+    Lane: 2
+    EndTime: 0
+  - StartTime: 208367
+    Lane: 4
+    EndTime: 0
+  - StartTime: 208367
+    Lane: 3
+    EndTime: 0
+  - StartTime: 208436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 208470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 208504
+    Lane: 4
+    EndTime: 0
+  - StartTime: 208539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 208573
+    Lane: 2
+    EndTime: 0
+  - StartTime: 208573
+    Lane: 1
+    EndTime: 0
+  - StartTime: 208625
+    Lane: 4
+    EndTime: 0
+  - StartTime: 208677
+    Lane: 3
+    EndTime: 0
+  - StartTime: 208729
+    Lane: 1
+    EndTime: 0
+  - StartTime: 208780
+    Lane: 2
+    EndTime: 0
+  - StartTime: 208884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 208987
+    Lane: 2
+    EndTime: 0
+  - StartTime: 208987
+    Lane: 4
+    EndTime: 0
+  - StartTime: 209056
+    Lane: 3
+    EndTime: 0
+  - StartTime: 209125
+    Lane: 2
+    EndTime: 0
+  - StartTime: 209194
+    Lane: 1
+    EndTime: 0
+  - StartTime: 209194
+    Lane: 4
+    EndTime: 0
+  - StartTime: 209298
+    Lane: 3
+    EndTime: 0
+  - StartTime: 209401
+    Lane: 1
+    EndTime: 0
+  - StartTime: 209401
+    Lane: 2
+    EndTime: 0
+  - StartTime: 209504
+    Lane: 4
+    EndTime: 0
+  - StartTime: 209608
+    Lane: 3
+    EndTime: 0
+  - StartTime: 209608
+    Lane: 2
+    EndTime: 0
+  - StartTime: 209711
+    Lane: 1
+    EndTime: 0
+  - StartTime: 209815
+    Lane: 3
+    EndTime: 0
+  - StartTime: 209815
+    Lane: 4
+    EndTime: 0
+  - StartTime: 209953
+    Lane: 1
+    EndTime: 0
+  - StartTime: 210022
+    Lane: 2
+    EndTime: 0
+  - StartTime: 210022
+    Lane: 4
+    EndTime: 0
+  - StartTime: 210073
+    Lane: 3
+    EndTime: 0
+  - StartTime: 210229
+    Lane: 1
+    EndTime: 0
+  - StartTime: 210229
+    Lane: 2
+    EndTime: 0
+  - StartTime: 210332
+    Lane: 3
+    EndTime: 0
+  - StartTime: 210436
+    Lane: 4
+    EndTime: 0
+  - StartTime: 210513
+    Lane: 2
+    EndTime: 0
+  - StartTime: 210642
+    Lane: 1
+    EndTime: 0
+  - StartTime: 210642
+    Lane: 4
+    EndTime: 0
+  - StartTime: 210746
+    Lane: 2
+    EndTime: 0
+  - StartTime: 210849
+    Lane: 3
+    EndTime: 0
+  - StartTime: 210953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 211004
+    Lane: 3
+    EndTime: 0
+  - StartTime: 211056
+    Lane: 1
+    EndTime: 0
+  - StartTime: 211056
+    Lane: 4
+    EndTime: 0
+  - StartTime: 211160
+    Lane: 3
+    EndTime: 0
+  - StartTime: 211263
+    Lane: 4
+    EndTime: 0
+  - StartTime: 211315
+    Lane: 2
+    EndTime: 0
+  - StartTime: 211367
+    Lane: 1
+    EndTime: 0
+  - StartTime: 211470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 211470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 211573
+    Lane: 3
+    EndTime: 0
+  - StartTime: 211677
+    Lane: 2
+    EndTime: 0
+  - StartTime: 211780
+    Lane: 1
+    EndTime: 0
+  - StartTime: 211884
+    Lane: 4
+    EndTime: 212091
+  - StartTime: 211884
+    Lane: 3
+    EndTime: 0
+  - StartTime: 211987
+    Lane: 2
+    EndTime: 0
+  - StartTime: 212091
+    Lane: 1
+    EndTime: 0
+  - StartTime: 212194
+    Lane: 2
+    EndTime: 0
+  - StartTime: 212298
+    Lane: 3
+    EndTime: 0
+  - StartTime: 212298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 212401
+    Lane: 2
+    EndTime: 0
+  - StartTime: 212504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 212504
+    Lane: 4
+    EndTime: 0
+  - StartTime: 212608
+    Lane: 2
+    EndTime: 0
+  - StartTime: 212608
+    Lane: 1
+    EndTime: 0
+  - StartTime: 212711
+    Lane: 3
+    EndTime: 0
+  - StartTime: 212711
+    Lane: 4
+    EndTime: 0
+  - StartTime: 212815
+    Lane: 2
+    EndTime: 0
+  - StartTime: 212918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 212918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 213022
+    Lane: 4
+    EndTime: 0
+  - StartTime: 213073
+    Lane: 3
+    EndTime: 0
+  - StartTime: 213125
+    Lane: 2
+    EndTime: 0
+  - StartTime: 213125
+    Lane: 1
+    EndTime: 0
+  - StartTime: 213194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 213263
+    Lane: 4
+    EndTime: 0
+  - StartTime: 213332
+    Lane: 3
+    EndTime: 0
+  - StartTime: 213332
+    Lane: 2
+    EndTime: 0
+  - StartTime: 213436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 213487
+    Lane: 2
+    EndTime: 0
+  - StartTime: 213539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 213539
+    Lane: 4
+    EndTime: 0
+  - StartTime: 213642
+    Lane: 2
+    EndTime: 0
+  - StartTime: 213746
+    Lane: 4
+    EndTime: 0
+  - StartTime: 213746
+    Lane: 1
+    EndTime: 0
+  - StartTime: 213849
+    Lane: 2
+    EndTime: 0
+  - StartTime: 213953
+    Lane: 3
+    EndTime: 0
+  - StartTime: 213953
+    Lane: 4
+    EndTime: 214367
+  - StartTime: 213953
+    Lane: 1
+    EndTime: 0
+  - StartTime: 214160
+    Lane: 2
+    EndTime: 214367
+  - StartTime: 214367
+    Lane: 3
+    EndTime: 0
+  - StartTime: 214367
+    Lane: 1
+    EndTime: 214780
+  - StartTime: 214573
+    Lane: 4
+    EndTime: 214780
+  - StartTime: 214780
+    Lane: 3
+    EndTime: 215194
+  - StartTime: 214780
+    Lane: 2
+    EndTime: 0
+  - StartTime: 214987
+    Lane: 1
+    EndTime: 215194
+  - StartTime: 215194
+    Lane: 4
+    EndTime: 215608
+  - StartTime: 215194
+    Lane: 2
+    EndTime: 0
+  - StartTime: 215401
+    Lane: 2
+    EndTime: 215608
+  - StartTime: 215608
+    Lane: 1
+    EndTime: 0
+  - StartTime: 215608
+    Lane: 3
+    EndTime: 215815
+  - StartTime: 215815
+    Lane: 1
+    EndTime: 215918
+  - StartTime: 215815
+    Lane: 2
+    EndTime: 0
+  - StartTime: 216022
+    Lane: 1
+    EndTime: 216125
+  - StartTime: 216022
+    Lane: 2
+    EndTime: 0
+  - StartTime: 216229
+    Lane: 1
+    EndTime: 216849
+  - StartTime: 216229
+    Lane: 4
+    EndTime: 216539
+  - StartTime: 216436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 216642
+    Lane: 2
+    EndTime: 216746
+  - StartTime: 216642
+    Lane: 3
+    EndTime: 0
+  - StartTime: 216849
+    Lane: 3
+    EndTime: 216953
+  - StartTime: 216849
+    Lane: 4
+    EndTime: 0
+  - StartTime: 217056
+    Lane: 4
+    EndTime: 217160
+  - StartTime: 217056
+    Lane: 1
+    EndTime: 0
+  - StartTime: 217263
+    Lane: 1
+    EndTime: 0
+  - StartTime: 217263
+    Lane: 4
+    EndTime: 0
+  - StartTime: 217263
+    Lane: 3
+    EndTime: 0
+  - StartTime: 217332
+    Lane: 2
+    EndTime: 0
+  - StartTime: 217401
+    Lane: 4
+    EndTime: 0
+  - StartTime: 217470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 217470
+    Lane: 1
+    EndTime: 0
+  - StartTime: 217573
+    Lane: 2
+    EndTime: 0
+  - StartTime: 217677
+    Lane: 4
+    EndTime: 0
+  - StartTime: 217677
+    Lane: 3
+    EndTime: 0
+  - StartTime: 217780
+    Lane: 1
+    EndTime: 0
+  - StartTime: 217884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 217884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 217987
+    Lane: 3
+    EndTime: 0
+  - StartTime: 218091
+    Lane: 4
+    EndTime: 0
+  - StartTime: 218091
+    Lane: 1
+    EndTime: 0
+  - StartTime: 218194
+    Lane: 2
+    EndTime: 0
+  - StartTime: 218298
+    Lane: 3
+    EndTime: 0
+  - StartTime: 218298
+    Lane: 4
+    EndTime: 0
+  - StartTime: 218401
+    Lane: 4
+    EndTime: 0
+  - StartTime: 218401
+    Lane: 1
+    EndTime: 0
+  - StartTime: 218504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 218504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 218608
+    Lane: 1
+    EndTime: 0
+  - StartTime: 218711
+    Lane: 3
+    EndTime: 0
+  - StartTime: 218711
+    Lane: 4
+    EndTime: 0
+  - StartTime: 218815
+    Lane: 2
+    EndTime: 0
+  - StartTime: 218918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 218918
+    Lane: 4
+    EndTime: 219125
+  - StartTime: 219125
+    Lane: 3
+    EndTime: 219332
+  - StartTime: 219125
+    Lane: 1
+    EndTime: 0
+  - StartTime: 219332
+    Lane: 2
+    EndTime: 0
+  - StartTime: 219332
+    Lane: 1
+    EndTime: 0
+  - StartTime: 219539
+    Lane: 4
+    EndTime: 219953
+  - StartTime: 219539
+    Lane: 1
+    EndTime: 219953
+  - StartTime: 219953
+    Lane: 3
+    EndTime: 0
+  - StartTime: 219953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 220056
+    Lane: 4
+    EndTime: 0
+  - StartTime: 220056
+    Lane: 1
+    EndTime: 0
+  - StartTime: 220160
+    Lane: 3
+    EndTime: 0
+  - StartTime: 220160
+    Lane: 2
+    EndTime: 0
+  - StartTime: 220263
+    Lane: 4
+    EndTime: 0
+  - StartTime: 220367
+    Lane: 1
+    EndTime: 0
+  - StartTime: 220367
+    Lane: 2
+    EndTime: 0
+  - StartTime: 220470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 220573
+    Lane: 3
+    EndTime: 0
+  - StartTime: 220573
+    Lane: 2
+    EndTime: 0
+  - StartTime: 220573
+    Lane: 1
+    EndTime: 221194
+  - StartTime: 220987
+    Lane: 3
+    EndTime: 0
+  - StartTime: 220987
+    Lane: 4
+    EndTime: 221194
+  - StartTime: 221194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 221194
+    Lane: 2
+    EndTime: 221815
+  - StartTime: 221608
+    Lane: 1
+    EndTime: 0
+  - StartTime: 221608
+    Lane: 4
+    EndTime: 221815
+  - StartTime: 221815
+    Lane: 1
+    EndTime: 0
+  - StartTime: 221815
+    Lane: 3
+    EndTime: 222436
+  - StartTime: 222229
+    Lane: 1
+    EndTime: 222436
+  - StartTime: 222229
+    Lane: 2
+    EndTime: 0
+  - StartTime: 222436
+    Lane: 4
+    EndTime: 222642
+  - StartTime: 222642
+    Lane: 3
+    EndTime: 222849
+  - StartTime: 222642
+    Lane: 1
+    EndTime: 0
+  - StartTime: 222849
+    Lane: 2
+    EndTime: 223056
+  - StartTime: 222849
+    Lane: 4
+    EndTime: 0
+  - StartTime: 223056
+    Lane: 1
+    EndTime: 0
+  - StartTime: 223056
+    Lane: 3
+    EndTime: 0
+  - StartTime: 223125
+    Lane: 4
+    EndTime: 0
+  - StartTime: 223194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 223263
+    Lane: 2
+    EndTime: 223367
+  - StartTime: 223367
+    Lane: 1
+    EndTime: 223470
+  - StartTime: 223470
+    Lane: 4
+    EndTime: 223573
+  - StartTime: 223470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 223573
+    Lane: 3
+    EndTime: 223677
+  - StartTime: 223677
+    Lane: 1
+    EndTime: 223780
+  - StartTime: 223780
+    Lane: 2
+    EndTime: 223884
+  - StartTime: 223884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 223884
+    Lane: 3
+    EndTime: 223987
+  - StartTime: 223987
+    Lane: 2
+    EndTime: 224091
+  - StartTime: 224091
+    Lane: 1
+    EndTime: 224194
+  - StartTime: 224194
+    Lane: 4
+    EndTime: 224298
+  - StartTime: 224298
+    Lane: 3
+    EndTime: 224401
+  - StartTime: 224298
+    Lane: 2
+    EndTime: 0
+  - StartTime: 224401
+    Lane: 4
+    EndTime: 224504
+  - StartTime: 224504
+    Lane: 3
+    EndTime: 224608
+  - StartTime: 224504
+    Lane: 1
+    EndTime: 0
+  - StartTime: 224608
+    Lane: 2
+    EndTime: 224711
+  - StartTime: 224711
+    Lane: 1
+    EndTime: 224815
+  - StartTime: 224815
+    Lane: 4
+    EndTime: 224918
+  - StartTime: 224918
+    Lane: 3
+    EndTime: 225022
+  - StartTime: 224918
+    Lane: 2
+    EndTime: 0
+  - StartTime: 225022
+    Lane: 4
+    EndTime: 225125
+  - StartTime: 225125
+    Lane: 2
+    EndTime: 225229
+  - StartTime: 225125
+    Lane: 1
+    EndTime: 0
+  - StartTime: 225229
+    Lane: 3
+    EndTime: 225332
+  - StartTime: 225332
+    Lane: 1
+    EndTime: 225436
+  - StartTime: 225436
+    Lane: 2
+    EndTime: 225539
+  - StartTime: 225539
+    Lane: 4
+    EndTime: 0
+  - StartTime: 225539
+    Lane: 3
+    EndTime: 225642
+  - StartTime: 225642
+    Lane: 1
+    EndTime: 0
+  - StartTime: 225642
+    Lane: 2
+    EndTime: 0
+  - StartTime: 225746
+    Lane: 4
+    EndTime: 225849
+  - StartTime: 225746
+    Lane: 3
+    EndTime: 0
+  - StartTime: 225953
+    Lane: 1
+    EndTime: 226056
+  - StartTime: 225953
+    Lane: 3
+    EndTime: 0
+  - StartTime: 226160
+    Lane: 1
+    EndTime: 226263
+  - StartTime: 226160
+    Lane: 4
+    EndTime: 0
+  - StartTime: 226263
+    Lane: 2
+    EndTime: 0
+  - StartTime: 226367
+    Lane: 3
+    EndTime: 226470
+  - StartTime: 226367
+    Lane: 4
+    EndTime: 226470
+  - StartTime: 226367
+    Lane: 1
+    EndTime: 0
+  - StartTime: 226573
+    Lane: 3
+    EndTime: 226677
+  - StartTime: 226573
+    Lane: 4
+    EndTime: 226677
+  - StartTime: 226780
+    Lane: 3
+    EndTime: 226884
+  - StartTime: 226780
+    Lane: 4
+    EndTime: 226884
+  - StartTime: 226884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 226987
+    Lane: 2
+    EndTime: 227091
+  - StartTime: 226987
+    Lane: 3
+    EndTime: 227091
+  - StartTime: 227091
+    Lane: 1
+    EndTime: 0
+  - StartTime: 227194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 227194
+    Lane: 4
+    EndTime: 227401
+  - StartTime: 227194
+    Lane: 2
+    EndTime: 0
+  - StartTime: 227401
+    Lane: 1
+    EndTime: 227608
+  - StartTime: 227608
+    Lane: 2
+    EndTime: 227815
+  - StartTime: 227608
+    Lane: 3
+    EndTime: 0
+  - StartTime: 227815
+    Lane: 4
+    EndTime: 228022
+  - StartTime: 227815
+    Lane: 1
+    EndTime: 0
+  - StartTime: 228022
+    Lane: 3
+    EndTime: 228229
+  - StartTime: 228229
+    Lane: 4
+    EndTime: 228436
+  - StartTime: 228229
+    Lane: 1
+    EndTime: 0
+  - StartTime: 228436
+    Lane: 2
+    EndTime: 228642
+  - StartTime: 228436
+    Lane: 3
+    EndTime: 0
+  - StartTime: 228642
+    Lane: 1
+    EndTime: 228849
+  - StartTime: 228642
+    Lane: 4
+    EndTime: 0
+  - StartTime: 228849
+    Lane: 4
+    EndTime: 0
+  - StartTime: 228849
+    Lane: 3
+    EndTime: 229056
+  - StartTime: 228849
+    Lane: 2
+    EndTime: 0
+  - StartTime: 229056
+    Lane: 1
+    EndTime: 229263
+  - StartTime: 229263
+    Lane: 2
+    EndTime: 229470
+  - StartTime: 229263
+    Lane: 3
+    EndTime: 0
+  - StartTime: 229470
+    Lane: 4
+    EndTime: 229677
+  - StartTime: 229470
+    Lane: 1
+    EndTime: 0
+  - StartTime: 229677
+    Lane: 3
+    EndTime: 229884
+  - StartTime: 229884
+    Lane: 2
+    EndTime: 230091
+  - StartTime: 229884
+    Lane: 1
+    EndTime: 0
+  - StartTime: 230091
+    Lane: 3
+    EndTime: 230298
+  - StartTime: 230091
+    Lane: 4
+    EndTime: 0
+  - StartTime: 230298
+    Lane: 2
+    EndTime: 0
+  - StartTime: 230298
+    Lane: 1
+    EndTime: 230504
+  - StartTime: 230504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 230504
+    Lane: 4
+    EndTime: 230711
+  - StartTime: 230504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 230711
+    Lane: 3
+    EndTime: 230918
+  - StartTime: 230918
+    Lane: 2
+    EndTime: 231125
+  - StartTime: 230918
+    Lane: 4
+    EndTime: 0
+  - StartTime: 231125
+    Lane: 3
+    EndTime: 231332
+  - StartTime: 231125
+    Lane: 1
+    EndTime: 0
+  - StartTime: 231332
+    Lane: 2
+    EndTime: 231539
+  - StartTime: 231539
+    Lane: 1
+    EndTime: 231746
+  - StartTime: 231539
+    Lane: 3
+    EndTime: 0
+  - StartTime: 231746
+    Lane: 2
+    EndTime: 231953
+  - StartTime: 231746
+    Lane: 4
+    EndTime: 0
+  - StartTime: 231953
+    Lane: 3
+    EndTime: 232160
+  - StartTime: 231953
+    Lane: 1
+    EndTime: 0
+  - StartTime: 232160
+    Lane: 1
+    EndTime: 0
+  - StartTime: 232160
+    Lane: 4
+    EndTime: 232367
+  - StartTime: 232367
+    Lane: 3
+    EndTime: 232573
+  - StartTime: 232573
+    Lane: 2
+    EndTime: 232780
+  - StartTime: 232573
+    Lane: 4
+    EndTime: 0
+  - StartTime: 232780
+    Lane: 1
+    EndTime: 232987
+  - StartTime: 232780
+    Lane: 3
+    EndTime: 0
+  - StartTime: 232987
+    Lane: 2
+    EndTime: 233401
+  - StartTime: 232987
+    Lane: 4
+    EndTime: 233401
+  - StartTime: 233194
+    Lane: 3
+    EndTime: 0
+  - StartTime: 233194
+    Lane: 1
+    EndTime: 0
+  - StartTime: 233401
+    Lane: 3
+    EndTime: 233815
+  - StartTime: 233401
+    Lane: 1
+    EndTime: 233815
+  - StartTime: 233815
+    Lane: 4
+    EndTime: 234022
+  - StartTime: 233815
+    Lane: 2
+    EndTime: 0
+  - StartTime: 234022
+    Lane: 1
+    EndTime: 234229
+  - StartTime: 234229
+    Lane: 2
+    EndTime: 0
+  - StartTime: 234229
+    Lane: 3
+    EndTime: 234436
+  - StartTime: 234436
+    Lane: 4
+    EndTime: 234642
+  - StartTime: 234436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 234642
+    Lane: 3
+    EndTime: 234849
+  - StartTime: 234849
+    Lane: 1
+    EndTime: 0
+  - StartTime: 234849
+    Lane: 2
+    EndTime: 235056
+  - StartTime: 235056
+    Lane: 4
+    EndTime: 235263
+  - StartTime: 235056
+    Lane: 3
+    EndTime: 0
+  - StartTime: 235263
+    Lane: 1
+    EndTime: 235470
+  - StartTime: 235263
+    Lane: 2
+    EndTime: 0
+  - StartTime: 235470
+    Lane: 3
+    EndTime: 235677
+  - StartTime: 235470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 235677
+    Lane: 1
+    EndTime: 235884
+  - StartTime: 235884
+    Lane: 3
+    EndTime: 236091
+  - StartTime: 235884
+    Lane: 2
+    EndTime: 0
+  - StartTime: 236091
+    Lane: 1
+    EndTime: 0
+  - StartTime: 236091
+    Lane: 4
+    EndTime: 236298
+  - StartTime: 236298
+    Lane: 3
+    EndTime: 236504
+  - StartTime: 236504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 236504
+    Lane: 1
+    EndTime: 236711
+  - StartTime: 236711
+    Lane: 3
+    EndTime: 236918
+  - StartTime: 236711
+    Lane: 2
+    EndTime: 0
+  - StartTime: 236711
+    Lane: 4
+    EndTime: 0
+  - StartTime: 236918
+    Lane: 1
+    EndTime: 0
+  - StartTime: 236918
+    Lane: 4
+    EndTime: 237125
+  - StartTime: 237125
+    Lane: 1
+    EndTime: 237332
+  - StartTime: 237125
+    Lane: 2
+    EndTime: 0
+  - StartTime: 237229
+    Lane: 4
+    EndTime: 0
+  - StartTime: 237332
+    Lane: 2
+    EndTime: 237539
+  - StartTime: 237332
+    Lane: 3
+    EndTime: 0
+  - StartTime: 237436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 237539
+    Lane: 3
+    EndTime: 237746
+  - StartTime: 237539
+    Lane: 4
+    EndTime: 0
+  - StartTime: 237642
+    Lane: 2
+    EndTime: 0
+  - StartTime: 237746
+    Lane: 4
+    EndTime: 237953
+  - StartTime: 237746
+    Lane: 1
+    EndTime: 0
+  - StartTime: 237849
+    Lane: 3
+    EndTime: 0
+  - StartTime: 237953
+    Lane: 1
+    EndTime: 238160
+  - StartTime: 237953
+    Lane: 2
+    EndTime: 0
+  - StartTime: 238056
+    Lane: 4
+    EndTime: 0
+  - StartTime: 238160
+    Lane: 3
+    EndTime: 238367
+  - StartTime: 238160
+    Lane: 2
+    EndTime: 0
+  - StartTime: 238263
+    Lane: 1
+    EndTime: 0
+  - StartTime: 238367
+    Lane: 2
+    EndTime: 238573
+  - StartTime: 238367
+    Lane: 4
+    EndTime: 0
+  - StartTime: 238470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 238573
+    Lane: 4
+    EndTime: 238780
+  - StartTime: 238573
+    Lane: 1
+    EndTime: 0
+  - StartTime: 238677
+    Lane: 2
+    EndTime: 0
+  - StartTime: 238780
+    Lane: 1
+    EndTime: 238987
+  - StartTime: 238780
+    Lane: 3
+    EndTime: 0
+  - StartTime: 238884
+    Lane: 4
+    EndTime: 0
+  - StartTime: 238987
+    Lane: 2
+    EndTime: 239194
+  - StartTime: 238987
+    Lane: 3
+    EndTime: 0
+  - StartTime: 239091
+    Lane: 4
+    EndTime: 0
+  - StartTime: 239194
+    Lane: 3
+    EndTime: 239401
+  - StartTime: 239194
+    Lane: 1
+    EndTime: 0
+  - StartTime: 239298
+    Lane: 2
+    EndTime: 0
+  - StartTime: 239401
+    Lane: 4
+    EndTime: 239608
+  - StartTime: 239401
+    Lane: 1
+    EndTime: 0
+  - StartTime: 239504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 239608
+    Lane: 2
+    EndTime: 0
+  - StartTime: 239608
+    Lane: 1
+    EndTime: 240022
+  - StartTime: 239711
+    Lane: 4
+    EndTime: 0
+  - StartTime: 239711
+    Lane: 3
+    EndTime: 0
+  - StartTime: 239815
+    Lane: 2
+    EndTime: 0
+  - StartTime: 239918
+    Lane: 3
+    EndTime: 0
+  - StartTime: 240022
+    Lane: 2
+    EndTime: 0
+  - StartTime: 240022
+    Lane: 4
+    EndTime: 240436
+  - StartTime: 240125
+    Lane: 1
+    EndTime: 0
+  - StartTime: 240229
+    Lane: 3
+    EndTime: 0
+  - StartTime: 240332
+    Lane: 2
+    EndTime: 0
+  - StartTime: 240436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 240436
+    Lane: 3
+    EndTime: 243742
+  - StartTime: 240436
+    Lane: 2
+    EndTime: 243742
+  - StartTime: 243742
+    Lane: 4
+    EndTime: 0
+  - StartTime: 243742
+    Lane: 1
+    EndTime: 0
+  - StartTime: 243826
+    Lane: 2
+    EndTime: 0
+  - StartTime: 243911
+    Lane: 3
+    EndTime: 0
+  - StartTime: 243996
+    Lane: 1
+    EndTime: 0
+  - StartTime: 244080
+    Lane: 4
+    EndTime: 0
+  - StartTime: 244165
+    Lane: 3
+    EndTime: 0
+  - StartTime: 244250
+    Lane: 4
+    EndTime: 0
+  - StartTime: 244335
+    Lane: 1
+    EndTime: 0
+  - StartTime: 244419
+    Lane: 2
+    EndTime: 0
+  - StartTime: 244504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 244589
+    Lane: 4
+    EndTime: 0
+  - StartTime: 244674
+    Lane: 3
+    EndTime: 0
+  - StartTime: 244758
+    Lane: 2
+    EndTime: 0
+  - StartTime: 244843
+    Lane: 1
+    EndTime: 0
+  - StartTime: 244928
+    Lane: 2
+    EndTime: 0
+  - StartTime: 245013
+    Lane: 4
+    EndTime: 0
+  - StartTime: 245097
+    Lane: 3
+    EndTime: 0
+  - StartTime: 245182
+    Lane: 2
+    EndTime: 0
+  - StartTime: 245267
+    Lane: 3
+    EndTime: 0
+  - StartTime: 245352
+    Lane: 1
+    EndTime: 0
+  - StartTime: 245436
+    Lane: 3
+    EndTime: 0
+  - StartTime: 245521
+    Lane: 1
+    EndTime: 0
+  - StartTime: 245606
+    Lane: 4
+    EndTime: 0
+  - StartTime: 245691
+    Lane: 3
+    EndTime: 0
+  - StartTime: 245775
+    Lane: 2
+    EndTime: 0
+  - StartTime: 245860
+    Lane: 3
+    EndTime: 0
+  - StartTime: 245945
+    Lane: 2
+    EndTime: 0
+  - StartTime: 246030
+    Lane: 1
+    EndTime: 0
+  - StartTime: 246114
+    Lane: 4
+    EndTime: 0
+  - StartTime: 246199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 246284
+    Lane: 2
+    EndTime: 0
+  - StartTime: 246369
+    Lane: 4
+    EndTime: 0
+  - StartTime: 246453
+    Lane: 3
+    EndTime: 0
+  - StartTime: 246453
+    Lane: 2
+    EndTime: 0
+  - StartTime: 246453
+    Lane: 1
+    EndTime: 0
+  - StartTime: 246538
+    Lane: 4
+    EndTime: 0
+  - StartTime: 246623
+    Lane: 1
+    EndTime: 0
+  - StartTime: 246708
+    Lane: 2
+    EndTime: 0
+  - StartTime: 246792
+    Lane: 4
+    EndTime: 0
+  - StartTime: 246877
+    Lane: 3
+    EndTime: 0
+  - StartTime: 246962
+    Lane: 2
+    EndTime: 0
+  - StartTime: 246962
+    Lane: 1
+    EndTime: 0
+  - StartTime: 247047
+    Lane: 4
+    EndTime: 0
+  - StartTime: 247131
+    Lane: 3
+    EndTime: 0
+  - StartTime: 247216
+    Lane: 2
+    EndTime: 0
+  - StartTime: 247301
+    Lane: 1
+    EndTime: 0
+  - StartTime: 247386
+    Lane: 2
+    EndTime: 0
+  - StartTime: 247470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 247470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 247555
+    Lane: 1
+    EndTime: 0
+  - StartTime: 247640
+    Lane: 3
+    EndTime: 0
+  - StartTime: 247725
+    Lane: 2
+    EndTime: 0
+  - StartTime: 247809
+    Lane: 1
+    EndTime: 0
+  - StartTime: 247809
+    Lane: 4
+    EndTime: 0
+  - StartTime: 247809
+    Lane: 3
+    EndTime: 0
+  - StartTime: 247894
+    Lane: 2
+    EndTime: 0
+  - StartTime: 247979
+    Lane: 3
+    EndTime: 0
+  - StartTime: 248064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 248148
+    Lane: 3
+    EndTime: 0
+  - StartTime: 248233
+    Lane: 4
+    EndTime: 0
+  - StartTime: 248318
+    Lane: 1
+    EndTime: 0
+  - StartTime: 248403
+    Lane: 3
+    EndTime: 0
+  - StartTime: 248487
+    Lane: 2
+    EndTime: 0
+  - StartTime: 248487
+    Lane: 1
+    EndTime: 0
+  - StartTime: 248572
+    Lane: 4
+    EndTime: 0
+  - StartTime: 248657
+    Lane: 3
+    EndTime: 0
+  - StartTime: 248742
+    Lane: 4
+    EndTime: 0
+  - StartTime: 248826
+    Lane: 2
+    EndTime: 0
+  - StartTime: 248826
+    Lane: 1
+    EndTime: 0
+  - StartTime: 248911
+    Lane: 3
+    EndTime: 0
+  - StartTime: 248996
+    Lane: 4
+    EndTime: 0
+  - StartTime: 249080
+    Lane: 3
+    EndTime: 0
+  - StartTime: 249165
+    Lane: 2
+    EndTime: 0
+  - StartTime: 249165
+    Lane: 1
+    EndTime: 0
+  - StartTime: 249250
+    Lane: 4
+    EndTime: 0
+  - StartTime: 249250
+    Lane: 3
+    EndTime: 0
+  - StartTime: 249335
+    Lane: 2
+    EndTime: 0
+  - StartTime: 249335
+    Lane: 1
+    EndTime: 0
+  - StartTime: 249419
+    Lane: 3
+    EndTime: 0
+  - StartTime: 249419
+    Lane: 4
+    EndTime: 0
+  - StartTime: 249504
+    Lane: 1
+    EndTime: 0
+  - StartTime: 249504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 249589
+    Lane: 3
+    EndTime: 0
+  - StartTime: 249674
+    Lane: 1
+    EndTime: 0
+  - StartTime: 249674
+    Lane: 4
+    EndTime: 0
+  - StartTime: 249758
+    Lane: 3
+    EndTime: 0
+  - StartTime: 249758
+    Lane: 2
+    EndTime: 0
+  - StartTime: 249843
+    Lane: 1
+    EndTime: 0
+  - StartTime: 249843
+    Lane: 4
+    EndTime: 0
+  - StartTime: 249928
+    Lane: 3
+    EndTime: 0
+  - StartTime: 249928
+    Lane: 2
+    EndTime: 0
+  - StartTime: 250013
+    Lane: 1
+    EndTime: 0
+  - StartTime: 250013
+    Lane: 4
+    EndTime: 0
+  - StartTime: 250097
+    Lane: 2
+    EndTime: 0
+  - StartTime: 250182
+    Lane: 3
+    EndTime: 0
+  - StartTime: 250182
+    Lane: 4
+    EndTime: 0
+  - StartTime: 250267
+    Lane: 1
+    EndTime: 0
+  - StartTime: 250267
+    Lane: 2
+    EndTime: 0
+  - StartTime: 250352
+    Lane: 3
+    EndTime: 0
+  - StartTime: 250352
+    Lane: 4
+    EndTime: 0
+  - StartTime: 250436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 250436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 250521
+    Lane: 3
+    EndTime: 0
+  - StartTime: 250521
+    Lane: 4
+    EndTime: 0
+  - StartTime: 250606
+    Lane: 1
+    EndTime: 0
+  - StartTime: 250691
+    Lane: 2
+    EndTime: 0
+  - StartTime: 250691
+    Lane: 4
+    EndTime: 0
+  - StartTime: 250775
+    Lane: 3
+    EndTime: 0
+  - StartTime: 250775
+    Lane: 1
+    EndTime: 0
+  - StartTime: 250860
+    Lane: 2
+    EndTime: 0
+  - StartTime: 250860
+    Lane: 4
+    EndTime: 0
+  - StartTime: 250945
+    Lane: 1
+    EndTime: 0
+  - StartTime: 250945
+    Lane: 3
+    EndTime: 0
+  - StartTime: 251030
+    Lane: 4
+    EndTime: 0
+  - StartTime: 251030
+    Lane: 2
+    EndTime: 0
+  - StartTime: 251114
+    Lane: 1
+    EndTime: 0
+  - StartTime: 251199
+    Lane: 3
+    EndTime: 0
+  - StartTime: 251199
+    Lane: 4
+    EndTime: 0
+  - StartTime: 251284
+    Lane: 2
+    EndTime: 0
+  - StartTime: 251369
+    Lane: 1
+    EndTime: 0
+  - StartTime: 251453
+    Lane: 4
+    EndTime: 0
+  - StartTime: 251538
+    Lane: 3
+    EndTime: 0
+  - StartTime: 251538
+    Lane: 2
+    EndTime: 0
+  - StartTime: 251623
+    Lane: 1
+    EndTime: 0
+  - StartTime: 251708
+    Lane: 4
+    EndTime: 0
+  - StartTime: 251792
+    Lane: 3
+    EndTime: 0
+  - StartTime: 251877
+    Lane: 2
+    EndTime: 0
+  - StartTime: 251877
+    Lane: 1
+    EndTime: 0
+  - StartTime: 251877
+    Lane: 4
+    EndTime: 0
+  - StartTime: 251962
+    Lane: 3
+    EndTime: 0
+  - StartTime: 252047
+    Lane: 2
+    EndTime: 0
+  - StartTime: 252131
+    Lane: 1
+    EndTime: 0
+  - StartTime: 252131
+    Lane: 3
+    EndTime: 0
+  - StartTime: 252131
+    Lane: 4
+    EndTime: 0
+  - StartTime: 252216
+    Lane: 2
+    EndTime: 0
+  - StartTime: 252301
+    Lane: 3
+    EndTime: 0
+  - StartTime: 252386
+    Lane: 1
+    EndTime: 0
+  - StartTime: 252386
+    Lane: 2
+    EndTime: 0
+  - StartTime: 252386
+    Lane: 4
+    EndTime: 0
+  - StartTime: 252470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 252555
+    Lane: 4
+    EndTime: 0
+  - StartTime: 252555
+    Lane: 1
+    EndTime: 0
+  - StartTime: 252555
+    Lane: 2
+    EndTime: 0
+  - StartTime: 252640
+    Lane: 3
+    EndTime: 0
+  - StartTime: 252725
+    Lane: 1
+    EndTime: 0
+  - StartTime: 252809
+    Lane: 3
+    EndTime: 0
+  - StartTime: 252894
+    Lane: 2
+    EndTime: 0
+  - StartTime: 252894
+    Lane: 4
+    EndTime: 0
+  - StartTime: 252979
+    Lane: 1
+    EndTime: 0
+  - StartTime: 253064
+    Lane: 3
+    EndTime: 0
+  - StartTime: 253064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 253148
+    Lane: 4
+    EndTime: 0
+  - StartTime: 253233
+    Lane: 1
+    EndTime: 0
+  - StartTime: 253233
+    Lane: 3
+    EndTime: 0
+  - StartTime: 253318
+    Lane: 2
+    EndTime: 0
+  - StartTime: 253403
+    Lane: 1
+    EndTime: 0
+  - StartTime: 253487
+    Lane: 2
+    EndTime: 0
+  - StartTime: 253572
+    Lane: 3
+    EndTime: 0
+  - StartTime: 253572
+    Lane: 4
+    EndTime: 0
+  - StartTime: 253657
+    Lane: 1
+    EndTime: 0
+  - StartTime: 253742
+    Lane: 3
+    EndTime: 0
+  - StartTime: 253742
+    Lane: 4
+    EndTime: 0
+  - StartTime: 253826
+    Lane: 1
+    EndTime: 0
+  - StartTime: 253911
+    Lane: 3
+    EndTime: 0
+  - StartTime: 253996
+    Lane: 2
+    EndTime: 0
+  - StartTime: 254080
+    Lane: 1
+    EndTime: 0
+  - StartTime: 254165
+    Lane: 4
+    EndTime: 0
+  - StartTime: 254250
+    Lane: 3
+    EndTime: 0
+  - StartTime: 254250
+    Lane: 2
+    EndTime: 0
+  - StartTime: 254335
+    Lane: 1
+    EndTime: 0
+  - StartTime: 254419
+    Lane: 2
+    EndTime: 0
+  - StartTime: 254504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 254589
+    Lane: 4
+    EndTime: 0
+  - StartTime: 254589
+    Lane: 2
+    EndTime: 0
+  - StartTime: 254589
+    Lane: 1
+    EndTime: 0
+  - StartTime: 254674
+    Lane: 3
+    EndTime: 0
+  - StartTime: 254758
+    Lane: 2
+    EndTime: 0
+  - StartTime: 254758
+    Lane: 4
+    EndTime: 0
+  - StartTime: 254843
+    Lane: 1
+    EndTime: 0
+  - StartTime: 254928
+    Lane: 2
+    EndTime: 0
+  - StartTime: 255013
+    Lane: 3
+    EndTime: 0
+  - StartTime: 255013
+    Lane: 1
+    EndTime: 0
+  - StartTime: 255097
+    Lane: 4
+    EndTime: 0
+  - StartTime: 255097
+    Lane: 2
+    EndTime: 0
+  - StartTime: 255182
+    Lane: 3
+    EndTime: 0
+  - StartTime: 255267
+    Lane: 2
+    EndTime: 0
+  - StartTime: 255267
+    Lane: 1
+    EndTime: 0
+  - StartTime: 255352
+    Lane: 3
+    EndTime: 0
+  - StartTime: 255436
+    Lane: 4
+    EndTime: 0
+  - StartTime: 255436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 255521
+    Lane: 3
+    EndTime: 0
+  - StartTime: 255521
+    Lane: 2
+    EndTime: 0
+  - StartTime: 255606
+    Lane: 1
+    EndTime: 0
+  - StartTime: 255691
+    Lane: 3
+    EndTime: 0
+  - StartTime: 255691
+    Lane: 4
+    EndTime: 0
+  - StartTime: 255775
+    Lane: 2
+    EndTime: 0
+  - StartTime: 255775
+    Lane: 1
+    EndTime: 0
+  - StartTime: 255860
+    Lane: 3
+    EndTime: 0
+  - StartTime: 255945
+    Lane: 4
+    EndTime: 0
+  - StartTime: 255945
+    Lane: 1
+    EndTime: 0
+  - StartTime: 256030
+    Lane: 3
+    EndTime: 0
+  - StartTime: 256114
+    Lane: 4
+    EndTime: 0
+  - StartTime: 256114
+    Lane: 2
+    EndTime: 0
+  - StartTime: 256199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 256284
+    Lane: 4
+    EndTime: 0
+  - StartTime: 256369
+    Lane: 1
+    EndTime: 0
+  - StartTime: 256369
+    Lane: 2
+    EndTime: 0
+  - StartTime: 256453
+    Lane: 3
+    EndTime: 0
+  - StartTime: 256453
+    Lane: 4
+    EndTime: 0
+  - StartTime: 256538
+    Lane: 1
+    EndTime: 0
+  - StartTime: 256623
+    Lane: 2
+    EndTime: 0
+  - StartTime: 256623
+    Lane: 3
+    EndTime: 0
+  - StartTime: 256708
+    Lane: 1
+    EndTime: 0
+  - StartTime: 256792
+    Lane: 3
+    EndTime: 0
+  - StartTime: 256792
+    Lane: 4
+    EndTime: 0
+  - StartTime: 256877
+    Lane: 1
+    EndTime: 0
+  - StartTime: 256877
+    Lane: 2
+    EndTime: 0
+  - StartTime: 256962
+    Lane: 4
+    EndTime: 0
+  - StartTime: 257047
+    Lane: 2
+    EndTime: 0
+  - StartTime: 257047
+    Lane: 3
+    EndTime: 0
+  - StartTime: 257131
+    Lane: 4
+    EndTime: 0
+  - StartTime: 257131
+    Lane: 1
+    EndTime: 0
+  - StartTime: 257216
+    Lane: 3
+    EndTime: 0
+  - StartTime: 257301
+    Lane: 1
+    EndTime: 257470
+  - StartTime: 257301
+    Lane: 2
+    EndTime: 0
+  - StartTime: 257386
+    Lane: 4
+    EndTime: 0
+  - StartTime: 257470
+    Lane: 2
+    EndTime: 257640
+  - StartTime: 257470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 257555
+    Lane: 1
+    EndTime: 0
+  - StartTime: 257640
+    Lane: 3
+    EndTime: 257809
+  - StartTime: 257640
+    Lane: 4
+    EndTime: 0
+  - StartTime: 257725
+    Lane: 2
+    EndTime: 0
+  - StartTime: 257809
+    Lane: 1
+    EndTime: 0
+  - StartTime: 257809
+    Lane: 4
+    EndTime: 257979
+  - StartTime: 257894
+    Lane: 2
+    EndTime: 0
+  - StartTime: 257979
+    Lane: 3
+    EndTime: 258148
+  - StartTime: 257979
+    Lane: 1
+    EndTime: 0
+  - StartTime: 258064
+    Lane: 4
+    EndTime: 0
+  - StartTime: 258148
+    Lane: 2
+    EndTime: 258318
+  - StartTime: 258148
+    Lane: 1
+    EndTime: 0
+  - StartTime: 258233
+    Lane: 3
+    EndTime: 0
+  - StartTime: 258318
+    Lane: 4
+    EndTime: 0
+  - StartTime: 258318
+    Lane: 1
+    EndTime: 258487
+  - StartTime: 258403
+    Lane: 2
+    EndTime: 0
+  - StartTime: 258487
+    Lane: 3
+    EndTime: 0
+  - StartTime: 258487
+    Lane: 4
+    EndTime: 258657
+  - StartTime: 258572
+    Lane: 1
+    EndTime: 0
+  - StartTime: 258657
+    Lane: 2
+    EndTime: 258742
+  - StartTime: 258742
+    Lane: 3
+    EndTime: 258826
+  - StartTime: 258826
+    Lane: 1
+    EndTime: 258911
+  - StartTime: 258826
+    Lane: 4
+    EndTime: 0
+  - StartTime: 258911
+    Lane: 3
+    EndTime: 258996
+  - StartTime: 258996
+    Lane: 2
+    EndTime: 259080
+  - StartTime: 259080
+    Lane: 4
+    EndTime: 259165
+  - StartTime: 259165
+    Lane: 2
+    EndTime: 0
+  - StartTime: 259165
+    Lane: 1
+    EndTime: 259250
+  - StartTime: 259250
+    Lane: 3
+    EndTime: 259335
+  - StartTime: 259335
+    Lane: 1
+    EndTime: 259419
+  - StartTime: 259419
+    Lane: 4
+    EndTime: 259504
+  - StartTime: 259504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 259504
+    Lane: 2
+    EndTime: 259589
+  - StartTime: 259589
+    Lane: 4
+    EndTime: 259674
+  - StartTime: 259674
+    Lane: 3
+    EndTime: 259843
+  - StartTime: 259674
+    Lane: 1
+    EndTime: 259843
+  - StartTime: 260013
+    Lane: 1
+    EndTime: 0
+  - StartTime: 260013
+    Lane: 3
+    EndTime: 0
+  - StartTime: 260013
+    Lane: 4
+    EndTime: 0
+  - StartTime: 260097
+    Lane: 2
+    EndTime: 0
+  - StartTime: 260182
+    Lane: 4
+    EndTime: 0
+  - StartTime: 260182
+    Lane: 3
+    EndTime: 0
+  - StartTime: 260267
+    Lane: 2
+    EndTime: 0
+  - StartTime: 260352
+    Lane: 1
+    EndTime: 0
+  - StartTime: 260436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 260521
+    Lane: 4
+    EndTime: 0
+  - StartTime: 260521
+    Lane: 3
+    EndTime: 0
+  - StartTime: 260578
+    Lane: 2
+    EndTime: 0
+  - StartTime: 260634
+    Lane: 1
+    EndTime: 0
+  - StartTime: 260691
+    Lane: 3
+    EndTime: 0
+  - StartTime: 260747
+    Lane: 4
+    EndTime: 0
+  - StartTime: 260860
+    Lane: 3
+    EndTime: 0
+  - StartTime: 260860
+    Lane: 2
+    EndTime: 0
+  - StartTime: 260917
+    Lane: 1
+    EndTime: 0
+  - StartTime: 260945
+    Lane: 4
+    EndTime: 0
+  - StartTime: 261030
+    Lane: 3
+    EndTime: 0
+  - StartTime: 261086
+    Lane: 2
+    EndTime: 0
+  - StartTime: 261143
+    Lane: 1
+    EndTime: 0
+  - StartTime: 261199
+    Lane: 4
+    EndTime: 0
+  - StartTime: 261199
+    Lane: 3
+    EndTime: 0
+  - StartTime: 261284
+    Lane: 2
+    EndTime: 0
+  - StartTime: 261369
+    Lane: 4
+    EndTime: 0
+  - StartTime: 261453
+    Lane: 3
+    EndTime: 0
+  - StartTime: 261496
+    Lane: 2
+    EndTime: 0
+  - StartTime: 261538
+    Lane: 1
+    EndTime: 0
+  - StartTime: 261538
+    Lane: 4
+    EndTime: 0
+  - StartTime: 261595
+    Lane: 3
+    EndTime: 0
+  - StartTime: 261651
+    Lane: 2
+    EndTime: 0
+  - StartTime: 261708
+    Lane: 4
+    EndTime: 0
+  - StartTime: 261792
+    Lane: 3
+    EndTime: 0
+  - StartTime: 261849
+    Lane: 1
+    EndTime: 0
+  - StartTime: 261877
+    Lane: 2
+    EndTime: 0
+  - StartTime: 261877
+    Lane: 4
+    EndTime: 0
+  - StartTime: 261962
+    Lane: 3
+    EndTime: 0
+  - StartTime: 262047
+    Lane: 1
+    EndTime: 0
+  - StartTime: 262131
+    Lane: 4
+    EndTime: 0
+  - StartTime: 262216
+    Lane: 3
+    EndTime: 0
+  - StartTime: 262216
+    Lane: 1
+    EndTime: 0
+  - StartTime: 262301
+    Lane: 2
+    EndTime: 0
+  - StartTime: 262386
+    Lane: 3
+    EndTime: 0
+  - StartTime: 262386
+    Lane: 4
+    EndTime: 0
+  - StartTime: 262470
+    Lane: 1
+    EndTime: 0
+  - StartTime: 262555
+    Lane: 2
+    EndTime: 262725
+  - StartTime: 262555
+    Lane: 3
+    EndTime: 0
+  - StartTime: 262725
+    Lane: 4
+    EndTime: 0
+  - StartTime: 262725
+    Lane: 1
+    EndTime: 0
+  - StartTime: 262781
+    Lane: 3
+    EndTime: 0
+  - StartTime: 262894
+    Lane: 2
+    EndTime: 0
+  - StartTime: 262894
+    Lane: 1
+    EndTime: 0
+  - StartTime: 262979
+    Lane: 4
+    EndTime: 0
+  - StartTime: 263064
+    Lane: 3
+    EndTime: 0
+  - StartTime: 263064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 263148
+    Lane: 1
+    EndTime: 0
+  - StartTime: 263233
+    Lane: 3
+    EndTime: 0
+  - StartTime: 263233
+    Lane: 4
+    EndTime: 0
+  - StartTime: 263318
+    Lane: 2
+    EndTime: 0
+  - StartTime: 263403
+    Lane: 1
+    EndTime: 0
+  - StartTime: 263403
+    Lane: 4
+    EndTime: 0
+  - StartTime: 263487
+    Lane: 3
+    EndTime: 0
+  - StartTime: 263572
+    Lane: 2
+    EndTime: 0
+  - StartTime: 263572
+    Lane: 4
+    EndTime: 0
+  - StartTime: 263657
+    Lane: 1
+    EndTime: 0
+  - StartTime: 263742
+    Lane: 3
+    EndTime: 0
+  - StartTime: 263742
+    Lane: 4
+    EndTime: 0
+  - StartTime: 263826
+    Lane: 2
+    EndTime: 0
+  - StartTime: 263911
+    Lane: 1
+    EndTime: 0
+  - StartTime: 263911
+    Lane: 3
+    EndTime: 0
+  - StartTime: 263996
+    Lane: 4
+    EndTime: 0
+  - StartTime: 264080
+    Lane: 2
+    EndTime: 0
+  - StartTime: 264080
+    Lane: 1
+    EndTime: 0
+  - StartTime: 264080
+    Lane: 3
+    EndTime: 0
+  - StartTime: 264165
+    Lane: 4
+    EndTime: 0
+  - StartTime: 264250
+    Lane: 1
+    EndTime: 0
+  - StartTime: 264250
+    Lane: 2
+    EndTime: 0
+  - StartTime: 264335
+    Lane: 3
+    EndTime: 0
+  - StartTime: 264335
+    Lane: 4
+    EndTime: 0
+  - StartTime: 264419
+    Lane: 1
+    EndTime: 0
+  - StartTime: 264419
+    Lane: 2
+    EndTime: 0
+  - StartTime: 264504
+    Lane: 4
+    EndTime: 0
+  - StartTime: 264589
+    Lane: 3
+    EndTime: 0
+  - StartTime: 264589
+    Lane: 1
+    EndTime: 0
+  - StartTime: 264674
+    Lane: 4
+    EndTime: 0
+  - StartTime: 264758
+    Lane: 2
+    EndTime: 0
+  - StartTime: 264758
+    Lane: 1
+    EndTime: 264843
+  - StartTime: 264843
+    Lane: 4
+    EndTime: 0
+  - StartTime: 264843
+    Lane: 3
+    EndTime: 264928
+  - StartTime: 264928
+    Lane: 1
+    EndTime: 0
+  - StartTime: 264928
+    Lane: 2
+    EndTime: 265013
+  - StartTime: 265013
+    Lane: 3
+    EndTime: 0
+  - StartTime: 265013
+    Lane: 4
+    EndTime: 265097
+  - StartTime: 265097
+    Lane: 2
+    EndTime: 0
+  - StartTime: 265097
+    Lane: 1
+    EndTime: 265182
+  - StartTime: 265182
+    Lane: 4
+    EndTime: 0
+  - StartTime: 265182
+    Lane: 3
+    EndTime: 265267
+  - StartTime: 265267
+    Lane: 1
+    EndTime: 0
+  - StartTime: 265267
+    Lane: 2
+    EndTime: 265352
+  - StartTime: 265352
+    Lane: 3
+    EndTime: 0
+  - StartTime: 265352
+    Lane: 4
+    EndTime: 265436
+  - StartTime: 265436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 265436
+    Lane: 1
+    EndTime: 265775
+  - StartTime: 265521
+    Lane: 3
+    EndTime: 0
+  - StartTime: 265606
+    Lane: 4
+    EndTime: 0
+  - StartTime: 265606
+    Lane: 2
+    EndTime: 0
+  - StartTime: 265691
+    Lane: 4
+    EndTime: 0
+  - StartTime: 265775
+    Lane: 3
+    EndTime: 0
+  - StartTime: 265860
+    Lane: 4
+    EndTime: 0
+  - StartTime: 265945
+    Lane: 3
+    EndTime: 0
+  - StartTime: 265945
+    Lane: 2
+    EndTime: 0
+  - StartTime: 266030
+    Lane: 2
+    EndTime: 0
+  - StartTime: 266114
+    Lane: 1
+    EndTime: 0
+  - StartTime: 266199
+    Lane: 4
+    EndTime: 0
+  - StartTime: 266284
+    Lane: 3
+    EndTime: 0
+  - StartTime: 266284
+    Lane: 1
+    EndTime: 0
+  - StartTime: 266369
+    Lane: 3
+    EndTime: 0
+  - StartTime: 266453
+    Lane: 2
+    EndTime: 0
+  - StartTime: 266538
+    Lane: 4
+    EndTime: 0
+  - StartTime: 266623
+    Lane: 1
+    EndTime: 0
+  - StartTime: 266623
+    Lane: 3
+    EndTime: 0
+  - StartTime: 266708
+    Lane: 1
+    EndTime: 0
+  - StartTime: 266792
+    Lane: 4
+    EndTime: 267047
+  - StartTime: 266792
+    Lane: 2
+    EndTime: 0
+  - StartTime: 266877
+    Lane: 3
+    EndTime: 267131
+  - StartTime: 266962
+    Lane: 1
+    EndTime: 267301
+  - StartTime: 267047
+    Lane: 2
+    EndTime: 267216
+  - StartTime: 267131
+    Lane: 4
+    EndTime: 267386
+  - StartTime: 267216
+    Lane: 3
+    EndTime: 267386
+  - StartTime: 267301
+    Lane: 2
+    EndTime: 267470
+  - StartTime: 267386
+    Lane: 1
+    EndTime: 267470
+  - StartTime: 267470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 267470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 267513
+    Lane: 2
+    EndTime: 0
+  - StartTime: 267555
+    Lane: 1
+    EndTime: 0
+  - StartTime: 267597
+    Lane: 4
+    EndTime: 0
+  - StartTime: 267640
+    Lane: 2
+    EndTime: 0
+  - StartTime: 267640
+    Lane: 3
+    EndTime: 0
+  - StartTime: 267682
+    Lane: 1
+    EndTime: 0
+  - StartTime: 267725
+    Lane: 4
+    EndTime: 0
+  - StartTime: 267767
+    Lane: 3
+    EndTime: 0
+  - StartTime: 267809
+    Lane: 2
+    EndTime: 0
+  - StartTime: 267809
+    Lane: 1
+    EndTime: 0
+  - StartTime: 267852
+    Lane: 4
+    EndTime: 0
+  - StartTime: 267894
+    Lane: 3
+    EndTime: 0
+  - StartTime: 267936
+    Lane: 2
+    EndTime: 0
+  - StartTime: 267979
+    Lane: 1
+    EndTime: 0
+  - StartTime: 267979
+    Lane: 4
+    EndTime: 0
+  - StartTime: 268021
+    Lane: 3
+    EndTime: 0
+  - StartTime: 268064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 268106
+    Lane: 4
+    EndTime: 0
+  - StartTime: 268148
+    Lane: 1
+    EndTime: 268657
+  - StartTime: 268148
+    Lane: 3
+    EndTime: 0
+  - StartTime: 268318
+    Lane: 4
+    EndTime: 0
+  - StartTime: 268318
+    Lane: 2
+    EndTime: 0
+  - StartTime: 268572
+    Lane: 4
+    EndTime: 0
+  - StartTime: 268657
+    Lane: 2
+    EndTime: 0
+  - StartTime: 268657
+    Lane: 3
+    EndTime: 0
+  - StartTime: 268742
+    Lane: 1
+    EndTime: 0
+  - StartTime: 268826
+    Lane: 4
+    EndTime: 0
+  - StartTime: 268826
+    Lane: 3
+    EndTime: 268996
+  - StartTime: 268996
+    Lane: 2
+    EndTime: 0
+  - StartTime: 269080
+    Lane: 4
+    EndTime: 0
+  - StartTime: 269080
+    Lane: 1
+    EndTime: 269250
+  - StartTime: 269250
+    Lane: 3
+    EndTime: 0
+  - StartTime: 269335
+    Lane: 2
+    EndTime: 0
+  - StartTime: 269335
+    Lane: 4
+    EndTime: 269504
+  - StartTime: 269504
+    Lane: 1
+    EndTime: 270182
+  - StartTime: 269504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 269674
+    Lane: 4
+    EndTime: 0
+  - StartTime: 269674
+    Lane: 3
+    EndTime: 0
+  - StartTime: 269758
+    Lane: 2
+    EndTime: 0
+  - StartTime: 269928
+    Lane: 2
+    EndTime: 0
+  - StartTime: 270013
+    Lane: 3
+    EndTime: 0
+  - StartTime: 270013
+    Lane: 4
+    EndTime: 0
+  - StartTime: 270182
+    Lane: 3
+    EndTime: 0
+  - StartTime: 270182
+    Lane: 4
+    EndTime: 0
+  - StartTime: 270267
+    Lane: 2
+    EndTime: 0
+  - StartTime: 270352
+    Lane: 4
+    EndTime: 0
+  - StartTime: 270352
+    Lane: 3
+    EndTime: 0
+  - StartTime: 270436
+    Lane: 1
+    EndTime: 0
+  - StartTime: 270436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 270521
+    Lane: 4
+    EndTime: 0
+  - StartTime: 270521
+    Lane: 3
+    EndTime: 0
+  - StartTime: 270606
+    Lane: 2
+    EndTime: 0
+  - StartTime: 270691
+    Lane: 4
+    EndTime: 0
+  - StartTime: 270691
+    Lane: 1
+    EndTime: 0
+  - StartTime: 270775
+    Lane: 2
+    EndTime: 0
+  - StartTime: 270860
+    Lane: 4
+    EndTime: 0
+  - StartTime: 270860
+    Lane: 3
+    EndTime: 0
+  - StartTime: 270860
+    Lane: 1
+    EndTime: 0
+  - StartTime: 270917
+    Lane: 2
+    EndTime: 0
+  - StartTime: 270973
+    Lane: 3
+    EndTime: 0
+  - StartTime: 271030
+    Lane: 1
+    EndTime: 0
+  - StartTime: 271030
+    Lane: 4
+    EndTime: 0
+  - StartTime: 271086
+    Lane: 2
+    EndTime: 0
+  - StartTime: 271143
+    Lane: 3
+    EndTime: 0
+  - StartTime: 271199
+    Lane: 4
+    EndTime: 0
+  - StartTime: 271199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 271256
+    Lane: 2
+    EndTime: 0
+  - StartTime: 271312
+    Lane: 3
+    EndTime: 0
+  - StartTime: 271369
+    Lane: 4
+    EndTime: 0
+  - StartTime: 271369
+    Lane: 1
+    EndTime: 0
+  - StartTime: 271453
+    Lane: 3
+    EndTime: 0
+  - StartTime: 271538
+    Lane: 2
+    EndTime: 0
+  - StartTime: 271538
+    Lane: 1
+    EndTime: 0
+  - StartTime: 271623
+    Lane: 4
+    EndTime: 0
+  - StartTime: 271708
+    Lane: 2
+    EndTime: 0
+  - StartTime: 271708
+    Lane: 3
+    EndTime: 0
+  - StartTime: 271764
+    Lane: 1
+    EndTime: 0
+  - StartTime: 271792
+    Lane: 4
+    EndTime: 0
+  - StartTime: 271821
+    Lane: 2
+    EndTime: 0
+  - StartTime: 271877
+    Lane: 3
+    EndTime: 0
+  - StartTime: 271934
+    Lane: 4
+    EndTime: 0
+  - StartTime: 271962
+    Lane: 1
+    EndTime: 0
+  - StartTime: 271990
+    Lane: 2
+    EndTime: 0
+  - StartTime: 272047
+    Lane: 4
+    EndTime: 0
+  - StartTime: 272047
+    Lane: 3
+    EndTime: 0
+  - StartTime: 272103
+    Lane: 1
+    EndTime: 0
+  - StartTime: 272160
+    Lane: 2
+    EndTime: 0
+  - StartTime: 272216
+    Lane: 3
+    EndTime: 0
+  - StartTime: 272216
+    Lane: 4
+    EndTime: 0
+  - StartTime: 272329
+    Lane: 1
+    EndTime: 0
+  - StartTime: 272386
+    Lane: 3
+    EndTime: 0
+  - StartTime: 272386
+    Lane: 4
+    EndTime: 0
+  - StartTime: 272470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 272555
+    Lane: 4
+    EndTime: 0
+  - StartTime: 272612
+    Lane: 3
+    EndTime: 0
+  - StartTime: 272640
+    Lane: 2
+    EndTime: 0
+  - StartTime: 272668
+    Lane: 1
+    EndTime: 0
+  - StartTime: 272725
+    Lane: 3
+    EndTime: 0
+  - StartTime: 272725
+    Lane: 4
+    EndTime: 0
+  - StartTime: 272809
+    Lane: 1
+    EndTime: 0
+  - StartTime: 272894
+    Lane: 3
+    EndTime: 0
+  - StartTime: 272894
+    Lane: 2
+    EndTime: 0
+  - StartTime: 272951
+    Lane: 4
+    EndTime: 0
+  - StartTime: 273007
+    Lane: 3
+    EndTime: 0
+  - StartTime: 273064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 273064
+    Lane: 1
+    EndTime: 0
+  - StartTime: 273120
+    Lane: 4
+    EndTime: 0
+  - StartTime: 273148
+    Lane: 3
+    EndTime: 0
+  - StartTime: 273177
+    Lane: 2
+    EndTime: 0
+  - StartTime: 273233
+    Lane: 1
+    EndTime: 0
+  - StartTime: 273290
+    Lane: 4
+    EndTime: 0
+  - StartTime: 273318
+    Lane: 3
+    EndTime: 0
+  - StartTime: 273346
+    Lane: 2
+    EndTime: 0
+  - StartTime: 273403
+    Lane: 1
+    EndTime: 0
+  - StartTime: 273403
+    Lane: 4
+    EndTime: 0
+  - StartTime: 273445
+    Lane: 3
+    EndTime: 0
+  - StartTime: 273487
+    Lane: 2
+    EndTime: 0
+  - StartTime: 273572
+    Lane: 4
+    EndTime: 0
+  - StartTime: 273572
+    Lane: 1
+    EndTime: 0
+  - StartTime: 273657
+    Lane: 3
+    EndTime: 0
+  - StartTime: 273742
+    Lane: 1
+    EndTime: 0
+  - StartTime: 273826
+    Lane: 3
+    EndTime: 0
+  - StartTime: 273911
+    Lane: 2
+    EndTime: 0
+  - StartTime: 273911
+    Lane: 1
+    EndTime: 0
+  - StartTime: 273911
+    Lane: 4
+    EndTime: 0
+  - StartTime: 273996
+    Lane: 3
+    EndTime: 0
+  - StartTime: 274080
+    Lane: 2
+    EndTime: 0
+  - StartTime: 274080
+    Lane: 1
+    EndTime: 0
+  - StartTime: 274080
+    Lane: 4
+    EndTime: 0
+  - StartTime: 274165
+    Lane: 3
+    EndTime: 0
+  - StartTime: 274250
+    Lane: 4
+    EndTime: 0
+  - StartTime: 274250
+    Lane: 1
+    EndTime: 0
+  - StartTime: 274306
+    Lane: 2
+    EndTime: 0
+  - StartTime: 274335
+    Lane: 3
+    EndTime: 0
+  - StartTime: 274363
+    Lane: 4
+    EndTime: 0
+  - StartTime: 274419
+    Lane: 2
+    EndTime: 0
+  - StartTime: 274419
+    Lane: 1
+    EndTime: 0
+  - StartTime: 274504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 274589
+    Lane: 1
+    EndTime: 0
+  - StartTime: 274589
+    Lane: 4
+    EndTime: 0
+  - StartTime: 274674
+    Lane: 3
+    EndTime: 0
+  - StartTime: 274674
+    Lane: 2
+    EndTime: 0
+  - StartTime: 274758
+    Lane: 1
+    EndTime: 0
+  - StartTime: 274758
+    Lane: 4
+    EndTime: 0
+  - StartTime: 274843
+    Lane: 3
+    EndTime: 0
+  - StartTime: 274928
+    Lane: 4
+    EndTime: 0
+  - StartTime: 274928
+    Lane: 1
+    EndTime: 0
+  - StartTime: 274928
+    Lane: 2
+    EndTime: 0
+  - StartTime: 275267
+    Lane: 1
+    EndTime: 0
+  - StartTime: 275267
+    Lane: 4
+    EndTime: 0
+  - StartTime: 275267
+    Lane: 3
+    EndTime: 0
+  - StartTime: 275606
+    Lane: 2
+    EndTime: 0
+  - StartTime: 275606
+    Lane: 1
+    EndTime: 0
+  - StartTime: 275606
+    Lane: 4
+    EndTime: 0
+  - StartTime: 275945
+    Lane: 2
+    EndTime: 0
+  - StartTime: 275945
+    Lane: 3
+    EndTime: 0
+  - StartTime: 275945
+    Lane: 4
+    EndTime: 0
+  - StartTime: 276284
+    Lane: 1
+    EndTime: 0
+  - StartTime: 276284
+    Lane: 2
+    EndTime: 0
+  - StartTime: 276284
+    Lane: 4
+    EndTime: 0
+  - StartTime: 276369
+    Lane: 3
+    EndTime: 0
+  - StartTime: 276453
+    Lane: 1
+    EndTime: 0
+  - StartTime: 276538
+    Lane: 3
+    EndTime: 0
+  - StartTime: 276623
+    Lane: 1
+    EndTime: 0
+  - StartTime: 276623
+    Lane: 2
+    EndTime: 0
+  - StartTime: 276623
+    Lane: 4
+    EndTime: 0
+  - StartTime: 276708
+    Lane: 3
+    EndTime: 0
+  - StartTime: 276792
+    Lane: 1
+    EndTime: 0
+  - StartTime: 276877
+    Lane: 3
+    EndTime: 0
+  - StartTime: 276962
+    Lane: 1
+    EndTime: 0
+  - StartTime: 276962
+    Lane: 2
+    EndTime: 0
+  - StartTime: 276962
+    Lane: 4
+    EndTime: 0
+  - StartTime: 277047
+    Lane: 3
+    EndTime: 0
+  - StartTime: 277131
+    Lane: 1
+    EndTime: 0
+  - StartTime: 277216
+    Lane: 2
+    EndTime: 0
+  - StartTime: 277301
+    Lane: 1
+    EndTime: 0
+  - StartTime: 277301
+    Lane: 3
+    EndTime: 0
+  - StartTime: 277301
+    Lane: 4
+    EndTime: 0
+  - StartTime: 277386
+    Lane: 2
+    EndTime: 0
+  - StartTime: 277470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 277555
+    Lane: 3
+    EndTime: 0
+  - StartTime: 277640
+    Lane: 1
+    EndTime: 0
+  - StartTime: 277640
+    Lane: 2
+    EndTime: 0
+  - StartTime: 277640
+    Lane: 3
+    EndTime: 0
+  - StartTime: 277640
+    Lane: 4
+    EndTime: 0
+  - StartTime: 278996
+    Lane: 2
+    EndTime: 0
+  - StartTime: 278996
+    Lane: 4
+    EndTime: 0
+  - StartTime: 278996
+    Lane: 1
+    EndTime: 0
+  - StartTime: 279080
+    Lane: 3
+    EndTime: 0
+  - StartTime: 279165
+    Lane: 1
+    EndTime: 0
+  - StartTime: 279165
+    Lane: 2
+    EndTime: 0
+  - StartTime: 279165
+    Lane: 4
+    EndTime: 0
+  - StartTime: 279250
+    Lane: 3
+    EndTime: 0
+  - StartTime: 279335
+    Lane: 1
+    EndTime: 0
+  - StartTime: 279419
+    Lane: 2
+    EndTime: 0
+  - StartTime: 279504
+    Lane: 1
+    EndTime: 0
+  - StartTime: 279504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 279504
+    Lane: 4
+    EndTime: 0
+  - StartTime: 279589
+    Lane: 2
+    EndTime: 0
+  - StartTime: 279674
+    Lane: 3
+    EndTime: 0
+  - StartTime: 279758
+    Lane: 4
+    EndTime: 0
+  - StartTime: 279843
+    Lane: 1
+    EndTime: 0
+  - StartTime: 279843
+    Lane: 2
+    EndTime: 0
+  - StartTime: 279843
+    Lane: 3
+    EndTime: 0
+  - StartTime: 279928
+    Lane: 4
+    EndTime: 0
+  - StartTime: 280013
+    Lane: 2
+    EndTime: 0
+  - StartTime: 280097
+    Lane: 3
+    EndTime: 0
+  - StartTime: 280182
+    Lane: 1
+    EndTime: 0
+  - StartTime: 280182
+    Lane: 4
+    EndTime: 0
+  - StartTime: 280182
+    Lane: 2
+    EndTime: 0
+  - StartTime: 280267
+    Lane: 3
+    EndTime: 0
+  - StartTime: 280352
+    Lane: 1
+    EndTime: 0
+  - StartTime: 280436
+    Lane: 3
+    EndTime: 0
+  - StartTime: 280521
+    Lane: 2
+    EndTime: 0
+  - StartTime: 280521
+    Lane: 1
+    EndTime: 0
+  - StartTime: 280521
+    Lane: 4
+    EndTime: 0
+  - StartTime: 280606
+    Lane: 3
+    EndTime: 0
+  - StartTime: 280691
+    Lane: 2
+    EndTime: 0
+  - StartTime: 280775
+    Lane: 4
+    EndTime: 0
+  - StartTime: 280860
+    Lane: 2
+    EndTime: 0
+  - StartTime: 280860
+    Lane: 3
+    EndTime: 0
+  - StartTime: 280860
+    Lane: 1
+    EndTime: 0
+  - StartTime: 280945
+    Lane: 4
+    EndTime: 0
+  - StartTime: 281030
+    Lane: 3
+    EndTime: 0
+  - StartTime: 281114
+    Lane: 1
+    EndTime: 0
+  - StartTime: 281199
+    Lane: 2
+    EndTime: 0
+  - StartTime: 281199
+    Lane: 3
+    EndTime: 0
+  - StartTime: 281199
+    Lane: 4
+    EndTime: 0
+  - StartTime: 281284
+    Lane: 1
+    EndTime: 0
+  - StartTime: 281369
+    Lane: 2
+    EndTime: 0
+  - StartTime: 281453
+    Lane: 3
+    EndTime: 0
+  - StartTime: 281538
+    Lane: 1
+    EndTime: 0
+  - StartTime: 281538
+    Lane: 2
+    EndTime: 0
+  - StartTime: 281538
+    Lane: 4
+    EndTime: 0
+  - StartTime: 281623
+    Lane: 3
+    EndTime: 0
+  - StartTime: 281708
+    Lane: 1
+    EndTime: 281877
+  - StartTime: 281708
+    Lane: 2
+    EndTime: 281877
+  - StartTime: 281877
+    Lane: 3
+    EndTime: 282047
+  - StartTime: 281877
+    Lane: 4
+    EndTime: 282047
+  - StartTime: 282047
+    Lane: 1
+    EndTime: 0
+  - StartTime: 282047
+    Lane: 2
+    EndTime: 0
+  - StartTime: 282131
+    Lane: 3
+    EndTime: 0
+  - StartTime: 282131
+    Lane: 4
+    EndTime: 0
+  - StartTime: 282216
+    Lane: 2
+    EndTime: 282386
+  - StartTime: 282216
+    Lane: 1
+    EndTime: 282386
+  - StartTime: 282386
+    Lane: 3
+    EndTime: 282555
+  - StartTime: 282386
+    Lane: 4
+    EndTime: 282555
+  - StartTime: 282555
+    Lane: 1
+    EndTime: 0
+  - StartTime: 282555
+    Lane: 2
+    EndTime: 0
+  - StartTime: 282640
+    Lane: 3
+    EndTime: 0
+  - StartTime: 282640
+    Lane: 4
+    EndTime: 0
+  - StartTime: 282725
+    Lane: 1
+    EndTime: 282894
+  - StartTime: 282725
+    Lane: 2
+    EndTime: 282894
+  - StartTime: 282894
+    Lane: 3
+    EndTime: 0
+  - StartTime: 282894
+    Lane: 4
+    EndTime: 0
+  - StartTime: 282979
+    Lane: 2
+    EndTime: 0
+  - StartTime: 282979
+    Lane: 1
+    EndTime: 0
+  - StartTime: 283064
+    Lane: 3
+    EndTime: 0
+  - StartTime: 283064
+    Lane: 4
+    EndTime: 0
+  - StartTime: 283148
+    Lane: 2
+    EndTime: 0
+  - StartTime: 283233
+    Lane: 1
+    EndTime: 0
+  - StartTime: 283233
+    Lane: 4
+    EndTime: 0
+  - StartTime: 283233
+    Lane: 3
+    EndTime: 0
+  - StartTime: 283318
+    Lane: 2
+    EndTime: 0
+  - StartTime: 283403
+    Lane: 4
+    EndTime: 0
+  - StartTime: 283403
+    Lane: 1
+    EndTime: 0
+  - StartTime: 283487
+    Lane: 3
+    EndTime: 0
+  - StartTime: 283572
+    Lane: 1
+    EndTime: 0
+  - StartTime: 283572
+    Lane: 4
+    EndTime: 0
+  - StartTime: 283572
+    Lane: 2
+    EndTime: 0
+  - StartTime: 283657
+    Lane: 3
+    EndTime: 0
+  - StartTime: 283742
+    Lane: 2
+    EndTime: 0
+  - StartTime: 283742
+    Lane: 1
+    EndTime: 0
+  - StartTime: 283826
+    Lane: 3
+    EndTime: 0
+  - StartTime: 283911
+    Lane: 4
+    EndTime: 0
+  - StartTime: 283911
+    Lane: 1
+    EndTime: 0
+  - StartTime: 283911
+    Lane: 2
+    EndTime: 0
+  - StartTime: 283996
+    Lane: 3
+    EndTime: 0
+  - StartTime: 284080
+    Lane: 1
+    EndTime: 0
+  - StartTime: 284080
+    Lane: 4
+    EndTime: 0
+  - StartTime: 284165
+    Lane: 2
+    EndTime: 0
+  - StartTime: 284250
+    Lane: 1
+    EndTime: 0
+  - StartTime: 284250
+    Lane: 4
+    EndTime: 0
+  - StartTime: 284250
+    Lane: 3
+    EndTime: 0
+  - StartTime: 284335
+    Lane: 2
+    EndTime: 0
+  - StartTime: 284419
+    Lane: 3
+    EndTime: 0
+  - StartTime: 284419
+    Lane: 4
+    EndTime: 0
+  - StartTime: 284504
+    Lane: 1
+    EndTime: 0
+  - StartTime: 284589
+    Lane: 3
+    EndTime: 0
+  - StartTime: 284589
+    Lane: 2
+    EndTime: 0
+  - StartTime: 284589
+    Lane: 4
+    EndTime: 0
+  - StartTime: 284674
+    Lane: 1
+    EndTime: 0
+  - StartTime: 284758
+    Lane: 3
+    EndTime: 0
+  - StartTime: 284758
+    Lane: 2
+    EndTime: 0
+  - StartTime: 284843
+    Lane: 4
+    EndTime: 0
+  - StartTime: 284928
+    Lane: 3
+    EndTime: 0
+  - StartTime: 284928
+    Lane: 2
+    EndTime: 0
+  - StartTime: 284928
+    Lane: 1
+    EndTime: 0
+  - StartTime: 285013
+    Lane: 4
+    EndTime: 0
+  - StartTime: 285097
+    Lane: 1
+    EndTime: 0
+  - StartTime: 285097
+    Lane: 2
+    EndTime: 0
+  - StartTime: 285182
+    Lane: 4
+    EndTime: 0
+  - StartTime: 285267
+    Lane: 2
+    EndTime: 0
+  - StartTime: 285267
+    Lane: 3
+    EndTime: 0
+  - StartTime: 285267
+    Lane: 1
+    EndTime: 0
+  - StartTime: 285352
+    Lane: 4
+    EndTime: 0
+  - StartTime: 285436
+    Lane: 3
+    EndTime: 0
+  - StartTime: 285436
+    Lane: 2
+    EndTime: 0
+  - StartTime: 285521
+    Lane: 1
+    EndTime: 0
+  - StartTime: 285606
+    Lane: 2
+    EndTime: 0
+  - StartTime: 285606
+    Lane: 3
+    EndTime: 0
+  - StartTime: 285606
+    Lane: 4
+    EndTime: 0
+  - StartTime: 285691
+    Lane: 1
+    EndTime: 0
+  - StartTime: 285775
+    Lane: 3
+    EndTime: 0
+  - StartTime: 285775
+    Lane: 4
+    EndTime: 286030
+  - StartTime: 285860
+    Lane: 2
+    EndTime: 0
+  - StartTime: 285945
+    Lane: 1
+    EndTime: 0
+  - StartTime: 286030
+    Lane: 2
+    EndTime: 0
+  - StartTime: 286114
+    Lane: 3
+    EndTime: 0
+  - StartTime: 286114
+    Lane: 4
+    EndTime: 286369
+  - StartTime: 286199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 286284
+    Lane: 2
+    EndTime: 0
+  - StartTime: 286369
+    Lane: 3
+    EndTime: 0
+  - StartTime: 286453
+    Lane: 1
+    EndTime: 0
+  - StartTime: 286453
+    Lane: 4
+    EndTime: 286708
+  - StartTime: 286538
+    Lane: 3
+    EndTime: 0
+  - StartTime: 286623
+    Lane: 2
+    EndTime: 0
+  - StartTime: 286708
+    Lane: 1
+    EndTime: 0
+  - StartTime: 286792
+    Lane: 2
+    EndTime: 0
+  - StartTime: 286792
+    Lane: 4
+    EndTime: 287047
+  - StartTime: 286877
+    Lane: 3
+    EndTime: 0
+  - StartTime: 286962
+    Lane: 1
+    EndTime: 0
+  - StartTime: 287047
+    Lane: 2
+    EndTime: 0
+  - StartTime: 287131
+    Lane: 3
+    EndTime: 0
+  - StartTime: 287131
+    Lane: 4
+    EndTime: 0
+  - StartTime: 287131
+    Lane: 1
+    EndTime: 0
+  - StartTime: 287301
+    Lane: 1
+    EndTime: 0
+  - StartTime: 287301
+    Lane: 2
+    EndTime: 0
+  - StartTime: 287301
+    Lane: 4
+    EndTime: 0
+  - StartTime: 287470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 287470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 287555
+    Lane: 2
+    EndTime: 0
+  - StartTime: 287640
+    Lane: 1
+    EndTime: 0
+  - StartTime: 287640
+    Lane: 3
+    EndTime: 0
+  - StartTime: 287640
+    Lane: 4
+    EndTime: 0
+  - StartTime: 287809
+    Lane: 1
+    EndTime: 0
+  - StartTime: 287809
+    Lane: 2
+    EndTime: 0
+  - StartTime: 287809
+    Lane: 4
+    EndTime: 0
+  - StartTime: 287979
+    Lane: 3
+    EndTime: 0
+  - StartTime: 287979
+    Lane: 4
+    EndTime: 0
+  - StartTime: 288064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 288064
+    Lane: 1
+    EndTime: 0
+  - StartTime: 288148
+    Lane: 3
+    EndTime: 0
+  - StartTime: 288148
+    Lane: 4
+    EndTime: 0
+  - StartTime: 288233
+    Lane: 2
+    EndTime: 0
+  - StartTime: 288233
+    Lane: 1
+    EndTime: 0
+  - StartTime: 288318
+    Lane: 3
+    EndTime: 0
+  - StartTime: 288318
+    Lane: 4
+    EndTime: 0
+  - StartTime: 288403
+    Lane: 2
+    EndTime: 0
+  - StartTime: 288487
+    Lane: 3
+    EndTime: 0
+  - StartTime: 288487
+    Lane: 4
+    EndTime: 0
+  - StartTime: 288487
+    Lane: 1
+    EndTime: 0
+  - StartTime: 288657
+    Lane: 2
+    EndTime: 0
+  - StartTime: 288657
+    Lane: 4
+    EndTime: 0
+  - StartTime: 288742
+    Lane: 3
+    EndTime: 0
+  - StartTime: 288742
+    Lane: 1
+    EndTime: 0
+  - StartTime: 288911
+    Lane: 2
+    EndTime: 0
+  - StartTime: 288911
+    Lane: 1
+    EndTime: 0
+  - StartTime: 288996
+    Lane: 4
+    EndTime: 0
+  - StartTime: 288996
+    Lane: 3
+    EndTime: 0
+  - StartTime: 289165
+    Lane: 1
+    EndTime: 0
+  - StartTime: 289165
+    Lane: 2
+    EndTime: 0
+  - StartTime: 289335
+    Lane: 2
+    EndTime: 0
+  - StartTime: 289335
+    Lane: 4
+    EndTime: 0
+  - StartTime: 289419
+    Lane: 3
+    EndTime: 0
+  - StartTime: 289504
+    Lane: 1
+    EndTime: 0
+  - StartTime: 289589
+    Lane: 2
+    EndTime: 0
+  - StartTime: 289674
+    Lane: 4
+    EndTime: 0
+  - StartTime: 289674
+    Lane: 1
+    EndTime: 0
+  - StartTime: 289674
+    Lane: 3
+    EndTime: 0
+  - StartTime: 289843
+    Lane: 4
+    EndTime: 290521
+  - StartTime: 289843
+    Lane: 2
+    EndTime: 0
+  - StartTime: 290013
+    Lane: 1
+    EndTime: 0
+  - StartTime: 290013
+    Lane: 3
+    EndTime: 0
+  - StartTime: 290182
+    Lane: 2
+    EndTime: 0
+  - StartTime: 290267
+    Lane: 1
+    EndTime: 0
+  - StartTime: 290352
+    Lane: 2
+    EndTime: 0
+  - StartTime: 290352
+    Lane: 3
+    EndTime: 0
+  - StartTime: 290521
+    Lane: 1
+    EndTime: 0
+  - StartTime: 290521
+    Lane: 2
+    EndTime: 0
+  - StartTime: 290691
+    Lane: 2
+    EndTime: 0
+  - StartTime: 290691
+    Lane: 4
+    EndTime: 0
+  - StartTime: 290775
+    Lane: 3
+    EndTime: 0
+  - StartTime: 290860
+    Lane: 2
+    EndTime: 0
+  - StartTime: 290945
+    Lane: 1
+    EndTime: 0
+  - StartTime: 291030
+    Lane: 2
+    EndTime: 0
+  - StartTime: 291030
+    Lane: 3
+    EndTime: 0
+  - StartTime: 291030
+    Lane: 4
+    EndTime: 0
+  - StartTime: 291199
+    Lane: 3
+    EndTime: 0
+  - StartTime: 291199
+    Lane: 1
+    EndTime: 291538
+  - StartTime: 291369
+    Lane: 2
+    EndTime: 0
+  - StartTime: 291369
+    Lane: 4
+    EndTime: 0
+  - StartTime: 291538
+    Lane: 2
+    EndTime: 0
+  - StartTime: 291538
+    Lane: 3
+    EndTime: 0
+  - StartTime: 291623
+    Lane: 1
+    EndTime: 0
+  - StartTime: 291708
+    Lane: 3
+    EndTime: 0
+  - StartTime: 291708
+    Lane: 4
+    EndTime: 0
+  - StartTime: 291708
+    Lane: 2
+    EndTime: 0
+  - StartTime: 291877
+    Lane: 1
+    EndTime: 0
+  - StartTime: 291877
+    Lane: 2
+    EndTime: 0
+  - StartTime: 292047
+    Lane: 2
+    EndTime: 0
+  - StartTime: 292047
+    Lane: 4
+    EndTime: 0
+  - StartTime: 292131
+    Lane: 3
+    EndTime: 0
+  - StartTime: 292216
+    Lane: 1
+    EndTime: 0
+  - StartTime: 292301
+    Lane: 3
+    EndTime: 0
+  - StartTime: 292386
+    Lane: 4
+    EndTime: 0
+  - StartTime: 292386
+    Lane: 1
+    EndTime: 0
+  - StartTime: 292386
+    Lane: 2
+    EndTime: 0
+  - StartTime: 292555
+    Lane: 3
+    EndTime: 292894
+  - StartTime: 292555
+    Lane: 2
+    EndTime: 0
+  - StartTime: 292725
+    Lane: 2
+    EndTime: 292894
+  - StartTime: 292725
+    Lane: 1
+    EndTime: 0
+  - StartTime: 292894
+    Lane: 1
+    EndTime: 293064
+  - StartTime: 292894
+    Lane: 4
+    EndTime: 0
+  - StartTime: 292979
+    Lane: 3
+    EndTime: 0
+  - StartTime: 293064
+    Lane: 4
+    EndTime: 293233
+  - StartTime: 293064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 293148
+    Lane: 1
+    EndTime: 0
+  - StartTime: 293233
+    Lane: 2
+    EndTime: 293403
+  - StartTime: 293233
+    Lane: 3
+    EndTime: 0
+  - StartTime: 293318
+    Lane: 4
+    EndTime: 0
+  - StartTime: 293403
+    Lane: 1
+    EndTime: 293572
+  - StartTime: 293403
+    Lane: 3
+    EndTime: 0
+  - StartTime: 293487
+    Lane: 4
+    EndTime: 0
+  - StartTime: 293572
+    Lane: 3
+    EndTime: 293742
+  - StartTime: 293572
+    Lane: 2
+    EndTime: 0
+  - StartTime: 293657
+    Lane: 1
+    EndTime: 0
+  - StartTime: 293742
+    Lane: 2
+    EndTime: 293911
+  - StartTime: 293742
+    Lane: 4
+    EndTime: 0
+  - StartTime: 293826
+    Lane: 1
+    EndTime: 0
+  - StartTime: 293911
+    Lane: 4
+    EndTime: 294419
+  - StartTime: 293911
+    Lane: 3
+    EndTime: 0
+  - StartTime: 293996
+    Lane: 1
+    EndTime: 0
+  - StartTime: 294080
+    Lane: 2
+    EndTime: 0
+  - StartTime: 294080
+    Lane: 3
+    EndTime: 0
+  - StartTime: 294165
+    Lane: 1
+    EndTime: 0
+  - StartTime: 294250
+    Lane: 2
+    EndTime: 0
+  - StartTime: 294335
+    Lane: 3
+    EndTime: 0
+  - StartTime: 294419
+    Lane: 2
+    EndTime: 0
+  - StartTime: 294419
+    Lane: 1
+    EndTime: 0
+  - StartTime: 294504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 294589
+    Lane: 4
+    EndTime: 0
+  - StartTime: 294674
+    Lane: 2
+    EndTime: 0
+  - StartTime: 294758
+    Lane: 1
+    EndTime: 0
+  - StartTime: 294758
+    Lane: 3
+    EndTime: 0
+  - StartTime: 294843
+    Lane: 2
+    EndTime: 0
+  - StartTime: 294843
+    Lane: 4
+    EndTime: 0
+  - StartTime: 294928
+    Lane: 1
+    EndTime: 0
+  - StartTime: 295013
+    Lane: 3
+    EndTime: 0
+  - StartTime: 295013
+    Lane: 4
+    EndTime: 0
+  - StartTime: 295097
+    Lane: 2
+    EndTime: 0
+  - StartTime: 295097
+    Lane: 1
+    EndTime: 0
+  - StartTime: 295182
+    Lane: 3
+    EndTime: 0
+  - StartTime: 295267
+    Lane: 4
+    EndTime: 0
+  - StartTime: 295267
+    Lane: 2
+    EndTime: 0
+  - StartTime: 295352
+    Lane: 1
+    EndTime: 0
+  - StartTime: 295436
+    Lane: 3
+    EndTime: 0
+  - StartTime: 295436
+    Lane: 4
+    EndTime: 0
+  - StartTime: 295521
+    Lane: 2
+    EndTime: 0
+  - StartTime: 295606
+    Lane: 1
+    EndTime: 0
+  - StartTime: 295606
+    Lane: 4
+    EndTime: 0
+  - StartTime: 295691
+    Lane: 3
+    EndTime: 0
+  - StartTime: 295775
+    Lane: 2
+    EndTime: 0
+  - StartTime: 295775
+    Lane: 1
+    EndTime: 0
+  - StartTime: 295860
+    Lane: 3
+    EndTime: 0
+  - StartTime: 295945
+    Lane: 2
+    EndTime: 0
+  - StartTime: 295945
+    Lane: 4
+    EndTime: 0
+  - StartTime: 296030
+    Lane: 1
+    EndTime: 0
+  - StartTime: 296114
+    Lane: 3
+    EndTime: 0
+  - StartTime: 296114
+    Lane: 4
+    EndTime: 0
+  - StartTime: 296199
+    Lane: 2
+    EndTime: 0
+  - StartTime: 296199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 296284
+    Lane: 3
+    EndTime: 0
+  - StartTime: 296369
+    Lane: 4
+    EndTime: 0
+  - StartTime: 296369
+    Lane: 1
+    EndTime: 0
+  - StartTime: 296453
+    Lane: 2
+    EndTime: 0
+  - StartTime: 296453
+    Lane: 3
+    EndTime: 0
+  - StartTime: 296538
+    Lane: 4
+    EndTime: 0
+  - StartTime: 296623
+    Lane: 1
+    EndTime: 0
+  - StartTime: 296623
+    Lane: 2
+    EndTime: 0
+  - StartTime: 296708
+    Lane: 3
+    EndTime: 0
+  - StartTime: 296792
+    Lane: 2
+    EndTime: 0
+  - StartTime: 296792
+    Lane: 4
+    EndTime: 0
+  - StartTime: 296877
+    Lane: 1
+    EndTime: 0
+  - StartTime: 296962
+    Lane: 2
+    EndTime: 0
+  - StartTime: 296962
+    Lane: 4
+    EndTime: 0
+  - StartTime: 297047
+    Lane: 3
+    EndTime: 0
+  - StartTime: 297131
+    Lane: 4
+    EndTime: 0
+  - StartTime: 297131
+    Lane: 2
+    EndTime: 0
+  - StartTime: 297216
+    Lane: 1
+    EndTime: 0
+  - StartTime: 297301
+    Lane: 2
+    EndTime: 0
+  - StartTime: 297301
+    Lane: 4
+    EndTime: 0
+  - StartTime: 297386
+    Lane: 3
+    EndTime: 0
+  - StartTime: 297470
+    Lane: 2
+    EndTime: 0
+  - StartTime: 297470
+    Lane: 4
+    EndTime: 0
+  - StartTime: 297555
+    Lane: 1
+    EndTime: 0
+  - StartTime: 297640
+    Lane: 2
+    EndTime: 0
+  - StartTime: 297640
+    Lane: 4
+    EndTime: 0
+  - StartTime: 297725
+    Lane: 3
+    EndTime: 0
+  - StartTime: 297809
+    Lane: 2
+    EndTime: 0
+  - StartTime: 297809
+    Lane: 4
+    EndTime: 0
+  - StartTime: 297894
+    Lane: 1
+    EndTime: 0
+  - StartTime: 297979
+    Lane: 3
+    EndTime: 0
+  - StartTime: 297979
+    Lane: 4
+    EndTime: 0
+  - StartTime: 298064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 298064
+    Lane: 1
+    EndTime: 0
+  - StartTime: 298148
+    Lane: 3
+    EndTime: 0
+  - StartTime: 298148
+    Lane: 4
+    EndTime: 0
+  - StartTime: 298233
+    Lane: 2
+    EndTime: 0
+  - StartTime: 298233
+    Lane: 1
+    EndTime: 0
+  - StartTime: 298318
+    Lane: 3
+    EndTime: 0
+  - StartTime: 298318
+    Lane: 4
+    EndTime: 0
+  - StartTime: 298403
+    Lane: 2
+    EndTime: 0
+  - StartTime: 298487
+    Lane: 1
+    EndTime: 0
+  - StartTime: 298572
+    Lane: 2
+    EndTime: 0
+  - StartTime: 298657
+    Lane: 4
+    EndTime: 0
+  - StartTime: 298657
+    Lane: 3
+    EndTime: 0
+  - StartTime: 298742
+    Lane: 2
+    EndTime: 0
+  - StartTime: 298742
+    Lane: 1
+    EndTime: 0
+  - StartTime: 298826
+    Lane: 4
+    EndTime: 0
+  - StartTime: 298826
+    Lane: 3
+    EndTime: 0
+  - StartTime: 298911
+    Lane: 1
+    EndTime: 0
+  - StartTime: 298996
+    Lane: 3
+    EndTime: 0
+  - StartTime: 298996
+    Lane: 4
+    EndTime: 299335
+  - StartTime: 298996
+    Lane: 2
+    EndTime: 0
+  - StartTime: 299080
+    Lane: 1
+    EndTime: 0
+  - StartTime: 299165
+    Lane: 2
+    EndTime: 0
+  - StartTime: 299250
+    Lane: 3
+    EndTime: 0
+  - StartTime: 299335
+    Lane: 2
+    EndTime: 0
+  - StartTime: 299335
+    Lane: 1
+    EndTime: 0
+  - StartTime: 299419
+    Lane: 4
+    EndTime: 0
+  - StartTime: 299504
+    Lane: 3
+    EndTime: 0
+  - StartTime: 299504
+    Lane: 2
+    EndTime: 0
+  - StartTime: 299504
+    Lane: 1
+    EndTime: 0
+  - StartTime: 299589
+    Lane: 4
+    EndTime: 0
+  - StartTime: 299674
+    Lane: 3
+    EndTime: 0
+  - StartTime: 299674
+    Lane: 1
+    EndTime: 0
+  - StartTime: 299758
+    Lane: 2
+    EndTime: 0
+  - StartTime: 299843
+    Lane: 3
+    EndTime: 0
+  - StartTime: 299843
+    Lane: 1
+    EndTime: 0
+  - StartTime: 299843
+    Lane: 4
+    EndTime: 0
+  - StartTime: 299928
+    Lane: 2
+    EndTime: 0
+  - StartTime: 300013
+    Lane: 4
+    EndTime: 0
+  - StartTime: 300013
+    Lane: 1
+    EndTime: 0
+  - StartTime: 300097
+    Lane: 3
+    EndTime: 0
+  - StartTime: 300182
+    Lane: 2
+    EndTime: 0
+  - StartTime: 300182
+    Lane: 4
+    EndTime: 0
+  - StartTime: 300182
+    Lane: 1
+    EndTime: 0
+  - StartTime: 300267
+    Lane: 3
+    EndTime: 0
+  - StartTime: 300352
+    Lane: 2
+    EndTime: 0
+  - StartTime: 300352
+    Lane: 1
+    EndTime: 0
+  - StartTime: 300436
+    Lane: 4
+    EndTime: 0
+  - StartTime: 300521
+    Lane: 3
+    EndTime: 0
+  - StartTime: 300521
+    Lane: 1
+    EndTime: 0
+  - StartTime: 300521
+    Lane: 2
+    EndTime: 0
+  - StartTime: 300606
+    Lane: 4
+    EndTime: 0
+  - StartTime: 300691
+    Lane: 2
+    EndTime: 0
+  - StartTime: 300691
+    Lane: 1
+    EndTime: 0
+  - StartTime: 300775
+    Lane: 3
+    EndTime: 0
+  - StartTime: 300860
+    Lane: 4
+    EndTime: 0
+  - StartTime: 300860
+    Lane: 1
+    EndTime: 0
+  - StartTime: 300860
+    Lane: 2
+    EndTime: 0
+  - StartTime: 300945
+    Lane: 3
+    EndTime: 0
+  - StartTime: 301030
+    Lane: 4
+    EndTime: 0
+  - StartTime: 301030
+    Lane: 1
+    EndTime: 0
+  - StartTime: 301114
+    Lane: 2
+    EndTime: 0
+  - StartTime: 301199
+    Lane: 4
+    EndTime: 0
+  - StartTime: 301199
+    Lane: 3
+    EndTime: 0
+  - StartTime: 301199
+    Lane: 1
+    EndTime: 0
+  - StartTime: 301284
+    Lane: 2
+    EndTime: 0
+  - StartTime: 301369
+    Lane: 3
+    EndTime: 0
+  - StartTime: 301369
+    Lane: 4
+    EndTime: 0
+  - StartTime: 301453
+    Lane: 1
+    EndTime: 0
+  - StartTime: 301538
+    Lane: 4
+    EndTime: 0
+  - StartTime: 301538
+    Lane: 3
+    EndTime: 0
+  - StartTime: 301538
+    Lane: 2
+    EndTime: 0
+  - StartTime: 301623
+    Lane: 1
+    EndTime: 0
+  - StartTime: 301708
+    Lane: 3
+    EndTime: 0
+  - StartTime: 301708
+    Lane: 2
+    EndTime: 0
+  - StartTime: 301792
+    Lane: 4
+    EndTime: 0
+  - StartTime: 301877
+    Lane: 3
+    EndTime: 0
+  - StartTime: 301877
+    Lane: 2
+    EndTime: 0
+  - StartTime: 301877
+    Lane: 1
+    EndTime: 0
+  - StartTime: 301962
+    Lane: 4
+    EndTime: 0
+  - StartTime: 302047
+    Lane: 3
+    EndTime: 0
+  - StartTime: 302047
+    Lane: 2
+    EndTime: 0
+  - StartTime: 302047
+    Lane: 1
+    EndTime: 0
+  - StartTime: 302216
+    Lane: 2
+    EndTime: 0
+  - StartTime: 302216
+    Lane: 3
+    EndTime: 0
+  - StartTime: 302216
+    Lane: 4
+    EndTime: 0
+  - StartTime: 302386
+    Lane: 3
+    EndTime: 0
+  - StartTime: 302470
+    Lane: 3
+    EndTime: 0
+  - StartTime: 302555
+    Lane: 2
+    EndTime: 0
+  - StartTime: 302555
+    Lane: 4
+    EndTime: 0
+  - StartTime: 302555
+    Lane: 1
+    EndTime: 0
+  - StartTime: 302725
+    Lane: 1
+    EndTime: 0
+  - StartTime: 302725
+    Lane: 3
+    EndTime: 0
+  - StartTime: 302725
+    Lane: 4
+    EndTime: 0
+  - StartTime: 302894
+    Lane: 4
+    EndTime: 0
+  - StartTime: 302894
+    Lane: 2
+    EndTime: 0
+  - StartTime: 302979
+    Lane: 1
+    EndTime: 0
+  - StartTime: 302979
+    Lane: 3
+    EndTime: 0
+  - StartTime: 303064
+    Lane: 2
+    EndTime: 0
+  - StartTime: 303064
+    Lane: 4
+    EndTime: 0
+  - StartTime: 303148
+    Lane: 1
+    EndTime: 0
+  - StartTime: 303148
+    Lane: 3
+    EndTime: 0
+  - StartTime: 303233
+    Lane: 2
+    EndTime: 0
+  - StartTime: 303233
+    Lane: 4
+    EndTime: 0
+  - StartTime: 303318
+    Lane: 1
+    EndTime: 0
+  - StartTime: 303403
+    Lane: 4
+    EndTime: 0
+  - StartTime: 303403
+    Lane: 3
+    EndTime: 0
+  - StartTime: 303487
+    Lane: 2
+    EndTime: 0
+  - StartTime: 303487
+    Lane: 1
+    EndTime: 0
+  - StartTime: 303572
+    Lane: 3
+    EndTime: 0
+  - StartTime: 303572
+    Lane: 4
+    EndTime: 0
+  - StartTime: 303657
+    Lane: 2
+    EndTime: 0
+  - StartTime: 303657
+    Lane: 1
+    EndTime: 0
+  - StartTime: 303742
+    Lane: 4
+    EndTime: 0
+  - StartTime: 303742
+    Lane: 3
+    EndTime: 0
+  - StartTime: 303826
+    Lane: 2
+    EndTime: 0
+  - StartTime: 303826
+    Lane: 1
+    EndTime: 0
+  - StartTime: 303911
+    Lane: 4
+    EndTime: 0
+  - StartTime: 303911
+    Lane: 3
+    EndTime: 0
+  - StartTime: 303996
+    Lane: 2
+    EndTime: 0
+  - StartTime: 303996
+    Lane: 1
+    EndTime: 0
+  - StartTime: 304080
+    Lane: 3
+    EndTime: 0
+  - StartTime: 304080
+    Lane: 4
+    EndTime: 0
+  - StartTime: 304165
+    Lane: 2
+    EndTime: 0
+  - StartTime: 304250
+    Lane: 1
+    EndTime: 0
+  - StartTime: 304335
+    Lane: 2
+    EndTime: 0
+  - StartTime: 304419
+    Lane: 3
+    EndTime: 0
+  - StartTime: 304419
+    Lane: 1
+    EndTime: 0
+  - StartTime: 304504
+    Lane: 4
+    EndTime: 0
+  - StartTime: 304589
+    Lane: 3
+    EndTime: 0
+  - StartTime: 304674
+    Lane: 2
+    EndTime: 0
+  - StartTime: 304758
+    Lane: 4
+    EndTime: 310040
+  - StartTime: 304758
+    Lane: 1
+    EndTime: 0
+  - StartTime: 304758
+    Lane: 3
+    EndTime: 306869
+  - StartTime: 306869
+    Lane: 2
+    EndTime: 310040
+  - StartTime: 306869
+    Lane: 1
+    EndTime: 310040
+  - StartTime: 308969
+    Lane: 3
+    EndTime: 310040
+  - StartTime: 310193
+    Lane: 1
+    EndTime: 314866
+  - StartTime: 310193
+    Lane: 4
+    EndTime: 314866
+  - StartTime: 310193
+    Lane: 3
+    EndTime: 314866
+  - StartTime: 310193
+    Lane: 2
+    EndTime: 314866
+  - StartTime: 315017
+    Lane: 4
+    EndTime: 0
+  - StartTime: 315017
+    Lane: 3
+    EndTime: 0
+  - StartTime: 315017
+    Lane: 1
+    EndTime: 0
+  - StartTime: 315017
+    Lane: 2
+    EndTime: 0
+  - StartTime: 315280
+    Lane: 4
+    EndTime: 316069
+  - StartTime: 315280
+    Lane: 3
+    EndTime: 316003
+  - StartTime: 315280
+    Lane: 1
+    EndTime: 315872
+  - StartTime: 315280
+    Lane: 2
+    EndTime: 315938

--- a/Quaver.API.Tests/Quaver/Resources/timing-points-override-svs-normalized.qua
+++ b/Quaver.API.Tests/Quaver/Resources/timing-points-override-svs-normalized.qua
@@ -1,0 +1,28 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: true
+InitialScrollVelocity: 1.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 4
+  - StartTime: 10.0
+    Bpm: 2.0
+    Signature: 4
+SliderVelocities:
+  - StartTime: 5.0
+    Multiplier: 10.0
+  - StartTime: 10.0
+    Multiplier: 2.0
+HitObjects:
+  - StartTime: 0
+    Lane: 1
+    EndTime: 0
+  - StartTime: 11
+    Lane: 1
+    EndTime: 0

--- a/Quaver.API.Tests/Quaver/Resources/timing-points-override-svs.qua
+++ b/Quaver.API.Tests/Quaver/Resources/timing-points-override-svs.qua
@@ -1,0 +1,26 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: false
+InitialScrollVelocity: 0.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 4
+  - StartTime: 10.0
+    Bpm: 2.0
+    Signature: 4
+SliderVelocities:
+  - StartTime: 5.0
+    Multiplier: 10.0
+HitObjects:
+  - StartTime: 0
+    Lane: 1
+    EndTime: 0
+  - StartTime: 11
+    Lane: 1
+    EndTime: 0

--- a/Quaver.API/Maps/Qua.cs
+++ b/Quaver.API/Maps/Qua.cs
@@ -543,9 +543,9 @@ namespace Quaver.API.Maps
             // Time between SVs in milliseconds is max()'d with this number.
             const float MIN_SV_TIME_DIFFERENCE = 250;
             // SVs below this are considered the same. "Basically stationary."
-            const float MIN_MULTIPLIER = 1e-4f;
+            const float MIN_MULTIPLIER = 1e-3f;
             // SVs above this are considered the same. "Basically teleport."
-            const float MAX_MULTIPLIER = 1e4f;
+            const float MAX_MULTIPLIER = 1e2f;
 
             var qua = WithNormalizedSVs();
 

--- a/Quaver.API/Maps/Qua.cs
+++ b/Quaver.API/Maps/Qua.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -102,6 +103,25 @@ namespace Quaver.API.Maps
         public string Genre { get; set; }
 
         /// <summary>
+        ///     Indicates if the BPM changes in affect scroll velocity.
+        ///
+        ///     If this is set to false, SliderVelocities are in the denormalized format (BPM affects SV),
+        ///     and if this is set to true, SliderVelocities are in the normalized format (BPM does not affect SV).
+        ///
+        ///     Use NormalizeSVs and DenormalizeSVs to change this value.
+        ///
+        ///     It's "does not affect" rather than "affects" so that the "affects" value (in this case, false) serializes to nothing to support old maps.
+        /// </summary>
+        public bool BPMDoesNotAffectScrollVelocity { get; private set; }
+
+        /// <summary>
+        ///    The initial scroll velocity before the first SV change.
+        ///
+        ///    Only matters if BPMDoesNotAffectScrollVelocity is true.
+        /// </summary>
+        public float InitialScrollVelocity { get; set; }
+
+        /// <summary>
         ///     EditorLayer .qua data
         /// </summary>
         public List<EditorLayerInfo> EditorLayers { get; private set; } = new List<EditorLayerInfo>();
@@ -123,6 +143,9 @@ namespace Quaver.API.Maps
 
         /// <summary>
         ///     Slider Velocity .qua data
+        ///
+        ///     Note that SVs can be both in normalized and denormalized form, depending on BPMDoesNotAffectSV.
+        ///     Check WithNormalizedSVs if you need normalized SVs.
         /// </summary>
         public List<SliderVelocityInfo> SliderVelocities { get; private set; } = new List<SliderVelocityInfo>();
 
@@ -174,6 +197,9 @@ namespace Quaver.API.Maps
                    && Genre == other.Genre
                    && TimingPoints.SequenceEqual(other.TimingPoints, TimingPointInfo.ByValueComparer)
                    && SliderVelocities.SequenceEqual(other.SliderVelocities, SliderVelocityInfo.ByValueComparer)
+                   // ReSharper disable once CompareOfFloatsByEqualityOperator
+                   && InitialScrollVelocity == other.InitialScrollVelocity
+                   && BPMDoesNotAffectScrollVelocity == other.BPMDoesNotAffectScrollVelocity
                    && HitObjects.SequenceEqual(other.HitObjects, HitObjectInfo.ByValueComparer)
                    && CustomAudioSamples.SequenceEqual(other.CustomAudioSamples, CustomAudioSampleInfo.ByValueComparer)
                    && SoundEffects.SequenceEqual(other.SoundEffects, SoundEffectInfo.ByValueComparer)
@@ -231,7 +257,7 @@ namespace Quaver.API.Maps
         /// <returns></returns>
         public string Serialize()
         {
-           // Sort the object before saving.
+            // Sort the object before saving.
             Sort();
 
             // Set default values to zero so they don't waste space in the .qua file.
@@ -414,6 +440,10 @@ namespace Quaver.API.Maps
         {
             if (TimingPoints.Count == 0)
                 return 0;
+
+            // This fallback isn't really justified, but it's only used for tests.
+            if (HitObjects.Count == 0)
+                return TimingPoints[0].Bpm;
 
             var lastObject = HitObjects.OrderByDescending(x => x.IsLongNote ? x.EndTime : x.StartTime).First();
             double lastTime = lastObject.IsLongNote ? lastObject.EndTime : lastObject.StartTime;
@@ -861,6 +891,272 @@ namespace Quaver.API.Maps
 
             // Try to sort the Qua before returning.
             qua.Sort();
+        }
+
+        /// <summary>
+        ///     Converts SVs to the normalized format (BPM does not affect SV).
+        ///
+        ///     Must be done after sorting TimingPoints and SliderVelocities.
+        /// </summary>
+        public void NormalizeSVs()
+        {
+            if (BPMDoesNotAffectScrollVelocity)
+                // Already normalized.
+                return;
+
+            var baseBpm = GetCommonBpm();
+
+            var normalizedScrollVelocities = new List<SliderVelocityInfo>();
+
+            var currentBpm = TimingPoints[0].Bpm;
+            var currentSvIndex = 0;
+            float? currentSvStartTime = null;
+            var currentSvMultiplier = 1f;
+            float? currentAdjustedSvMultiplier = null;
+            float? initialSvMultiplier = null;
+
+            foreach (var timingPoint in TimingPoints)
+            {
+                while (true)
+                {
+                    if (currentSvIndex >= SliderVelocities.Count)
+                        break;
+
+                    var sv = SliderVelocities[currentSvIndex];
+                    if (sv.StartTime > timingPoint.StartTime)
+                        break;
+
+                    if (sv.StartTime < timingPoint.StartTime)
+                    {
+                        var multiplier = sv.Multiplier * (currentBpm / baseBpm);
+
+                        if (currentAdjustedSvMultiplier == null)
+                        {
+                            currentAdjustedSvMultiplier = multiplier;
+                            initialSvMultiplier = multiplier;
+                        }
+
+                        // ReSharper disable once CompareOfFloatsByEqualityOperator
+                        if (multiplier != currentAdjustedSvMultiplier.Value)
+                        {
+                            normalizedScrollVelocities.Add(new SliderVelocityInfo
+                            {
+                                StartTime = sv.StartTime,
+                                Multiplier = multiplier,
+                            });
+                            currentAdjustedSvMultiplier = multiplier;
+                        }
+                    }
+
+                    currentSvStartTime = sv.StartTime;
+                    currentSvMultiplier = sv.Multiplier;
+                    currentSvIndex += 1;
+                }
+
+                // Timing points reset the previous SV multiplier.
+                if (currentSvStartTime == null || currentSvStartTime.Value < timingPoint.StartTime)
+                    currentSvMultiplier = 1;
+
+                currentBpm = timingPoint.Bpm;
+
+                // C# is stupid.
+                var multiplierToo = currentSvMultiplier * (currentBpm / baseBpm);
+
+                if (currentAdjustedSvMultiplier == null)
+                {
+                    currentAdjustedSvMultiplier = multiplierToo;
+                    initialSvMultiplier = multiplierToo;
+                }
+
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                if (multiplierToo != currentAdjustedSvMultiplier.Value)
+                {
+                    normalizedScrollVelocities.Add(new SliderVelocityInfo
+                    {
+                        StartTime = timingPoint.StartTime,
+                        Multiplier = multiplierToo,
+                    });
+                    currentAdjustedSvMultiplier = multiplierToo;
+                }
+            }
+
+            for (; currentSvIndex < SliderVelocities.Count; currentSvIndex++)
+            {
+                var sv = SliderVelocities[currentSvIndex];
+                var multiplier = sv.Multiplier * (currentBpm / baseBpm);
+
+                Debug.Assert(currentAdjustedSvMultiplier != null, nameof(currentAdjustedSvMultiplier) + " != null");
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                if (multiplier != currentAdjustedSvMultiplier.Value)
+                {
+                    normalizedScrollVelocities.Add(new SliderVelocityInfo
+                    {
+                        StartTime = sv.StartTime,
+                        Multiplier = multiplier,
+                    });
+                    currentAdjustedSvMultiplier = multiplier;
+                }
+            }
+
+            BPMDoesNotAffectScrollVelocity = true;
+            InitialScrollVelocity = initialSvMultiplier ?? 1;
+            SliderVelocities = normalizedScrollVelocities;
+        }
+
+        /// <summary>
+        ///     Converts SVs to the denormalized format (BPM affects SV).
+        ///
+        ///     Must be done after sorting TimingPoints and SliderVelocities.
+        /// </summary>
+        public void DenormalizeSVs()
+        {
+            if (!BPMDoesNotAffectScrollVelocity)
+                // Already denormalized.
+                return;
+
+            var baseBpm = GetCommonBpm();
+
+            var denormalizedScrollVelocities = new List<SliderVelocityInfo>();
+            var currentBpm = TimingPoints[0].Bpm;
+
+            // For the purposes of this conversion, 0 and +inf should be handled like max value.
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            if (currentBpm == 0 || float.IsPositiveInfinity(currentBpm))
+                currentBpm = float.MaxValue;
+
+            var currentSvIndex = 0;
+            var currentSvMultiplier = InitialScrollVelocity;
+            float? currentAdjustedSvMultiplier = null;
+
+            for (var i = 0; i < TimingPoints.Count; i++)
+            {
+                var timingPoint = TimingPoints[i];
+                while (true)
+                {
+                    if (currentSvIndex >= SliderVelocities.Count)
+                        break;
+
+                    var sv = SliderVelocities[currentSvIndex];
+                    if (sv.StartTime > timingPoint.StartTime)
+                        break;
+
+                    if (sv.StartTime < timingPoint.StartTime)
+                    {
+                        var multiplier = sv.Multiplier / (currentBpm / baseBpm);
+
+                        // ReSharper disable once CompareOfFloatsByEqualityOperator
+                        if (currentAdjustedSvMultiplier == null || multiplier != currentAdjustedSvMultiplier)
+                        {
+                            // ReSharper disable once CompareOfFloatsByEqualityOperator
+                            if (currentAdjustedSvMultiplier == null && sv.Multiplier != InitialScrollVelocity)
+                            {
+                                // Insert an SV 1 ms earlier to simulate the initial scroll speed multiplier.
+                                denormalizedScrollVelocities.Add(new SliderVelocityInfo
+                                {
+                                    StartTime = sv.StartTime - 1,
+                                    Multiplier = InitialScrollVelocity / (currentBpm / baseBpm),
+                                });
+                            }
+
+                            denormalizedScrollVelocities.Add(new SliderVelocityInfo
+                            {
+                                StartTime = sv.StartTime,
+                                Multiplier = multiplier,
+                            });
+                            currentAdjustedSvMultiplier = multiplier;
+                        }
+                    }
+
+                    currentSvMultiplier = sv.Multiplier;
+                    currentSvIndex += 1;
+                }
+
+                currentBpm = timingPoint.Bpm;
+
+                // For the purposes of this conversion, 0 and +inf should be handled like max value.
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                if (currentBpm == 0 || float.IsPositiveInfinity(currentBpm))
+                    currentBpm = float.MaxValue;
+
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                if (currentAdjustedSvMultiplier == null && currentSvMultiplier != InitialScrollVelocity)
+                {
+                    // Insert an SV 1 ms earlier to simulate the initial scroll speed multiplier.
+                    denormalizedScrollVelocities.Add(new SliderVelocityInfo
+                    {
+                        StartTime = timingPoint.StartTime - 1,
+                        Multiplier = InitialScrollVelocity / (currentBpm / baseBpm),
+                    });
+                }
+
+                // Timing points reset the SV multiplier.
+                currentAdjustedSvMultiplier = 1;
+
+                // Skip over multiple timing points at the same timestamp.
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                if (i + 1 < TimingPoints.Count && TimingPoints[i + 1].StartTime == timingPoint.StartTime)
+                    continue;
+
+                // C# is stupid.
+                var multiplierToo = currentSvMultiplier / (currentBpm / baseBpm);
+
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                if (multiplierToo != currentAdjustedSvMultiplier.Value)
+                {
+                    denormalizedScrollVelocities.Add(new SliderVelocityInfo
+                    {
+                        StartTime = timingPoint.StartTime,
+                        Multiplier = multiplierToo,
+                    });
+                    currentAdjustedSvMultiplier = multiplierToo;
+                }
+            }
+
+            for (; currentSvIndex < SliderVelocities.Count; currentSvIndex++)
+            {
+                var sv = SliderVelocities[currentSvIndex];
+                var multiplier = sv.Multiplier / (currentBpm / baseBpm);
+
+                Debug.Assert(currentAdjustedSvMultiplier != null, nameof(currentAdjustedSvMultiplier) + " != null");
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                if (multiplier != currentAdjustedSvMultiplier.Value)
+                {
+                    denormalizedScrollVelocities.Add(new SliderVelocityInfo
+                    {
+                        StartTime = sv.StartTime,
+                        Multiplier = multiplier,
+                    });
+                    currentAdjustedSvMultiplier = multiplier;
+                }
+            }
+
+            BPMDoesNotAffectScrollVelocity = false;
+            InitialScrollVelocity = 0;
+            SliderVelocities = denormalizedScrollVelocities;
+        }
+
+        /// <summary>
+        ///     Returns a Qua with normalized SVs.
+        /// </summary>
+        /// <returns></returns>
+        public Qua WithNormalizedSVs()
+        {
+            var qua = (Qua) MemberwiseClone();
+            // Relies on NormalizeSVs not changing anything within the by-reference members (but rather creating a new List).
+            qua.NormalizeSVs();
+            return qua;
+        }
+
+        /// <summary>
+        ///     Returns a Qua with denormalized SVs.
+        /// </summary>
+        /// <returns></returns>
+        public Qua WithDenormalizedSVs()
+        {
+            var qua = (Qua) MemberwiseClone();
+            // Relies on DenormalizeSVs not changing anything within the by-reference members (but rather creating a new List).
+            qua.DenormalizeSVs();
+            return qua;
         }
     }
 }


### PR DESCRIPTION
pr with quaver changes soon tm

## SV de-/normalization

Adds SV normalization and denormalization routines to Qua. Normalized means "BPM does not affect SV", denormalized means "BPM affects SV".

Additionally, a new .qua field is added, BPMDoesNotAffectScrollVelocity. When this is set to true, SVs are assumed to be normalized in the .qua itself. If this flag is set before serializing, the .qua will be saved with normalized SVs. cc https://github.com/Quaver/Quaver/issues/631

The normalization and denormalization routines were converted from the [plitki implementation](https://github.com/YaLTeR/plitki/blob/41e9dd034848222d5047524bd1a5fe74e1f88dab/plitki-map-qua/src/lib.rs#L289), which was very well tested. All tests were converted from there too.

This does not fix= https://github.com/Quaver/Quaver/issues/1189 which means that issue is elsewhere in the Quaver code.

## SV factor

I went through a few different iterations with this one, and the one in the PR seems to work best. That isn't to say it works extremely well, but it gets the job done more or less.

For future experiments, I attach a zip-archive of Quaver databases with SV factor computed for 15k osu!mania maps for every commit from [my experimental branch](https://github.com/YaLTeR/Quaver.API/tree/sv-changes). Open them with [SQLite Browser](https://sqlitebrowser.org/), go to the Browse Data tab, click on the SVFactor header to sort by it. Hide unnecessary columns by left-click-dragging on the headers, right clicking and choosing Hide selected columns.

[sv-changes-databases.zip](https://github.com/Quaver/Quaver.API/files/4323015/sv-changes-databases.zip)
