### PR TITLE
Rework HP to be less volatile

### DIFF
--- a/Quaver.API/Maps/Processors/Scoring/ScoreProcessorKeys.cs
+++ b/Quaver.API/Maps/Processors/Scoring/ScoreProcessorKeys.cs
@@ -112,12 +112,12 @@ namespace Quaver.API.Maps.Processors.Scoring
         /// </summary>
         public override Dictionary<Judgement, float> JudgementHealthWeighting { get; } = new Dictionary<Judgement, float>()
         {
-            {Judgement.Marv, 0.5f},
-            {Judgement.Perf, 0.4f},
-            {Judgement.Great, 0.2f},
-            {Judgement.Good, -3.0f},
-            {Judgement.Okay, -4.5f},
-            {Judgement.Miss, -6.0f}
+            { Judgement.Marv, 100f / 1500 },
+            { Judgement.Perf, 100f / 1800 },
+            { Judgement.Great, 100f / 2500 },
+            { Judgement.Good, -100f / 100 },
+            { Judgement.Okay, -100f / 60 },
+            { Judgement.Miss, -100f / 30 }
         };
 
         private const float ReleaseHealthWeight = 0.5f;

--- a/Quaver.API/Maps/Processors/Scoring/ScoreProcessorKeys.cs
+++ b/Quaver.API/Maps/Processors/Scoring/ScoreProcessorKeys.cs
@@ -323,7 +323,7 @@ namespace Quaver.API.Maps.Processors.Scoring
         ///     Calculates the final health weighting values for each judgement from
         ///     average actions per second. <see cref="Qua.GetActionsPerSecond"/>
         ///
-        ///     Resource: https://www.desmos.com/calculator/veeobxirvz
+        ///     Makes recovery easier on maps with lower density, linear scaling based on density
         /// </summary>
         protected override void InitializeHealthWeighting()
         {
@@ -331,7 +331,7 @@ namespace Quaver.API.Maps.Processors.Scoring
             if (Mods.HasFlag(ModIdentifier.Autoplay))
                 return;
 
-            var density = MathHelper.Clamp(Map.HitObjects.Count, 2, baseDensity);
+            var density = MathHelper.Clamp(Map.GetActionsPerSecond(), 2, baseDensity);
             foreach (var judge in new[] { Judgement.Marv, Judgement.Perf, Judgement.Great })
                 JudgementHealthWeighting[judge] *= baseDensity / density;
         }

--- a/Quaver.API/Maps/Processors/Scoring/ScoreProcessorKeys.cs
+++ b/Quaver.API/Maps/Processors/Scoring/ScoreProcessorKeys.cs
@@ -120,6 +120,8 @@ namespace Quaver.API.Maps.Processors.Scoring
             {Judgement.Miss, -6.0f}
         };
 
+        private const float ReleaseHealthWeight = 0.5f;
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -286,7 +288,9 @@ namespace Quaver.API.Maps.Processors.Scoring
 #endregion
 
 #region HEALTH_CALCULATION
-            var newHealth = Health += JudgementHealthWeighting[judgement];
+            var healthDelta = JudgementHealthWeighting[judgement];
+            if (isLongNoteRelease) healthDelta *= ReleaseHealthWeight;
+            var newHealth = Health += healthDelta;
 
             // Constrain health from 0-100
             if (newHealth <= 0)

