### PR TITLE
[StepMania] Don't count the semicolon as a row to solve the wrong rhythm in the last measure

### DIFF
--- a/Quaver.API/Maps/Parsers/Stepmania/StepFile.cs
+++ b/Quaver.API/Maps/Parsers/Stepmania/StepFile.cs
@@ -228,6 +228,11 @@ namespace Quaver.API.Maps.Parsers.Stepmania
                 else if (currentChart != null && currentChart.GrooveRadarValues != null &&
                          !string.IsNullOrEmpty(trimmedLine))
                 {
+                    // Last line is a ';', skip that as we would add a new row to the measure otherwise
+                    // which would break the last measure
+                    if (trimmedLine.StartsWith(";"))
+                        continue;
+
                     // Denotes a new measure
                     if (trimmedLine.StartsWith(","))
                     {


### PR DESCRIPTION
[Flashes (25).zip](https://github.com/user-attachments/files/17090035/Flashes.25.zip)

Check the last measure. The snap isnt right without the change.