### PR TITLE
Qua: Fix SV normalization with 2+ timing points and SV

### DIFF
--- a/Quaver.API.Tests/Quaver.API.Tests.csproj
+++ b/Quaver.API.Tests/Quaver.API.Tests.csproj
@@ -263,5 +263,11 @@
     <None Update="AutoMods\Resources\multi-mode-diff-name-2.qua">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Quaver\Resources\regression-9.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Quaver\Resources\regression-9-normalized.qua">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Quaver.API.Tests/Quaver/Resources/regression-9-normalized.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-9-normalized.qua
@@ -1,0 +1,20 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: true
+InitialScrollVelocity: 1.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 1
+  - StartTime: 0.0
+    Bpm: 2.0
+    Signature: 1
+SliderVelocities:
+  - StartTime: 0.0
+    Multiplier: 4.0
+HitObjects: []

--- a/Quaver.API.Tests/Quaver/Resources/regression-9.qua
+++ b/Quaver.API.Tests/Quaver/Resources/regression-9.qua
@@ -1,0 +1,20 @@
+---
+Mode: Keys4
+Title: ~
+Artist: ~
+Creator: ~
+DifficultyName: ~
+AudioFile: ~
+BPMDoesNotAffectScrollVelocity: false
+InitialScrollVelocity: 0.0
+TimingPoints:
+  - StartTime: 0.0
+    Bpm: 1.0
+    Signature: 1
+  - StartTime: 0.0
+    Bpm: 2.0
+    Signature: 1
+SliderVelocities:
+  - StartTime: 0.0
+    Multiplier: 2.0
+HitObjects: []

--- a/Quaver.API.Tests/Quaver/TestCaseQua.cs
+++ b/Quaver.API.Tests/Quaver/TestCaseQua.cs
@@ -225,6 +225,7 @@ namespace Quaver.API.Tests.Quaver
                 "regression-6",
                 "regression-7",
                 "regression-8",
+                "regression-9",
                 "sample",
                 "sv-at-first-timing-point",
                 "sv-before-first-timing-point",

--- a/Quaver.API/Maps/Qua.cs
+++ b/Quaver.API/Maps/Qua.cs
@@ -1071,8 +1071,14 @@ namespace Quaver.API.Maps
             float? currentAdjustedSvMultiplier = null;
             float? initialSvMultiplier = null;
 
-            foreach (var timingPoint in TimingPoints)
+            for (var i = 0; i < TimingPoints.Count; i++)
             {
+                var timingPoint = TimingPoints[i];
+
+                var nextTimingPointHasSameTimestamp = false;
+                if (i + 1 < TimingPoints.Count && TimingPoints[i + 1].StartTime == timingPoint.StartTime)
+                    nextTimingPointHasSameTimestamp = true;
+
                 while (true)
                 {
                     if (currentSvIndex >= SliderVelocities.Count)
@@ -1080,6 +1086,11 @@ namespace Quaver.API.Maps
 
                     var sv = SliderVelocities[currentSvIndex];
                     if (sv.StartTime > timingPoint.StartTime)
+                        break;
+
+                    // If there are more timing points on this timestamp, the SV only applies on the
+                    // very last one, so skip it for now.
+                    if (nextTimingPointHasSameTimestamp && sv.StartTime == timingPoint.StartTime)
                         break;
 
                     if (sv.StartTime < timingPoint.StartTime)


### PR DESCRIPTION
This fixes a bug that I initially missed which results in different
behavior from old Quaver code and a mismatch between normalization and
denormalization when the following conditions are met:

1. BPMDoesNotAffectSV = false (old maps),
2. There's at least two timing points and at least one SV all on the
   same StartTime.

In this case the SV was already considered when converting the first
timing point, even though it only applies to the last timing point.

We ran a check across ranked maps and found none that have this
configuration. I've manually tested a number of SV maps (both Quaver and
osu! converts) and found no change in behavior.