### PR TITLE
Fix Qua equality

### DIFF
--- a/Quaver.API/Maps/Qua.cs
+++ b/Quaver.API/Maps/Qua.cs
@@ -225,6 +225,7 @@ namespace Quaver.API.Maps
                    // ReSharper disable once CompareOfFloatsByEqualityOperator
                    && InitialScrollVelocity == other.InitialScrollVelocity
                    && BPMDoesNotAffectScrollVelocity == other.BPMDoesNotAffectScrollVelocity
+                   && LegacyLNRendering == other.LegacyLNRendering
                    && HasScratchKey == other.HasScratchKey
                    && HitObjects.SequenceEqual(other.HitObjects, HitObjectInfo.ByValueComparer)
                    && CustomAudioSamples.SequenceEqual(other.CustomAudioSamples, CustomAudioSampleInfo.ByValueComparer)


### PR DESCRIPTION
Fixes extremely niche edgecase with map backups that causes maps to not be backed up if the only difference between the new and old is a difference in the Legacy LN toggle. Any other difference still saves properly.