--- a/Quaver.API/Maps/Processors/Scoring/ScoreProcessorKeys.cs
+++ b/Quaver.API/Maps/Processors/Scoring/ScoreProcessorKeys.cs
@@ -327,36 +327,13 @@ namespace Quaver.API.Maps.Processors.Scoring
         /// </summary>
         protected override void InitializeHealthWeighting()
         {
+            const float baseDensity = 20;
             if (Mods.HasFlag(ModIdentifier.Autoplay))
                 return;
 
-            var density = Map.GetActionsPerSecond(ModHelper.GetRateFromMods(Mods));
-
-            // ReSharper disable once CompareOfFloatsByEqualityOperator
-            if (density == 0 || density >= 12 || double.IsNaN(density))
-                return;
-
-            // Set baseline density to 2
-            if (density > 0 && density < 2)
-                density = 2;
-
-            var values = new Dictionary<Judgement, Tuple<float, float>>
-            {
-                {Judgement.Marv, new Tuple<float, float>(-0.14f, 2.68f)},
-                {Judgement.Perf, new Tuple<float, float>(-0.2f, 3.4f)},
-                {Judgement.Great, new Tuple<float, float>(-0.14f, 2.68f)},
-                {Judgement.Good, new Tuple<float, float>(0.084f, -0.008f)},
-                {Judgement.Okay, new Tuple<float, float>(0.081f, 0.028f)}
-            };
-
-            foreach (var item in values)
-            {
-                var val = values[item.Key];
-                var multiplier = val.Item1 * density + val.Item2;
-
-                var weight = JudgementHealthWeighting[item.Key];
-                JudgementHealthWeighting[item.Key] = (float) Math.Round(multiplier * weight, 2, MidpointRounding.ToEven);
-            }
+            var density = MathHelper.Clamp(Map.HitObjects.Count, 2, baseDensity);
+            foreach (var judge in new[] { Judgement.Marv, Judgement.Perf, Judgement.Great })
+                JudgementHealthWeighting[judge] *= baseDensity / density;
         }
 
         /// <summary>


### PR DESCRIPTION
# Issue

Right now, the HP in Quaver is quite volatile. You need 17 misses in order to deplete your health bar and LNs count hits and releases separately. So this means that missing a 7 note chord of short LNs means you're only left with 16% HP, which is ridiculous. Especially on high level 7k LN maps, where the issue is most apparent, the HP is very volatile and can quite literally kill you in a split second. This, paired with only requiring 250 marvelouses in order to refill your health to 100% means that, HP is quite meaningless, in the sense that any time you drop into low HP, you either instantly regain HP to get back to full in mere seconds, or you die.

Here are some current stats:

| Judgement | Weight | # in order to fill/deplete |
| --------- | ------ | -------------------------- |
| MA        | 0.5    | 200                        |
| PF        | 0.4    | 250                        |
| GR        | 0.2    | 500                        |
| GD        | -3.0   | 34                         |
| BD        | -4.0   | 25                         |
| MS        | -6.0   | 17                         |

MA's required to recoup 1 miss: 12

# Solution

## Weight changes

Taking note from other HP-based games such as BMS or O2Jam, where the miss pool is much larger (35 or even 50) but the recovery is much slower (1000 or 3000 notes to fully refill), I have adjusted the values to be closer to those games.

This makes the experience of HP passing more enjoyable, as you don't feel *bullshitted* when there is a sudden difficulty spike in the map. On the other hand, there is more weight in seeing your HP lower during gameplay, as you don't recover it in a matter of seconds anymore. It also means that there will be more opportunities to have close passes, additionally increasing the excitement and enjoyability of HP passing.

Here are the adjusted values:

| Judgement | Weight | # in order to fill/deplete |
| --------- | ------ | -------------------------- |
| MA        | 0.07   | 1500                       |
| PF        | 0.06   | 1750                       |
| GR        | 0.03   | 3000                       |
| GD        | -1.00  | 100                        |
| BD        | -1.67  | 60                         |
| MS        | -3.33  | 30                         |

MA's required to recoup 1 miss: 50

## Weight of LN Release

In addition to these weight changes, the **weight of a release has also been halved**, so missing an entire LN will only subtract 1.5 misses worth of HP instead of 2 like before.

## Lower density scaling

Finally, the scaling of HP lower density maps has also been changed in order to accommodate the new weights.

The weights have been chosen in a way that close passes are at around 85%-90% accuracy. I have analyzed my own scores and checked the average judgement distribution in accuracy bins, and simulated what final health that distribution would have on a particular density. For reference, 20 density is about 200bpm jumpstream.

![Health simulation of aggregated judgement distributions](https://user-images.githubusercontent.com/22303902/186224227-2a387c3f-0f5f-4d4c-98f9-f39ceda55716.png)
