### PR TITLE
Contain gamemode instead of prefix for multi-mode sets

### DIFF
--- a/Quaver.API.Tests/AutoMods/Resources/multi-mode-diff-name-1.qua
+++ b/Quaver.API.Tests/AutoMods/Resources/multi-mode-diff-name-1.qua
@@ -8,7 +8,7 @@ Artist: Swan
 Source: ''
 Tags: ''
 Creator: Swan
-DifficultyName: Mutl-Mode Missing (7K)
+DifficultyName: Mutl-Mode Missing (7 Keys)
 Description: Created at 1615146469000
 EditorLayers: []
 CustomAudioSamples: []

--- a/Quaver.API.Tests/AutoMods/Resources/multi-mode-diff-name-2.qua
+++ b/Quaver.API.Tests/AutoMods/Resources/multi-mode-diff-name-2.qua
@@ -8,7 +8,7 @@ Artist: Swan
 Source: ''
 Tags: ''
 Creator: Swan
-DifficultyName: 4K (Mutli-Mode Missing)
+DifficultyName: 4K (Multi-Mode Missing)
 Description: Created at 1615146448000
 EditorLayers: []
 CustomAudioSamples: []

--- a/Quaver.API/Maps/AutoMod/AutoModMapset.cs
+++ b/Quaver.API/Maps/AutoMod/AutoModMapset.cs
@@ -100,7 +100,7 @@ namespace Quaver.API.Maps.AutoMod
             {
                 var modeString = ModeHelper.ToShortHand(map.Mode).ToLower();
 
-                if (map.DifficultyName.ToLower().StartsWith(modeString))
+                if (map.DifficultyName.ToLower().Contains(modeString))
                     continue;
 
                 Issues.Add(new AutoModIssueMultiModeDiffName(map));

--- a/Quaver.API/Maps/AutoMod/Issues/Metadata/AutoModIssueMultiModeDiffName.cs
+++ b/Quaver.API/Maps/AutoMod/Issues/Metadata/AutoModIssueMultiModeDiffName.cs
@@ -12,8 +12,7 @@ namespace Quaver.API.Maps.AutoMod.Issues.Metadata
         {
             Map = map;
 
-            Text = $"The difficulty '{Map.DifficultyName}' should be named: " +
-                   $"'{ModeHelper.ToShortHand(Map.Mode)} {Map.DifficultyName}'";
+            Text = $"The difficulty '{Map.DifficultyName}' must contain '{ModeHelper.ToShortHand(Map.Mode)}'";
         }
     }
 }

--- a/Quaver.API/Maps/AutoMod/Issues/Metadata/AutoModIssueMultiModeDiffName.cs
+++ b/Quaver.API/Maps/AutoMod/Issues/Metadata/AutoModIssueMultiModeDiffName.cs
@@ -12,7 +12,7 @@ namespace Quaver.API.Maps.AutoMod.Issues.Metadata
         {
             Map = map;
 
-            Text = $"The difficulty '{Map.DifficultyName}' must contain '{ModeHelper.ToShortHand(Map.Mode)}'";
+            Text = $"The difficulty '{Map.DifficultyName}' should contain '{ModeHelper.ToShortHand(Map.Mode)}'";
         }
     }
 }


### PR DESCRIPTION
Allows for "Swan's 4K Beginner" instead of having to use "4K Swan's Beginner"

Related https://github.com/Quaver/Quaver.Wiki/pull/132