### PR TITLE
Use bit manipulation instead of arithmetic subtraction for generating perfect replay releases

### DIFF
--- a/Quaver.API/Replays/Replay.cs
+++ b/Quaver.API/Replays/Replay.cs
@@ -368,7 +368,7 @@ namespace Quaver.API.Replays
                             state |= KeyLaneToPressState(frame.HitObject.Lane);
                             break;
                         case ReplayAutoplayFrameType.Release:
-                            state -= KeyLaneToPressState(frame.HitObject.Lane);
+                            state &= ~KeyLaneToPressState(frame.HitObject.Lane);
                             break;
                         default:
                             throw new ArgumentOutOfRangeException();


### PR DESCRIPTION
[Opera Skaala - Heart of Light - 29686.zip](https://github.com/Quaver/Quaver.API/files/15242532/Opera.Skaala.-.Heart.of.Light.-.29686.zip)

In this map (SM convert), some notes overlap so it messes up the perfect replay. This map spams this error:
```
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
   at System.Collections.Generic.List`1.set_Item(Int32 index, T value)
   at Quaver.Shared.Screens.Gameplay.Rulesets.Input.ReplayInputManagerKeys.HandleInput(Boolean forceInput) in D:\RiderProjects\QuaverCanary\Quaver.Shared\Screens\Gameplay\Rulesets\Input\ReplayInputManagerKeys.cs:line 142
```
Which is due to the use of arithmetic subtraction, instead of bit manipulation, of press state.

This PR resolves this issue