### PR TITLE
Make stepfile have no SV by default

### DIFF
--- a/Quaver.API/Maps/Parsers/Stepmania/StepFile.cs
+++ b/Quaver.API/Maps/Parsers/Stepmania/StepFile.cs
@@ -262,6 +262,8 @@ namespace Quaver.API.Maps.Parsers.Stepmania
                     SongPreviewTime = (int) (SampleStart * 1000),
                     Mode = GameMode.Keys4,
                     DifficultyName = chart.Difficulty,
+                    BPMDoesNotAffectScrollVelocity = true,
+                    InitialScrollVelocity = 1,
                 };
 
                 var totalBeats = 0f;

--- a/Quaver.API/Maps/Qua.cs
+++ b/Quaver.API/Maps/Qua.cs
@@ -112,7 +112,7 @@ namespace Quaver.API.Maps
         ///
         ///     It's "does not affect" rather than "affects" so that the "affects" value (in this case, false) serializes to nothing to support old maps.
         /// </summary>
-        public bool BPMDoesNotAffectScrollVelocity { get; private set; }
+        public bool BPMDoesNotAffectScrollVelocity { get; set; }
 
         /// <summary>
         ///    The initial scroll velocity before the first SV change.


### PR DESCRIPTION
Because we all love those random speedup because the charter made bpm change for sync purpose.

in more seriousness, .sm file are not really intented to have SV, it started supporting SV since .ssc file. Some .sm file do have some SV like effect with STOP for example, but no one do that for a long time, people just use .ssc.

Apparently it does exist really old chart that was make with Xmod in mind, but those are the old school charting style, nowadays people just use Cmod in all case anyways. And since chart that are supposed to be played on Cmod represent literally 99.9% of the chart in stepmania/etterna, i think it is safe to make them all play like Cmod by default.

This is specially useful considering Quaver want unranked leaderboard, and everyone just use the no SV modifier for obvious reason, which doesn't have leaderboard.

Obviously if the user want to play the chart like Xmod (so with SV), they can simply go in the editor and uncheck the bpm box, tho it will not have any leaderboard if doing that.