### PR TITLE
Difficulty calculator improvements

### DIFF
--- a/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
+++ b/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
@@ -26,7 +26,7 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
         /// <summary>
         ///     The version of the processor.
         /// </summary>
-        public static string Version { get; } = "0.0.3";
+        public static string Version { get; } = "0.0.4";
 
         /// <summary>
         ///     Constants used for solving

--- a/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
+++ b/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
@@ -548,7 +548,6 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
             foreach (var data in StrainSolverData)
                 data.CalculateStrainValue();
 
-
             var maxStrain = StrainSolverData.Select(s => s.TotalStrainValue).Max();
 
             /*
@@ -563,7 +562,7 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
              * strainCountAvg if a section is low in strain
              */
             var strainCountAvg = (float)StrainSolverData.Select(
-                s => 0.9 + 0.15 * Math.Sqrt(s.TotalStrainValue / maxStrain)
+                s => 0.15 * Math.Sqrt(s.TotalStrainValue / maxStrain) + 0.9
             ).Sum();
 
             var mapStart = float.MaxValue;
@@ -606,7 +605,8 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                                ( shortMapThreshold - shortMapThresholdFloor );
 
             var shortMapMultiplier = Math.Min(1, Math.Max(maxShortNerf,
-                maxShortNerf + ( 1 - maxShortNerf ) * mapShortness));
+                ( 1 - maxShortNerf ) * mapShortness + maxShortNerf
+            ));
 
             calculatedDiff *= shortMapMultiplier;
 

--- a/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
+++ b/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
@@ -462,9 +462,6 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                 // Check if data is LN
                 if (data.EndTime > data.StartTime)
                 {
-                    if (Map.Mode == GameMode.Keys4 && Math.Abs(data.EndTime - data.StartTime) < shortLnThreshold)
-                        continue;
-
                     var durationValue = 1 - Math.Min(1, Math.Max(0, (StrainConstants.LnLayerThresholdMs + StrainConstants.LnLayerToleranceMs
                                                                      - (data.EndTime - data.StartTime)) / StrainConstants.LnLayerToleranceMs));
 

--- a/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
+++ b/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
@@ -146,12 +146,11 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
             // Compute for overall difficulty
             switch (Map.Mode)
             {
-                case ( GameMode.Keys4 ):
+                case GameMode.Keys4:
                     OverallDifficulty = ComputeForOverallDifficulty(rate);
                     break;
-                case ( GameMode.Keys7 ):
-                    OverallDifficulty = ( ComputeForOverallDifficulty(rate, Hand.Left) +
-                                          ComputeForOverallDifficulty(rate, Hand.Right) ) / 2;
+                case GameMode.Keys7:
+                    OverallDifficulty = (ComputeForOverallDifficulty(rate, Hand.Left) + ComputeForOverallDifficulty(rate, Hand.Right) ) / 2;
                     break;
             }
         }
@@ -284,8 +283,7 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                     if (curHitOb.Hand == nextHitOb.Hand && nextHitOb.StartTime > curHitOb.StartTime)
                     {
                         // Determined by if there's a minijack within 2 set of chords/single notes
-                        var actionJackFound =
-                            ( (int) nextHitOb.FingerState & ( 1 << (int) curHitOb.FingerState - 1 ) ) != 0;
+                        var actionJackFound = ((int) nextHitOb.FingerState & (1 << (int) curHitOb.FingerState - 1)) != 0;
 
                         // Determined by if a chord is found in either finger state
                         var actionChordFound = curHitOb.HandChord || nextHitOb.HandChord;
@@ -360,7 +358,8 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
         }
 
         /// <summary>
