### PR TITLE
Compare Qua.TimingGroups properly

### DIFF
--- a/Quaver.API.Tests/Quaver/TestCaseQua.cs
+++ b/Quaver.API.Tests/Quaver/TestCaseQua.cs
@@ -268,6 +268,26 @@ namespace Quaver.API.Tests.Quaver
         }
 
         [Fact]
+        public void TimingGroupsComparison()
+        {
+            var q1 = new Qua();
+            var q2 = new Qua();
+            Assert.True(q1.EqualByValue(q2));
+
+            q2.TimingGroups["a"] = new ScrollGroup();
+            Assert.False(q1.EqualByValue(q2));
+
+            q1.TimingGroups["a"] = new ScrollGroup();
+            Assert.True(q1.EqualByValue(q2));
+
+            ((ScrollGroup)q2.TimingGroups["a"]).ScrollVelocities.Add(new SliderVelocityInfo {Multiplier = 2});
+            Assert.False(q1.EqualByValue(q2));
+
+            ((ScrollGroup)q1.TimingGroups["a"]).ScrollVelocities.Add(new SliderVelocityInfo {Multiplier = 2});
+            Assert.True(q1.EqualByValue(q2));
+        }
+
+        [Fact]
         public void SVNormalization()
         {
             var tests = new[]

--- a/Quaver.API/Maps/Qua.cs
+++ b/Quaver.API/Maps/Qua.cs
@@ -259,7 +259,7 @@ namespace Quaver.API.Maps
             TimingPoints.SequenceEqual(other.TimingPoints, TimingPointInfo.ByValueComparer) &&
             SliderVelocities.SequenceEqual(other.SliderVelocities, SliderVelocityInfo.ByValueComparer) &&
             InitialScrollVelocity == other.InitialScrollVelocity &&
-            TimingGroups.SequenceEqual(other.TimingGroups) &&
+            CompareTimingGroups(other.TimingGroups) &&
             BPMDoesNotAffectScrollVelocity == other.BPMDoesNotAffectScrollVelocity &&
             LegacyLNRendering == other.LegacyLNRendering &&
             HasScratchKey == other.HasScratchKey &&
@@ -269,6 +269,19 @@ namespace Quaver.API.Maps
             EditorLayers.SequenceEqual(other.EditorLayers, EditorLayerInfo.ByValueComparer) &&
             Bookmarks.SequenceEqual(other.Bookmarks, BookmarkInfo.ByValueComparer) &&
             RandomizeModifierSeed == other.RandomizeModifierSeed;
+
+        private bool CompareTimingGroups(Dictionary<string, TimingGroup> other)
+        {
+            if (TimingGroups == null || other == null || TimingGroups.Count != other.Count)
+                return false;
+            foreach (var (key, value) in TimingGroups)
+            {
+                if (!other.TryGetValue(key, out var otherGroup) || !otherGroup.Equals(value))
+                    return false;
+            }
+
+            return true;
+        }
 
         private static IDeserializer Deserializer =>
             new DeserializerBuilder()

--- a/Quaver.API/Maps/Structures/ScrollGroup.cs
+++ b/Quaver.API/Maps/Structures/ScrollGroup.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using MoonSharp.Interpreter;
 using Quaver.API.Helpers;
 using YamlDotNet.Serialization;
@@ -13,21 +14,36 @@ namespace Quaver.API.Maps.Structures
     [MoonSharpUserData]
     public class ScrollGroup : TimingGroup
     {
-        public float InitialScrollVelocity
-        {
-            get;
-            [MoonSharpHidden] set;
-        } = 1;
+        public float InitialScrollVelocity { get; [MoonSharpHidden] set; } = 1;
 
-        public List<SliderVelocityInfo> ScrollVelocities
-        {
-            get;
-            [MoonSharpHidden] set;
-        } = new List<SliderVelocityInfo>();
+        public List<SliderVelocityInfo> ScrollVelocities { get; [MoonSharpHidden] set; } =
+            new List<SliderVelocityInfo>();
 
         public SliderVelocityInfo GetScrollVelocityAt(double time)
         {
             return ScrollVelocities.AtTime((float)time);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        protected bool Equals(ScrollGroup other)
+        {
+            return base.Equals(other) && InitialScrollVelocity.Equals(other.InitialScrollVelocity) &&
+                   ScrollVelocities.SequenceEqual(other.ScrollVelocities, SliderVelocityInfo.ByValueComparer);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((ScrollGroup)obj);
         }
     }
 }

--- a/Quaver.API/Maps/Structures/TimingGroup.cs
+++ b/Quaver.API/Maps/Structures/TimingGroup.cs
@@ -35,5 +35,26 @@ namespace Quaver.API.Maps.Structures
             byte.TryParse(tb, out var b)
                 ? Color.FromArgb(r, g, b)
                 : Color.White;
+
+        /// <summary>
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        protected bool Equals(TimingGroup other)
+        {
+            return ColorRgb == other.ColorRgb;
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((TimingGroup)obj);
+        }
     }
 }


### PR DESCRIPTION
Seems like implementing an equality comparer is not viable because we have class inheritance. So, I override `Equals()` instead.