### PR TITLE
Set lower bound of osu! converted SVs to 0.01

### DIFF
--- a/Quaver.API/Maps/Parsers/OsuBeatmap.cs
+++ b/Quaver.API/Maps/Parsers/OsuBeatmap.cs
@@ -540,7 +540,7 @@ namespace Quaver.API.Maps.Parsers
                     qua.SliderVelocities.Add(new SliderVelocityInfo
                     {
                         StartTime = tp.Offset,
-                        Multiplier = (-100 / tp.MillisecondsPerBeat).Clamp(0.1f, 10)
+                        Multiplier = (-100 / tp.MillisecondsPerBeat).Clamp(0.01f, 10)
                     });
                 }
                 else


### PR DESCRIPTION
Back then, osu! used to clamp SV values to 0.1, but that behavior changed sometime in 2019(?) to 0.01.

Modern SV charts rely on this a lot, such as [SPIRAL](https://osu.ppy.sh/beatmapsets/2115576#mania/4442623).

The example shown refers to `129975|2,130108|2,130241|2` (2:09.975).

### Quaver:
![image](https://github.com/Quaver/Quaver.API/assets/14614115/a35135e7-274b-4d80-ae47-349edac3d8b2)

### osu!stable:
![image](https://github.com/Quaver/Quaver.API/assets/14614115/9fc5ec84-df09-4c28-9a4a-f1fe20c8bd5f)
