### PR TITLE
Allows Quaver.Tools to be ran

### DIFF
--- a/Quaver.Tools/Quaver.Tools.csproj
+++ b/Quaver.Tools/Quaver.Tools.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="RestSharp" Version="106.12.0" />

--- a/Quaver.Tools/Quaver.Tools.csproj
+++ b/Quaver.Tools/Quaver.Tools.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <SelfContained>True</SelfContained>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="RestSharp" Version="106.12.0" />

--- a/Quaver.Tools/Quaver.Tools.csproj
+++ b/Quaver.Tools/Quaver.Tools.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <InvariantGlobalization>true</InvariantGlobalization>
-    <SelfContained>True</SelfContained>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="RestSharp" Version="106.12.0" />


### PR DESCRIPTION
Without this property we are getting error for ICU package missing.
From reading the documentation below, I don't think this effects anything hopefully.

More info about this here https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md