### PR TITLE
Restore bookmark list when serialize finishes

### DIFF
--- a/Quaver.API/Maps/Qua.cs
+++ b/Quaver.API/Maps/Qua.cs
@@ -362,6 +362,7 @@ namespace Quaver.API.Maps
             TimingPoints = originalTimingPoints;
             HitObjects = originalHitObjects;
             SoundEffects = originalSoundEffects;
+            Bookmarks = new List<BookmarkInfo>();
 
             return serialized;
         }

--- a/Quaver.API/Maps/Qua.cs
+++ b/Quaver.API/Maps/Qua.cs
@@ -286,6 +286,7 @@ namespace Quaver.API.Maps
             var originalTimingPoints = TimingPoints;
             var originalHitObjects = HitObjects;
             var originalSoundEffects = SoundEffects;
+            var originalBookmarks = Bookmarks;
 
             TimingPoints = new List<TimingPointInfo>();
             foreach (var tp in originalTimingPoints)
@@ -362,7 +363,7 @@ namespace Quaver.API.Maps
             TimingPoints = originalTimingPoints;
             HitObjects = originalHitObjects;
             SoundEffects = originalSoundEffects;
-            Bookmarks = new List<BookmarkInfo>();
+            Bookmarks = originalBookmarks;
 
             return serialized;
         }


### PR DESCRIPTION
Fixes errors when saving map after placing a note that prevents map to be edited after.