### PR TITLE
Compute map length starting from the first note

### DIFF
--- a/Quaver.API/Maps/Qua.cs
+++ b/Quaver.API/Maps/Qua.cs
@@ -522,8 +522,6 @@ namespace Quaver.API.Maps
             if (HitObjects.Count == 0)
                 return TimingPoints[0].Bpm;
 
-            var firstTime = HitObjects[0].StartTime;
-
             var lastObject = HitObjects.OrderByDescending(x => x.IsLongNote ? x.EndTime : x.StartTime).First();
             double lastTime = lastObject.IsLongNote ? lastObject.EndTime : lastObject.StartTime;
 
@@ -543,9 +541,6 @@ namespace Quaver.API.Maps
                     durations[point.Bpm] += duration;
                 else
                     durations[point.Bpm] = duration;
-
-                if (point.StartTime < firstTime)
-                    break;
             }
 
             if (durations.Count == 0)

--- a/Quaver.API/Maps/Qua.cs
+++ b/Quaver.API/Maps/Qua.cs
@@ -165,7 +165,7 @@ namespace Quaver.API.Maps
         /// </summary>
         /// <returns></returns>
         [YamlIgnore]
-        public int Length => HitObjects.Count == 0 ? 0 : HitObjects.Max(x => Math.Max(x.StartTime, x.EndTime));
+        public int Length => HitObjects.Count == 0 ? 0 : HitObjects.Max(x => Math.Max(x.StartTime, x.EndTime)) - HitObjects[0].StartTime;
 
         /// <summary>
         ///     Integer based seed used for shuffling the lanes when randomize mod is active.

--- a/Quaver.API/Maps/Qua.cs
+++ b/Quaver.API/Maps/Qua.cs
@@ -522,6 +522,8 @@ namespace Quaver.API.Maps
             if (HitObjects.Count == 0)
                 return TimingPoints[0].Bpm;
 
+            var firstTime = HitObjects[0].StartTime;
+
             var lastObject = HitObjects.OrderByDescending(x => x.IsLongNote ? x.EndTime : x.StartTime).First();
             double lastTime = lastObject.IsLongNote ? lastObject.EndTime : lastObject.StartTime;
 
@@ -541,6 +543,9 @@ namespace Quaver.API.Maps
                     durations[point.Bpm] += duration;
                 else
                     durations[point.Bpm] = duration;
+
+                if (point.StartTime < firstTime)
+                    break;
             }
 
             if (durations.Count == 0)


### PR DESCRIPTION
Both common BPM and map length computation assume the map starts at 0ms. This is changed so both compute starting from the first hit object instead. This indirectly fixes the NPS shown in-game as well.