### PR TITLE
Use XmlSerializer over BinaryFormatter

### DIFF
--- a/Quaver.API/Helpers/Objects.cs
+++ b/Quaver.API/Helpers/Objects.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
+using System.Xml.Serialization;
 
 namespace Quaver.API.Helpers
 {
@@ -15,7 +15,7 @@ namespace Quaver.API.Helpers
         {
             using (var ms = new MemoryStream())
             {
-                var formatter = new BinaryFormatter();
+                var formatter = new XmlSerializer(typeof(T));
                 formatter.Serialize(ms, obj);
                 ms.Position = 0;
 


### PR DESCRIPTION
[`BinaryFormatter` will become fully deprecated in .NET 9](https://github.com/dotnet/runtime/issues/98245), and already throws exceptions in .NET 8 since it's opt-in now. This pull request makes migrations to .NET 8 and up possible.

`XmlSerializer` in this case is an easy swap-in replacement. There may be some performance implications, but I haven't noticed any regressions when previewing or playing charts in the Quaver game, including extremely heavy/dense charts.