### PR TITLE
Deep clone map when (de)normalizing SVs

### DIFF
--- a/Quaver.API.Tests/Quaver/TestCaseQua.cs
+++ b/Quaver.API.Tests/Quaver/TestCaseQua.cs
@@ -316,24 +316,30 @@ namespace Quaver.API.Tests.Quaver
                 var pathDenormalized = $"./Quaver/Resources/{test}-normalized.qua";
 
                 var quaDenormalized = Qua.Parse(pathNormalized, false);
+                var quaDenormalizedDeepClone = quaDenormalized.DeepClone();
                 var quaNormalized = Qua.Parse(pathDenormalized, false);
+                var quaNormalizedDeepClone = quaNormalized.DeepClone();
 
                 // Check that the normalization gives the correct result.
                 var quaDenormalizedNormalized = quaDenormalized.WithNormalizedSVs();
+                Assert.True(quaDenormalized.EqualByValue(quaDenormalizedDeepClone), $"Expected normalization in {test} to not change the original content.");
                 Assert.True(quaDenormalizedNormalized.EqualByValue(quaNormalized), $"Expected {test} to normalize correctly.");
 
                 // Denormalization can move the first SV (it doesn't matter where to put the InitialScrollVelocity SV).
                 // So check back-and-forth instead of just denormalization.
                 var quaNormalizedDenormalizedNormalized = quaNormalized.WithDenormalizedSVs().WithNormalizedSVs();
-                Assert.True(quaNormalizedDenormalizedNormalized.EqualByValue(quaNormalized), $"Expected {test} to remain the same after denormalization and subsequent normalization.");
+                Assert.True(quaNormalized.EqualByValue(quaNormalizedDeepClone), $"Expected denormalization in {test} to not change the original content.");
+                Assert.True(quaNormalizedDenormalizedNormalized.EqualByValue(quaNormalizedDeepClone), $"Expected {test} to remain the same after denormalization and subsequent normalization.");
 
                 // Check that serializing and parsing the result does not change it.
                 var bufferDenormalized = Encoding.UTF8.GetBytes(quaDenormalized.Serialize());
                 var quaDenormalized2 = Qua.Parse(bufferDenormalized, false);
+                Assert.True(quaDenormalizedDeepClone.EqualByValue(quaDenormalized2), $"Expected {test} denormalized to not change the original content.");
                 Assert.True(quaDenormalized.EqualByValue(quaDenormalized2), $"Expected {test} denormalized to remain the same after serialization and parsing.");
 
                 var bufferNormalized = Encoding.UTF8.GetBytes(quaNormalized.Serialize());
                 var quaNormalized2 = Qua.Parse(bufferNormalized, false);
+                Assert.True(quaNormalizedDeepClone.EqualByValue(quaNormalized2), $"Expected {test} normalized to not change the original content.");
                 Assert.True(quaNormalized.EqualByValue(quaNormalized2), $"Expected {test} to normalized to remain the same after serialization and parsing.");
             }
         }

--- a/Quaver.API/Maps/Qua.cs
+++ b/Quaver.API/Maps/Qua.cs
@@ -1441,8 +1441,7 @@ namespace Quaver.API.Maps
         /// <returns></returns>
         public Qua WithNormalizedSVs()
         {
-            var qua = (Qua)MemberwiseClone();
-            // Relies on NormalizeSVs not changing anything within the by-reference members (but rather creating a new List).
+            var qua = this.DeepClone();
             qua.NormalizeSVs();
             return qua;
         }
@@ -1453,8 +1452,7 @@ namespace Quaver.API.Maps
         /// <returns></returns>
         public Qua WithDenormalizedSVs()
         {
-            var qua = (Qua)MemberwiseClone();
-            // Relies on DenormalizeSVs not changing anything within the by-reference members (but rather creating a new List).
+            var qua = this.DeepClone();
             qua.DenormalizeSVs();
             return qua;
         }

--- a/Quaver.API/Maps/Structures/ScrollGroup.cs
+++ b/Quaver.API/Maps/Structures/ScrollGroup.cs
@@ -14,7 +14,7 @@ namespace Quaver.API.Maps.Structures
     [MoonSharpUserData]
     public class ScrollGroup : TimingGroup
     {
-        public float InitialScrollVelocity { get; [MoonSharpHidden] set; } = 1;
+        public float InitialScrollVelocity { get; [MoonSharpHidden] set; }
 
         public List<SliderVelocityInfo> ScrollVelocities { get; [MoonSharpHidden] set; } =
             new List<SliderVelocityInfo>();


### PR DESCRIPTION
Since SV list is now a reference inside another reference (DefaultTimingGroup) in Qua, shallow MemberwiseClone() no longer applies. So we need to use DeepClone instead.