### PR TITLE
Downgrade Quaver.API to use netstandard2.1

### DIFF
--- a/Quaver.API/Quaver.API.csproj
+++ b/Quaver.API/Quaver.API.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>

--- a/Quaver.Tools/Quaver.Tools.csproj
+++ b/Quaver.Tools/Quaver.Tools.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="RestSharp" Version="106.12.0" />


### PR DESCRIPTION
Using net6.0 required other repos to be updated to not use netstandard2.1 which caused different hashes on all platforms. 
This PR reverts the change and also adds another csproj config which allows still to be compiled for ARM.