### PR TITLE
add scaling to beginner difficulties

### DIFF
--- a/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
+++ b/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
@@ -568,7 +568,7 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
         private void ComputeNoteDensityData(float rate)
         {
             //MapLength = Qua.Length;
-            AverageNoteDensity = SECONDS_TO_MILLISECONDS * Map.HitObjects.Count / (Map.Length * (2- rate));
+            AverageNoteDensity = SECONDS_TO_MILLISECONDS * Map.HitObjects.Count / (Map.Length * (-.5f * rate + 1.5f));
 
             //todo: solve note density graph
             // put stuff here

--- a/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
+++ b/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
@@ -582,17 +582,18 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
             // todo: temp. Linear for now
             // todo: apply cosine curve
             const float lowestDifficulty = 1;
+            float densityMultiplier = .266f;
+            float densityDifficultyMin = .4f;
 
             // calculate ratio between min and max value
             var ratio = Math.Max(0, (duration - xMin) / (xMax - xMin));
-            //if ratio is too big scale based on nps instead
-            if (ratio > 1)
+            //if ratio is too big and map isnt a beginner map (nps > 4) scale based on nps instead
+            if (ratio > 1 && AverageNoteDensity < 4)
             {
+                //if note density is too low dont bother calculating for density either
                 if (AverageNoteDensity < 1)
-                    return .4f;
-                if (AverageNoteDensity > 4)
-                    return AverageNoteDensity * .5f;
-                return AverageNoteDensity * .266f + .134f;
+                    return densityDifficultyMin;
+                return AverageNoteDensity * densityMultiplier + .134f;
             }
             ratio = 1 - Math.Min(1, ratio);
 


### PR DESCRIPTION
when a map has patterns so slow that the calc determines them outside the boundaries for the lower threshold of a pattern (as defined in StrainConstantsKeys) it will isntead scale its qr value based on the nps of the difficulty (ranging from .4 to ~1.2) which adds a lot more scaling to beginner difficulties than there were before and will help guide beginners much better (no more easies being lower than beginners)

I also added another condition where if this specific part is in a much harder map it will impact it less.