### PR TITLE
Return difficulty 0 when StrainSolverData is empty

### DIFF
--- a/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
+++ b/Quaver.API/Maps/Processors/Difficulty/Rulesets/Keys/DifficultyProcessorKeys.cs
@@ -541,6 +541,10 @@ namespace Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys
         /// <returns></returns>
         private float CalculateOverallDifficulty()
         {
+            // When the map has only scratch key notes, StrainSolverData would be empty, so we return 0
+            if (StrainSolverData.Count == 0)
+                return 0;
+
             float calculatedDiff;
 
             // Solve strain value of every data point


### PR DESCRIPTION
Fixes error throwing when there are >= 2 scratch lane notes and nothing else.