### PR TITLE
Make default name for Default and Global Scroll group $Default and $Global

### DIFF
--- a/Quaver.API/Maps/Qua.cs
+++ b/Quaver.API/Maps/Qua.cs
@@ -190,12 +190,12 @@ namespace Quaver.API.Maps
         /// <summary>
         ///     Reserved ID for default scroll group
         /// </summary>
-        public const string DefaultScrollGroupId = "";
+        public const string DefaultScrollGroupId = "$Default";
 
         /// <summary>
         ///     Reserved ID for global scroll group (applied to every scroll groups)
         /// </summary>
-        public const string GlobalScrollGroupId = "*";
+        public const string GlobalScrollGroupId = "$Global";
 
         /// <summary>
         ///     Finds the length of the map


### PR DESCRIPTION
Instead of "" and "*", this should be more intuitive.