-        ///     Scans for roll manipulation. "Roll Manipulation" is definced as notes in sequence "A -> B -> A" with one action at least twice as long as the other.
+        ///     Scans for roll manipulation. "Roll Manipulation" is definced as notes in sequence
+        ///     "A -> B -> A" with one action at least twice as long as the other.
         /// </summary>
         private void ComputeForRollManipulation()
         {
@@ -383,24 +382,22 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                         if (data.FingerState == last.FingerState)
                         {
                             // Get action duration ratio from both actions
-                            var durationRatio = Math.Max(data.FingerActionDurationMs / middle.FingerActionDurationMs,
-                                middle.FingerActionDurationMs / data.FingerActionDurationMs);
+                            var durationRatio = Math.Max(data.FingerActionDurationMs / middle.FingerActionDurationMs, middle.FingerActionDurationMs / data.FingerActionDurationMs);
 
                             // If the ratio is above this threshold, count it as a roll manipulation
                             if (durationRatio >= StrainConstants.RollRatioToleranceMs)
                             {
                                 // Apply multiplier
                                 // todo: catch possible arithmetic error (division by 0)
-                                var durationMultiplier =
-                                    1 / ( 1 + ( ( durationRatio - 1 ) * StrainConstants.RollRatioMultiplier ) );
-                                var manipulationFoundRatio =
-                                    1 - ( ( manipulationIndex / StrainConstants.RollMaxLength ) *
-                                          ( 1 - StrainConstants.RollLengthMultiplier ) );
+                                var durationMultiplier = 1 / (1 + (durationRatio - 1) * StrainConstants.RollRatioMultiplier);
+
+                                var manipulationFoundRatio = 1 - manipulationIndex / StrainConstants.RollMaxLength * (1 - StrainConstants.RollLengthMultiplier);
                                 data.RollManipulationStrainMultiplier = durationMultiplier * manipulationFoundRatio;
 
                                 // Count manipulation
                                 manipulationFound = true;
                                 RollInaccuracyConfidence++;
+
                                 if (manipulationIndex < StrainConstants.RollMaxLength)
                                     manipulationIndex++;
                             }
@@ -430,6 +427,7 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                 if (data.NextStrainSolverDataOnCurrentHand != null)
                 {
                     var next = data.NextStrainSolverDataOnCurrentHand;
+
                     if (data.FingerAction == FingerAction.SimpleJack && next.FingerAction == FingerAction.SimpleJack)
                     {
                         // Apply multiplier
@@ -439,18 +437,16 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                         //          93.7ms = 160bpm 1/4 vibro
 
                         // 35f = 35ms tolerance before hitting vibro point (88.2ms, 170bpm vibro)
-                        var durationValue = Math.Min(1,
-                            Math.Max(0,
-                                ( ( StrainConstants.VibroActionDurationMs + StrainConstants.VibroActionToleranceMs ) -
-                                  data.FingerActionDurationMs ) / StrainConstants.VibroActionToleranceMs));
-                        var durationMultiplier = 1 - ( durationValue * ( 1 - StrainConstants.VibroMultiplier ) );
-                        var manipulationFoundRatio = 1 - ( ( longJackSize / StrainConstants.VibroMaxLength ) *
-                                                           ( 1 - StrainConstants.VibroLengthMultiplier ) );
+                        var durationValue = Math.Min(1, Math.Max(0, (StrainConstants.VibroActionDurationMs + StrainConstants.VibroActionToleranceMs - data.FingerActionDurationMs ) / StrainConstants.VibroActionToleranceMs));
+
+                        var durationMultiplier = 1 - durationValue * (1 - StrainConstants.VibroMultiplier);
+                        var manipulationFoundRatio = 1 - longJackSize / StrainConstants.VibroMaxLength * (1 - StrainConstants.VibroLengthMultiplier);
                         data.RollManipulationStrainMultiplier = durationMultiplier * manipulationFoundRatio;
 
                         // Count manipulation
                         manipulationFound = true;
                         VibroInaccuracyConfidence++;
+
                         if (longJackSize < StrainConstants.VibroMaxLength)
                             longJackSize++;
                     }
@@ -475,34 +471,34 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                 // Check if data is LN
                 if (data.EndTime > data.StartTime)
                 {
-                    var durationValue = 1 - Math.Min(1, Math.Max(0,
-                        ( StrainConstants.LnLayerThresholdMs + StrainConstants.LnLayerToleranceMs
-                          - ( data.EndTime - data.StartTime ) ) / StrainConstants.LnLayerToleranceMs));
+                    var durationValue = 1 - Math.Min(1, Math.Max(0, (StrainConstants.LnLayerThresholdMs + StrainConstants.LnLayerToleranceMs - (data.EndTime - data.StartTime)) / StrainConstants.LnLayerToleranceMs));
 
                     var lnLength = Math.Abs(data.EndTime - data.StartTime);
                     var shortLnMultiplier = 1f;
+
                     if (Map.Mode == GameMode.Keys4)
                     {
                         // if ln is 150/4, then 1
                         // if ln is 180/4, then 0
-                        var lnShortness = ( shortLnThreshold - Math.Max(lnLength, shortLnThresholdCeiling) ) /
-                                          ( shortLnThreshold - shortLnThresholdCeiling );
+                        var lnShortness = (shortLnThreshold - Math.Max(lnLength, shortLnThresholdCeiling)) / (shortLnThreshold - shortLnThresholdCeiling);
                         shortLnMultiplier = 1 - Math.Min(1, Math.Max(0, lnShortness));
                     }
 
-                    var baseMultiplier =
-                        1 + (float) ( ( 1 - durationValue ) * StrainConstants.LnBaseMultiplier * shortLnMultiplier );
+                    var baseMultiplier = 1 + (1 - durationValue) * StrainConstants.LnBaseMultiplier * shortLnMultiplier;
+
                     foreach (var k in data.HitObjects)
                         k.LnStrainMultiplier = baseMultiplier;
 
                     // Check if next data point exists on current hand
                     var next = data.NextStrainSolverDataOnCurrentHand;
+
                     if (next != null)
-
-                        // Check to see if the target hitobject is layered inside the current LN
+                    {
+                         // Check to see if the target hitobject is layered inside the current LN
                         if (next.StartTime < data.EndTime - StrainConstants.LnEndThresholdMs)
+                        {
                             if (next.StartTime >= data.StartTime + StrainConstants.LnEndThresholdMs)
-
+                            {
                                 // Target hitobject's LN ends after current hitobject's LN end.
                                 if (next.EndTime > data.EndTime + StrainConstants.LnEndThresholdMs)
                                 {
@@ -532,6 +528,9 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                                         k.LnStrainMultiplier *= StrainConstants.LnTapMultiplier;
                                     }
                                 }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -557,7 +556,7 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
         /// <returns></returns>
         private float CalculateOverallDifficulty()
         {
-            float calculatedDiff = 0;
+            float calculatedDiff;
 
             // Solve strain value of every data point
             foreach (var data in StrainSolverData)
@@ -571,10 +570,12 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
 
             var mapStart = StrainSolverData.Min(s => s.StartTime);
             var mapEnd = StrainSolverData.Max(s => Math.Max(s.StartTime, s.EndTime));
+
             for (var i = mapStart; i < mapEnd; i += binSize)
             {
                 var valuesInBin = StrainSolverData.Where(s => s.StartTime >= i && s.StartTime < i + binSize).ToList();
                 var averageRating = valuesInBin.Count > 0 ? valuesInBin.Average(s => s.TotalStrainValue) : 0;
+
                 bins.Add(averageRating);
             }
 
@@ -594,13 +595,16 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
             // Average of the hardest 40% of the map
             var cutoffPos = (int)Math.Floor(bins.Count * 0.4);
             var top40 = bins.OrderByDescending(s => s).Take(cutoffPos);
-            var easyRatingCutoff = top40.Any() ? top40.Average() : 0;
+            var enumerable = top40 as float[] ?? top40.ToArray();
+            var easyRatingCutoff = enumerable.Any() ? enumerable.Average() : 0;
 
-            // We do not consider sections without notes, since there are no "easy notes". Those sections have barely affected the rating in the old difficulty calculator.
+            // We do not consider sections without notes, since there are no "easy notes". Those sections have barely
+            // affected the rating in the old difficulty calculator.
             var continuity = (float) bins.Where(strain => strain > 0)
                 .Average(strain => Math.Sqrt(strain / easyRatingCutoff));
 
-            // The average continuity of maps in our dataset has been observed to be around 0.85, so we take that as the reference value to keep the rating the same.
+            // The average continuity of maps in our dataset has been observed to be around 0.85, so we take that
+            // as the reference value to keep the rating the same.
             const float maxContinuity = 1.00f;
             const float avgContinuity = 0.85f;
             const float minContinuity = 0.60f;
@@ -614,16 +618,13 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
             if (continuity > avgContinuity)
             {
                 var continuityFactor = 1 - (continuity - avgContinuity)/(maxContinuity - avgContinuity);
-                continuityAdjustment = Math.Min(avgAdjustment, Math.Max(minAdjustment,
-                    ( continuityFactor * ( avgAdjustment - minAdjustment ) ) + minAdjustment
+                continuityAdjustment = Math.Min(avgAdjustment, Math.Max(minAdjustment, continuityFactor * ( avgAdjustment - minAdjustment ) + minAdjustment
                 ));
             }
             else
             {
                 var continuityFactor = 1 - (continuity - minContinuity)/(avgContinuity - minContinuity);
-                continuityAdjustment = Math.Min(maxAdjustment, Math.Max(avgAdjustment,
-                    ( continuityFactor * ( maxAdjustment - avgAdjustment ) ) + avgAdjustment
-                ));
+                continuityAdjustment = Math.Min(maxAdjustment, Math.Max(avgAdjustment, continuityFactor * (maxAdjustment - avgAdjustment) + avgAdjustment));
             }
 
             calculatedDiff *= continuityAdjustment;
@@ -637,9 +638,7 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
             const float shortMapThreshold = 60 * SECONDS_TO_MILLISECONDS; // Start applying the nerf once a map is shorter
 
             var trueDrainTime = bins.Count * continuity * binSize;
-            var shortMapAdjustment = (float)Math.Min(1, Math.Max(maxShortMapAdjustment,
-                ( 0.25 * Math.Sqrt(trueDrainTime / shortMapThreshold) ) + 0.75
-            ));
+            var shortMapAdjustment = (float)Math.Min(1, Math.Max(maxShortMapAdjustment, 0.25 * Math.Sqrt(trueDrainTime / shortMapThreshold) + 0.75));
 
             calculatedDiff *= shortMapAdjustment;
 
@@ -654,11 +653,7 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
         private void ComputeNoteDensityData(float rate)
         {
             //MapLength = Qua.Length;
-            AverageNoteDensity =
-                SECONDS_TO_MILLISECONDS * Map.HitObjects.Count / ( Map.Length * ( -.5f * rate + 1.5f ) );
-
-            //todo: solve note density graph
-            // put stuff here
+            AverageNoteDensity = SECONDS_TO_MILLISECONDS * Map.HitObjects.Count / ( Map.Length * ( -.5f * rate + 1.5f ) );
         }
 
         /// <summary>
@@ -669,24 +664,26 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
             // todo: temp. Linear for now
             // todo: apply cosine curve
             const float lowestDifficulty = 1;
-            float densityMultiplier = .266f;
-            float densityDifficultyMin = .4f;
+            const float densityMultiplier = .266f;
+            const float densityDifficultyMin = .4f;
 
             // calculate ratio between min and max value
-            var ratio = Math.Max(0, ( duration - xMin ) / ( xMax - xMin ));
+            var ratio = Math.Max(0, (duration - xMin) / (xMax - xMin));
+
             //if ratio is too big and map isnt a beginner map (nps > 4) scale based on nps instead
             if (ratio > 1 && AverageNoteDensity < 4)
             {
                 //if note density is too low dont bother calculating for density either
                 if (AverageNoteDensity < 1)
                     return densityDifficultyMin;
+
                 return AverageNoteDensity * densityMultiplier + .134f;
             }
 
             ratio = 1 - Math.Min(1, ratio);
 
             // compute for difficulty
-            return lowestDifficulty + ( strainMax - lowestDifficulty ) * (float) Math.Pow(ratio, exp);
+            return lowestDifficulty + (strainMax - lowestDifficulty) * (float) Math.Pow(ratio, exp);
         }
     }
 }

--- a/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
+++ b/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
@@ -48,10 +48,10 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
         /// </summary>
         private Dictionary<int, Hand> LaneToHand4K { get; set; } = new Dictionary<int, Hand>()
         {
-            { 1, Hand.Left },
-            { 2, Hand.Left },
-            { 3, Hand.Right },
-            { 4, Hand.Right }
+            {1, Hand.Left},
+            {2, Hand.Left},
+            {3, Hand.Right},
+            {4, Hand.Right}
         };
 
         /// <summary>
@@ -59,13 +59,13 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
         /// </summary>
         private Dictionary<int, Hand> LaneToHand7K { get; set; } = new Dictionary<int, Hand>()
         {
-            { 1, Hand.Left },
-            { 2, Hand.Left },
-            { 3, Hand.Left },
-            { 4, Hand.Ambiguous },
-            { 5, Hand.Right },
-            { 6, Hand.Right },
-            { 7, Hand.Right }
+            {1, Hand.Left},
+            {2, Hand.Left},
+            {3, Hand.Left},
+            {4, Hand.Ambiguous},
+            {5, Hand.Right},
+            {6, Hand.Right},
+            {7, Hand.Right}
         };
 
         /// <summary>
@@ -73,10 +73,10 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
         /// </summary>
         private Dictionary<int, FingerState> LaneToFinger4K { get; set; } = new Dictionary<int, FingerState>()
         {
-            { 1, FingerState.Middle },
-            { 2, FingerState.Index },
-            { 3, FingerState.Index },
-            { 4, FingerState.Middle }
+            {1, FingerState.Middle},
+            {2, FingerState.Index},
+            {3, FingerState.Index},
+            {4, FingerState.Middle}
         };
 
         /// <summary>
@@ -84,13 +84,13 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
         /// </summary>
         private Dictionary<int, FingerState> LaneToFinger7K { get; set; } = new Dictionary<int, FingerState>()
         {
-            { 1, FingerState.Ring },
-            { 2, FingerState.Middle },
-            { 3, FingerState.Index },
-            { 4, FingerState.Thumb },
-            { 5, FingerState.Index },
-            { 6, FingerState.Middle },
-            { 7, FingerState.Ring }
+            {1, FingerState.Ring},
+            {2, FingerState.Middle},
+            {3, FingerState.Index},
+            {4, FingerState.Thumb},
+            {5, FingerState.Index},
+            {6, FingerState.Middle},
+            {7, FingerState.Ring}
         };
 
         /// <summary>
@@ -110,10 +110,11 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
         /// <param name="constants"></param>
         /// <param name="mods"></param>
         /// <param name="detailedSolve"></param>
-        public DifficultyProcessorKeys(Qua map, StrainConstants constants, ModIdentifier mods = ModIdentifier.None, bool detailedSolve = false) : base(map, constants, mods)
+        public DifficultyProcessorKeys(Qua map, StrainConstants constants, ModIdentifier mods = ModIdentifier.None,
+            bool detailedSolve = false) : base(map, constants, mods)
         {
             // Cast the current Strain Constants Property to the correct type.
-            StrainConstants = (StrainConstantsKeys)constants;
+            StrainConstants = (StrainConstantsKeys) constants;
 
             // Don't bother calculating map difficulty if there's less than 2 hit objects
             if (map.HitObjects.Count < 2)
@@ -145,11 +146,12 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
             // Compute for overall difficulty
             switch (Map.Mode)
             {
-                case (GameMode.Keys4):
+                case ( GameMode.Keys4 ):
                     OverallDifficulty = ComputeForOverallDifficulty(rate);
                     break;
-                case (GameMode.Keys7):
-                    OverallDifficulty = (ComputeForOverallDifficulty(rate, Hand.Left) + ComputeForOverallDifficulty(rate, Hand.Right))/2;
+                case ( GameMode.Keys7 ):
+                    OverallDifficulty = ( ComputeForOverallDifficulty(rate, Hand.Left) +
+                                          ComputeForOverallDifficulty(rate, Hand.Right) ) / 2;
                     break;
             }
         }
@@ -200,7 +202,9 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                         break;
                     case GameMode.Keys7:
                         curHitOb.FingerState = LaneToFinger7K[Map.HitObjects[i].Lane];
-                        curStrainData.Hand = LaneToHand7K[Map.HitObjects[i].Lane] == Hand.Ambiguous ? assumeHand : LaneToHand7K[Map.HitObjects[i].Lane];
+                        curStrainData.Hand = LaneToHand7K[Map.HitObjects[i].Lane] == Hand.Ambiguous
+                            ? assumeHand
+                            : LaneToHand7K[Map.HitObjects[i].Lane];
                         break;
                 }
 
@@ -280,7 +284,8 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                     if (curHitOb.Hand == nextHitOb.Hand && nextHitOb.StartTime > curHitOb.StartTime)
                     {
                         // Determined by if there's a minijack within 2 set of chords/single notes
-                        var actionJackFound = ((int)nextHitOb.FingerState & (1 << (int)curHitOb.FingerState - 1)) != 0;
+                        var actionJackFound =
+                            ( (int) nextHitOb.FingerState & ( 1 << (int) curHitOb.FingerState - 1 ) ) != 0;
 
                         // Determined by if a chord is found in either finger state
                         var actionChordFound = curHitOb.HandChord || nextHitOb.HandChord;
@@ -352,7 +357,6 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
         /// <param name="qssData"></param>
         private void ComputeForActionPatterns()
         {
-
         }
 
         /// <summary>
@@ -368,7 +372,8 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                 var manipulationFound = false;
 
                 // Check to see if the current data point has two other following points
-                if (data.NextStrainSolverDataOnCurrentHand != null && data.NextStrainSolverDataOnCurrentHand.NextStrainSolverDataOnCurrentHand != null)
+                if (data.NextStrainSolverDataOnCurrentHand != null &&
+                    data.NextStrainSolverDataOnCurrentHand.NextStrainSolverDataOnCurrentHand != null)
                 {
                     var middle = data.NextStrainSolverDataOnCurrentHand;
                     var last = data.NextStrainSolverDataOnCurrentHand.NextStrainSolverDataOnCurrentHand;
@@ -378,15 +383,19 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                         if (data.FingerState == last.FingerState)
                         {
                             // Get action duration ratio from both actions
-                            var durationRatio = Math.Max(data.FingerActionDurationMs / middle.FingerActionDurationMs, middle.FingerActionDurationMs / data.FingerActionDurationMs);
+                            var durationRatio = Math.Max(data.FingerActionDurationMs / middle.FingerActionDurationMs,
+                                middle.FingerActionDurationMs / data.FingerActionDurationMs);
 
                             // If the ratio is above this threshold, count it as a roll manipulation
                             if (durationRatio >= StrainConstants.RollRatioToleranceMs)
                             {
                                 // Apply multiplier
                                 // todo: catch possible arithmetic error (division by 0)
-                                var durationMultiplier = 1 / (1 + ((durationRatio - 1) * StrainConstants.RollRatioMultiplier));
-                                var manipulationFoundRatio = 1 - ((manipulationIndex / StrainConstants.RollMaxLength) * (1 - StrainConstants.RollLengthMultiplier));
+                                var durationMultiplier =
+                                    1 / ( 1 + ( ( durationRatio - 1 ) * StrainConstants.RollRatioMultiplier ) );
+                                var manipulationFoundRatio =
+                                    1 - ( ( manipulationIndex / StrainConstants.RollMaxLength ) *
+                                          ( 1 - StrainConstants.RollLengthMultiplier ) );
                                 data.RollManipulationStrainMultiplier = durationMultiplier * manipulationFoundRatio;
 
                                 // Count manipulation
@@ -418,7 +427,7 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                 var manipulationFound = false;
 
                 // Check to see if the current data point has a following data point
-                if (data.NextStrainSolverDataOnCurrentHand != null )
+                if (data.NextStrainSolverDataOnCurrentHand != null)
                 {
                     var next = data.NextStrainSolverDataOnCurrentHand;
                     if (data.FingerAction == FingerAction.SimpleJack && next.FingerAction == FingerAction.SimpleJack)
@@ -430,9 +439,13 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                         //          93.7ms = 160bpm 1/4 vibro
 
                         // 35f = 35ms tolerance before hitting vibro point (88.2ms, 170bpm vibro)
-                        var durationValue = Math.Min(1, Math.Max(0, ((StrainConstants.VibroActionDurationMs + StrainConstants.VibroActionToleranceMs) - data.FingerActionDurationMs) / StrainConstants.VibroActionToleranceMs));
-                        var durationMultiplier = 1 - (durationValue * (1 - StrainConstants.VibroMultiplier));
-                        var manipulationFoundRatio = 1 - ((longJackSize / StrainConstants.VibroMaxLength) * (1 - StrainConstants.VibroLengthMultiplier));
+                        var durationValue = Math.Min(1,
+                            Math.Max(0,
+                                ( ( StrainConstants.VibroActionDurationMs + StrainConstants.VibroActionToleranceMs ) -
+                                  data.FingerActionDurationMs ) / StrainConstants.VibroActionToleranceMs));
+                        var durationMultiplier = 1 - ( durationValue * ( 1 - StrainConstants.VibroMultiplier ) );
+                        var manipulationFoundRatio = 1 - ( ( longJackSize / StrainConstants.VibroMaxLength ) *
+                                                           ( 1 - StrainConstants.VibroLengthMultiplier ) );
                         data.RollManipulationStrainMultiplier = durationMultiplier * manipulationFoundRatio;
 
                         // Count manipulation
@@ -462,8 +475,9 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                 // Check if data is LN
                 if (data.EndTime > data.StartTime)
                 {
-                    var durationValue = 1 - Math.Min(1, Math.Max(0, (StrainConstants.LnLayerThresholdMs + StrainConstants.LnLayerToleranceMs
-                                                                     - (data.EndTime - data.StartTime)) / StrainConstants.LnLayerToleranceMs));
+                    var durationValue = 1 - Math.Min(1, Math.Max(0,
+                        ( StrainConstants.LnLayerThresholdMs + StrainConstants.LnLayerToleranceMs
+                          - ( data.EndTime - data.StartTime ) ) / StrainConstants.LnLayerToleranceMs));
 
                     var lnLength = Math.Abs(data.EndTime - data.StartTime);
                     var shortLnMultiplier = 1f;
@@ -476,7 +490,8 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                         shortLnMultiplier = 1 - Math.Min(1, Math.Max(0, lnShortness));
                     }
 
-                    var baseMultiplier = 1 + (float) ( ( 1 - durationValue ) * StrainConstants.LnBaseMultiplier * shortLnMultiplier );
+                    var baseMultiplier =
+                        1 + (float) ( ( 1 - durationValue ) * StrainConstants.LnBaseMultiplier * shortLnMultiplier );
                     foreach (var k in data.HitObjects)
                         k.LnStrainMultiplier = baseMultiplier;
 
@@ -484,39 +499,39 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                     var next = data.NextStrainSolverDataOnCurrentHand;
                     if (next != null)
 
-                    // Check to see if the target hitobject is layered inside the current LN
-                    if (next.StartTime < data.EndTime - StrainConstants.LnEndThresholdMs)
-                    if (next.StartTime >= data.StartTime + StrainConstants.LnEndThresholdMs)
+                        // Check to see if the target hitobject is layered inside the current LN
+                        if (next.StartTime < data.EndTime - StrainConstants.LnEndThresholdMs)
+                            if (next.StartTime >= data.StartTime + StrainConstants.LnEndThresholdMs)
 
-                    // Target hitobject's LN ends after current hitobject's LN end.
-                    if (next.EndTime > data.EndTime + StrainConstants.LnEndThresholdMs)
-                    {
-                        foreach (var k in data.HitObjects)
-                        {
-                            k.LnLayerType = LnLayerType.OutsideRelease;
-                            k.LnStrainMultiplier *= StrainConstants.LnReleaseAfterMultiplier;
-                        }
-                    }
+                                // Target hitobject's LN ends after current hitobject's LN end.
+                                if (next.EndTime > data.EndTime + StrainConstants.LnEndThresholdMs)
+                                {
+                                    foreach (var k in data.HitObjects)
+                                    {
+                                        k.LnLayerType = LnLayerType.OutsideRelease;
+                                        k.LnStrainMultiplier *= StrainConstants.LnReleaseAfterMultiplier;
+                                    }
+                                }
 
-                    // Target hitobject's LN ends before current hitobject's LN end
-                    else if (next.EndTime > 0)
-                    {
-                        foreach (var k in data.HitObjects)
-                        {
-                            k.LnLayerType = LnLayerType.InsideRelease;
-                            k.LnStrainMultiplier *= StrainConstants.LnReleaseBeforeMultiplier;
-                        }
-                    }
+                                // Target hitobject's LN ends before current hitobject's LN end
+                                else if (next.EndTime > 0)
+                                {
+                                    foreach (var k in data.HitObjects)
+                                    {
+                                        k.LnLayerType = LnLayerType.InsideRelease;
+                                        k.LnStrainMultiplier *= StrainConstants.LnReleaseBeforeMultiplier;
+                                    }
+                                }
 
-                    // Target hitobject is not an LN
-                    else
-                    {
-                        foreach (var k in data.HitObjects)
-                        {
-                            k.LnLayerType = LnLayerType.InsideTap;
-                            k.LnStrainMultiplier *= StrainConstants.LnTapMultiplier;
-                        }
-                    }
+                                // Target hitobject is not an LN
+                                else
+                                {
+                                    foreach (var k in data.HitObjects)
+                                    {
+                                        k.LnLayerType = LnLayerType.InsideTap;
+                                        k.LnStrainMultiplier *= StrainConstants.LnTapMultiplier;
+                                    }
+                                }
                 }
             }
         }
@@ -548,13 +563,19 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
             foreach (var data in StrainSolverData)
                 data.CalculateStrainValue();
 
-            calculatedDiff = StrainSolverData.Where(s => s.Hand == Hand.Left || s.Hand == Hand.Right).Select(s => s.TotalStrainValue).Average();
+            calculatedDiff = StrainSolverData.Where(s => s.Hand == Hand.Left || s.Hand == Hand.Right)
+                .Select(s => s.TotalStrainValue)
+                .Average();
 
             var bins = new List<float>();
             const int binSize = 1000;
-            for (var i = Map.HitObjects.Select(h => h.StartTime).Min(); i < Map.HitObjects.Select(h => Math.Max(h.StartTime, h.EndTime)).Max(); i += 1000)
+
+            var mapStart = Map.HitObjects.Select(h => h.StartTime).Min();
+            var mapEnd = Map.HitObjects.Select(h => Math.Max(h.StartTime, h.EndTime)).Max();
+            for (var i = mapStart; i < mapEnd; i += binSize)
             {
-                var valuesInBin = StrainSolverData.Where(s => s.StartTime >= i && s.StartTime < i + binSize).Select(s => s.TotalStrainValue);
+                var valuesInBin = StrainSolverData.Where(s => s.StartTime >= i && s.StartTime < i + binSize)
+                    .Select(s => s.TotalStrainValue);
                 if (valuesInBin.Any())
                     bins.Add(valuesInBin.ToList().Average());
                 else
@@ -596,14 +617,14 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
             {
                 var continuityFactor = 1 - (continuity - avgContinuity)/(maxContinuity - avgContinuity);
                 continuityAdjustment = Math.Min(avgAdjustment, Math.Max(minAdjustment,
-                    continuityFactor * ( avgAdjustment - minAdjustment ) + minAdjustment
+                    ( continuityFactor * ( avgAdjustment - minAdjustment ) ) + minAdjustment
                 ));
             }
             else
             {
                 var continuityFactor = 1 - (continuity - minContinuity)/(avgContinuity - minContinuity);
                 continuityAdjustment = Math.Min(maxAdjustment, Math.Max(avgAdjustment,
-                    continuityFactor * ( maxAdjustment - avgAdjustment ) + avgAdjustment
+                    ( continuityFactor * ( maxAdjustment - avgAdjustment ) ) + avgAdjustment
                 ));
             }
 
@@ -619,14 +640,11 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
 
             var trueDrainTime = bins.Count * continuity * binSize;
             var shortMapAdjustment = (float)Math.Min(1, Math.Max(maxShortMapAdjustment,
-                0.75 + 0.25 * Math.Sqrt(trueDrainTime / shortMapThreshold)
+                ( 0.25 * Math.Sqrt(trueDrainTime / shortMapThreshold) ) + 0.75
             ));
 
             calculatedDiff *= shortMapAdjustment;
 
-            Console.WriteLine($"{Map.MapId},{Map},{calculatedDiff},{continuity},{continuityAdjustment},{shortMapAdjustment}");
-
-            // Get Overall 4k difficulty
             return calculatedDiff;
         }
 
@@ -638,7 +656,8 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
         private void ComputeNoteDensityData(float rate)
         {
             //MapLength = Qua.Length;
-            AverageNoteDensity = SECONDS_TO_MILLISECONDS * Map.HitObjects.Count / (Map.Length * (-.5f * rate + 1.5f));
+            AverageNoteDensity =
+                SECONDS_TO_MILLISECONDS * Map.HitObjects.Count / ( Map.Length * ( -.5f * rate + 1.5f ) );
 
             //todo: solve note density graph
             // put stuff here
@@ -656,7 +675,7 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
             float densityDifficultyMin = .4f;
 
             // calculate ratio between min and max value
-            var ratio = Math.Max(0, (duration - xMin) / (xMax - xMin));
+            var ratio = Math.Max(0, ( duration - xMin ) / ( xMax - xMin ));
             //if ratio is too big and map isnt a beginner map (nps > 4) scale based on nps instead
             if (ratio > 1 && AverageNoteDensity < 4)
             {
@@ -665,10 +684,11 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                     return densityDifficultyMin;
                 return AverageNoteDensity * densityMultiplier + .134f;
             }
+
             ratio = 1 - Math.Min(1, ratio);
 
             // compute for difficulty
-            return lowestDifficulty + (strainMax - lowestDifficulty) * (float)Math.Pow(ratio, exp);
+            return lowestDifficulty + ( strainMax - lowestDifficulty ) * (float) Math.Pow(ratio, exp);
         }
     }
 }

--- a/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
+++ b/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
@@ -582,6 +582,8 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
                     bins.Add(0);
             }
 
+            if (!bins.Any(strain => strain > 0)) return 0;
+
             /*
              * Having a section where notes are relatively easy, compared to the hardest sections of the map, drops the rating way more than it should.
              *
@@ -595,12 +597,13 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
 
             // Average of the hardest 40% of the map
             var cutoffPos = (int)Math.Floor(bins.Count * 0.4);
-            var easyRatingCutoff = bins.OrderByDescending(s => s).Take(cutoffPos).Average();
+            var top40 = bins.OrderByDescending(s => s).Take(cutoffPos);
+            var easyRatingCutoff = top40.Any() ? top40.Average() : 0;
 
             // We do consider sections without notes, since there are no "easy notes". Those sections have barely affected the rating in the old difficulty calculator.
-            var continuity = (float)bins.Where(strain => strain > 0)
-                .Select(strain => Math.Sqrt(strain / easyRatingCutoff))
-                .Average();
+            var continuity = (float) bins.Where(strain => strain > 0)
+                .Select(strain => Math.Sqrt(strain / easyRatingCutoff)
+            ).Average();
 
             // The average continuity of maps in our dataset has been observed to be around 0.85, so we take that as the reference value to keep the rating the same.
             const float maxContinuity = 1.00f;

--- a/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
+++ b/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
@@ -569,12 +569,12 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
             var bins = new List<float>();
             const int binSize = 1000;
 
-            var mapStart = StrainSolverData.Select(s => s.StartTime).Min();
-            var mapEnd = StrainSolverData.Select(s => s.EndTime).Max();
+            var mapStart = StrainSolverData.Min(s => s.StartTime);
+            var mapEnd = StrainSolverData.Max(s => Math.Max(s.StartTime, s.EndTime));
             for (var i = mapStart; i < mapEnd; i += binSize)
             {
                 var valuesInBin = StrainSolverData.Where(s => s.StartTime >= i && s.StartTime < i + binSize).ToList();
-                var averageRating = valuesInBin.Count != 0 ? valuesInBin.Average(s => s.TotalStrainValue) : 0;
+                var averageRating = valuesInBin.Count > 0 ? valuesInBin.Average(s => s.TotalStrainValue) : 0;
                 bins.Add(averageRating);
             }
 
@@ -596,7 +596,7 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
             var top40 = bins.OrderByDescending(s => s).Take(cutoffPos);
             var easyRatingCutoff = top40.Any() ? top40.Average() : 0;
 
-            // We do consider sections without notes, since there are no "easy notes". Those sections have barely affected the rating in the old difficulty calculator.
+            // We do not consider sections without notes, since there are no "easy notes". Those sections have barely affected the rating in the old difficulty calculator.
             var continuity = (float) bins.Where(strain => strain > 0)
                 .Average(strain => Math.Sqrt(strain / easyRatingCutoff));
 


### PR DESCRIPTION
Changes applied to my local ranked and unranked sets (all ranked maps are included): [Spreadsheet](https://docs.google.com/spreadsheets/d/1tLPmtzzDPP5hYrXe-Qo1ojKjxkqmg0gVJd8mV64tujo/edit#gid=2055591202)

Requires https://github.com/Quaver/Quaver/pull/2819 to be useable in client.

## Changing the cutoff for 170BPM 1/4 short LNs to a gradient that goes from 150 to 180 instead.

This prevents radical jumps in rating from crossing the threshold (Always Smiling used to jump from 37 to 31 at 1.2x to 1.25x)

![Short-LN gradient](https://user-images.githubusercontent.com/22303902/105110276-90873c00-5abe-11eb-8508-1a24ad412d2e.png)

## Buffing maps with easy sections

Maps with breaks were heavily underrated at times because of the "average" approach taken with the strain values. This adjusts the impact of easy sections on the average of the map by computing a "continuity" value. This value is set from 1 (no breaks at all) to 0 (there is only a single short spike in the map with the rest being easy notes). The average continuity observed for the tested map dataset (see spreadsheet) is 0.85, so scaling has been set to keep maps around that range the same.

![Continuity](https://user-images.githubusercontent.com/22303902/105110789-b5c87a00-5abf-11eb-9925-b9d8a090b76f.png)

## Nerf short maps below 60s true drain time

Short maps that didn't have any breaks were massively overrated, so this adjusts the rating by up to 0.75x at 0s. The true drain time refers to the regular drain time factored with the continuity, since easy sections should not count as much towards measuring the time of hard sections. The adjustment is `f(t) = 0.75 + 0.25 * sqrt(t / 60s)`.

![Length](https://user-images.githubusercontent.com/22303902/105110909-fe803300-5abf-11eb-8321-601a1fe95f64.png)